### PR TITLE
build: use features to control build configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,19 @@ license = "GPL-3.0"
 readme = "README.md"
 repository = "https://github.com/messense/mupdf-rs"
 
+[features]
+default = ["noto-small", "no-cjk", "js", "xps", "svg", "cbz", "img", "html", "epub"]
+noto-small = ["mupdf-sys/noto-small"]
+no-cjk = ["mupdf-sys/no-cjk"]
+tofu = ["mupdf-sys/tofu"]
+js = ["mupdf-sys/js"]
+xps = ["mupdf-sys/xps"]
+svg = ["mupdf-sys/svg"]
+cbz = ["mupdf-sys/cbz"]
+img = ["mupdf-sys/img"]
+html = ["mupdf-sys/html"]
+epub = ["mupdf-sys/epub"]
+
 [dependencies]
 mupdf-sys = { version = "0.0.3", path = "mupdf-sys" }
 once_cell = "1.3.1"

--- a/mupdf-sys/Cargo.toml
+++ b/mupdf-sys/Cargo.toml
@@ -34,6 +34,19 @@ license = "GPL-3.0"
 links="mupdf-wrapper"
 repository = "https://github.com/messense/mupdf-rs"
 
+[features]
+default = ["noto-small", "no-cjk"]
+noto-small = []
+no-cjk = []
+tofu = []
+no-js = []
+no-xps = []
+no-svg = []
+no-cbz = []
+no-img = []
+no-html = []
+no-epub = []
+
 [build-dependencies]
 bindgen = "0.54"
 cc = "1.0.50"

--- a/mupdf-sys/Cargo.toml
+++ b/mupdf-sys/Cargo.toml
@@ -35,17 +35,16 @@ links="mupdf-wrapper"
 repository = "https://github.com/messense/mupdf-rs"
 
 [features]
-default = ["noto-small", "no-cjk"]
 noto-small = []
 no-cjk = []
 tofu = []
-no-js = []
-no-xps = []
-no-svg = []
-no-cbz = []
-no-img = []
-no-html = []
-no-epub = []
+js = []
+xps = []
+svg = []
+cbz = []
+img = []
+html = []
+epub = []
 
 [build-dependencies]
 bindgen = "0.54"

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -26,6 +26,38 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let current_dir = env::current_dir().unwrap();
     let mupdf_dir = current_dir.join("mupdf");
+    // see https://github.com/ArtifexSoftware/mupdf/blob/master/include/mupdf/fitz/config.h
+    // and https://github.com/ArtifexSoftware/mupdf/blob/master/source/fitz/noto.c
+    let xcflags = vec![
+        #[cfg(feature = "noto-small")]
+        "NOTO_SMALL",
+        #[cfg(feature = "no-cjk")]
+        "NO_CJK",
+        #[cfg(feature = "tofu")]
+        "TOFU",
+        #[cfg(feature = "no-xps")]
+        "FZ_ENABLE_XPS=0",
+        #[cfg(feature = "no-svg")]
+        "FZ_ENABLE_SVG=0",
+        #[cfg(feature = "no-cbz")]
+        "FZ_ENABLE_CBZ=0",
+        #[cfg(feature = "no-img")]
+        "FZ_ENABLE_IMG=0",
+        #[cfg(feature = "no-html")]
+        "FZ_ENABLE_HTML=0",
+        #[cfg(feature = "no-epub")]
+        "FZ_ENABLE_EPUB=0",
+        #[cfg(feature = "no-js")]
+        "FZ_ENABLE_JS=0",
+    ]
+    .into_iter()
+    .map(|s| {
+        let mut s = s.to_owned();
+        s.insert_str(0, "-D");
+        s
+    })
+    .collect::<Vec<String>>()
+    .join(" ");
     let output = Command::new("make")
         .arg("libs")
         .arg(format!("build={}", profile))
@@ -35,7 +67,7 @@ fn main() {
         .arg("HAVE_GLUT=no")
         .arg("HAVE_CURL=no")
         .arg("verbose=yes")
-        .arg("XCFLAGS=-DNOTO_SMALL -DNO_CJK")
+        .arg(format!("XCFLAGS={}", xcflags))
         .current_dir(mupdf_dir)
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -35,19 +35,19 @@ fn main() {
         "NO_CJK",
         #[cfg(feature = "tofu")]
         "TOFU",
-        #[cfg(feature = "no-xps")]
+        #[cfg(not(feature = "xps"))]
         "FZ_ENABLE_XPS=0",
-        #[cfg(feature = "no-svg")]
+        #[cfg(not(feature = "svg"))]
         "FZ_ENABLE_SVG=0",
-        #[cfg(feature = "no-cbz")]
+        #[cfg(not(feature = "cbz"))]
         "FZ_ENABLE_CBZ=0",
-        #[cfg(feature = "no-img")]
+        #[cfg(not(feature = "img"))]
         "FZ_ENABLE_IMG=0",
-        #[cfg(feature = "no-html")]
+        #[cfg(not(feature = "html"))]
         "FZ_ENABLE_HTML=0",
-        #[cfg(feature = "no-epub")]
+        #[cfg(not(feature = "epub"))]
         "FZ_ENABLE_EPUB=0",
-        #[cfg(feature = "no-js")]
+        #[cfg(not(feature = "js"))]
         "FZ_ENABLE_JS=0",
     ]
     .into_iter()


### PR DESCRIPTION
Adds features to the `mupdf-sys` crate which map to some of the options in [fitz/config.h](https://github.com/ArtifexSoftware/mupdf/blob/master/include/mupdf/fitz/config.h).
Of course, more or all of the options could be added as features if deemed necessary; I found these to be the most effective in reducing the size of the library.