### PR TITLE
Correct c_key string for Title metadata

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -29,7 +29,7 @@ impl MetadataName {
             Format => "format",
             Encryption => "encryption",
             Author => "info:Author",
-            Title => "info::Title",
+            Title => "info:Title",
             Producer => "info:Producer",
             Creator => "info:Creator",
             CreationDate => "info:CreationDate",


### PR DESCRIPTION
I noticed that calling `metadata(MetadataName::Title)` title always returned an empty string, even when the document does have a title set. This change corrects that.