### PR TITLE
Fix undefined behavior in PDF image filtering

### DIFF
--- a/src/pdf/filter.rs
+++ b/src/pdf/filter.rs
@@ -1,16 +1,21 @@
 use mupdf_sys::*;
 
 use std::ffi::CStr;
-use std::mem;
+use std::marker::PhantomData;
+use std::mem::{self, ManuallyDrop};
 use std::os::raw::{c_char, c_void};
 use std::ptr;
 
 use crate::pdf::PdfDocument;
 use crate::{Image, Matrix, Rect};
 
-#[derive(Clone, Copy)]
-pub struct PdfFilterOptions {
+// Double indirection is required to pass trait objects trough FFI.
+type BoxedCallback<'a> = Box<Box<dyn FnMut(Matrix, &str, &Image) -> Option<Image> + 'a>>;
+
+pub struct PdfFilterOptions<'a> {
     pub(crate) inner: pdf_filter_options,
+    // This corresponds to the BoxedCallback<'a> which is pointed to by `inner.opaque`
+    phantom: Option<PhantomData<BoxedCallback<'a>>>,
 }
 
 // Callback types
@@ -18,15 +23,30 @@ pub type TextFilter = fn(ucsbuf: i32, ucslen: i32, trm: &Matrix, ctm: &Matrix, b
 pub type AfterTextObject = fn(doc: &PdfDocument, chain: &pdf_processor, ctm: &Matrix);
 pub type EndPage = fn();
 
-impl Default for PdfFilterOptions {
+impl Default for PdfFilterOptions<'_> {
     fn default() -> Self {
         Self {
             inner: unsafe { mem::zeroed() },
+            phantom: None,
         }
     }
 }
 
-impl PdfFilterOptions {
+impl Drop for PdfFilterOptions<'_> {
+    fn drop(&mut self) {
+        self.drop_opaque_if_necessary();
+    }
+}
+
+impl<'a> PdfFilterOptions<'a> {
+    fn drop_opaque_if_necessary(&mut self) -> Option<BoxedCallback<'a>> {
+        self.phantom.take().map(|_| {
+            let ptr = self.inner.opaque;
+            self.inner.opaque = std::ptr::null_mut();
+            unsafe { Box::from_raw(ptr as *mut _) }
+        })
+    }
+
     pub fn ascii(&self) -> bool {
         self.inner.ascii != 0
     }
@@ -68,13 +88,16 @@ impl PdfFilterOptions {
     ///
     /// The returned image has to be a new one, so `image.clone()` can be used
     /// to keep the same.
-    pub fn set_image_filter<Cb>(&mut self, mut wrapper: Cb) -> &mut Self
+    pub fn set_image_filter<Cb: 'a>(&mut self, wrapper: Cb) -> &mut Self
     where
         Cb: FnMut(Matrix, &str, &Image) -> Option<Image>,
     {
         // The opaque field can be used to have data easily accessible in the
         // callback, in this case the user's closure.
-        self.inner.opaque = &mut wrapper as *mut _ as *mut c_void;
+        self.drop_opaque_if_necessary();
+        let wrapper: BoxedCallback = Box::new(Box::new(wrapper));
+        self.inner.opaque = Box::into_raw(wrapper) as *mut _ as *mut c_void;
+        self.phantom = Some(PhantomData);
 
         unsafe extern "C" fn image_filter_callback<Cb>(
             // TODO: `context()` inside this function should probably use the
@@ -90,12 +113,13 @@ impl PdfFilterOptions {
         {
             let ret = std::panic::catch_unwind(move || {
                 // Reading the closure again
-                let wrapper = &mut *(opaque as *mut Cb);
+                let wrapper = &mut **(opaque as *mut *mut Cb);
 
                 wrapper(
                     Matrix::from(ctm),
                     CStr::from_ptr(name).to_str().unwrap(),
-                    &Image::from_raw(image),
+                    // Mupdf has ownership of image so we mustn't drop it
+                    &ManuallyDrop::new(Image::from_raw(image)),
                 )
             });
 


### PR DESCRIPTION
Fix two sources UB:
1. A double free of the image which gets passed image_filter_callback().
   Mupdf retains ownership of the image so we mustn't drop it. This
   fixes test_filters.rs.
2. The callback wrapper's lifetime is now properly tracked by the
   PdfFilterOptions struct. While this isn't required to fix the test
   it is a correctness fix and now passes miri validation. See [1] for
   a minimized comparison between three different approaches for this
   problem.

[1]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=02fb40ba51deac47eb3e1960cb6e787d

Somewhat amusingly number 1 is what I spotted immediately and is sufficient for the test to pass. But since I was already running with address sanitizer it still complained so I went down the rabbit hole for number 2 which was much more involved. But now neither miri (only for the minimized example) nor address sanitizer complain anymore. Though the added complexity is unfortunate...