### PR TITLE
Use devenv.com instead of devenv.exe

### DIFF
--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -266,7 +266,7 @@ fn build_libmupdf() {
     let mupdf_src_dir = current_dir.join("mupdf");
     cp_r(&mupdf_src_dir, &build_dir);
 
-    let devenv = cc::windows_registry::find(target.as_str(), "devenv.exe");
+    let devenv = cc::windows_registry::find(target.as_str(), "devenv.com");
     if let Some(mut devenv) = devenv {
         let d = devenv
             .args(&["/upgrade", "platform\\win32\\mupdf.sln"])
@@ -305,7 +305,7 @@ fn build_libmupdf() {
         if cfg!(not(feature = "js")) {
             cl_env.push("/DFZ_ENABLE_JS#0".to_string());
         }
-        let d = cc::windows_registry::find(target.as_str(), "devenv.exe")
+        let d = cc::windows_registry::find(target.as_str(), "devenv.com")
             .unwrap()
             .args(&[
                 "platform\\win32\\mupdf.sln",


### PR DESCRIPTION
For some reason on some Visual Studio installs* devenv.exe just returns
immediately with an error code and runs the build in the background. It
also doesn't emit any output via stdout/stderr. According to [1]
devenv.com is the executable to use for build output via stdout/stderr
and it doesn't misbehave so switch to that.

[1]: https://docs.microsoft.com/en-us/visualstudio/ide/reference/devenv-command-line-switches?view=vs-2019

*In my case it fails with Visual Studio 2022 Preview but works on another (virtual) machine with Visual Studio 2019. But if I install deinstall 2019 and install 2022 in that VM then it also works so I honestly have no idea why the behavior differs. But since it's documented that devenv.com is for stdout/stderr usage I think it makes sense to switch regardless.