### PR TITLE
Add address sanitizer CI job & fix #27

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,6 +50,26 @@ jobs:
         with:
           command: test
 
+  asan:
+    name: Address Sanitizer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+          fetch-depth: 500
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target x86_64-unknown-linux-gnu
+        env:
+          RUSTFLAGS: -Z sanitizer=address
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/tests/test_issues.rs
+++ b/tests/test_issues.rs
@@ -17,13 +17,16 @@ fn test_issue_16_pixmap_to_png() {
 #[test]
 fn test_issue_27_flatten() {
     let doc = PdfDocument::open("tests/files/dummy.pdf").unwrap();
-    let blocks = doc
+    let pages = doc
         .pages()
         .unwrap()
         .map(|page| Ok(page?.to_text_page(TextPageOptions::PRESERVE_LIGATURES)?))
         .collect::<Result<Vec<_>, Error>>()
-        .unwrap()
-        .into_iter()
+        .unwrap();
+    // The original code from the issue doesn't compile anymore since `pages` is required to hold
+    // ownership.
+    let blocks = pages
+        .iter()
         .map(|text_page| text_page.blocks())
         .flatten()
         .collect::<Vec<_>>();


### PR DESCRIPTION
The first commit adds a Address Sanitizer job to our CI. See https://github.com/Bobo1239/mupdf-rs/runs/3329570361?check_suite_focus=true#step:4:230 for how the address sanitizer detected #27.
The second commit fixes the bug by tracking the necessary lifetimes and making the code from the issue uncompilable without modifications.