### PR TITLE
Implement Send/Sync for DisplayList

### DIFF
--- a/src/display_list.rs
+++ b/src/display_list.rs
@@ -135,6 +135,10 @@ impl Drop for DisplayList {
     }
 }
 
+// `DisplayList`s may be used by multiple threads simultaneously
+unsafe impl Send for DisplayList {}
+unsafe impl Sync for DisplayList {}
+
 #[cfg(test)]
 mod test {
     use crate::Document;


### PR DESCRIPTION
From [MuPDF Explored](https://ghostscript.com/~robin/mupdf_explored.pdf):
> Once displaylists  are  created  from  that  document,  multiple  threads  can  operate  on them safely.

Think this should be safe.