### PR TITLE
Panic if devenv couldn't be found

### DIFF
--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -342,7 +342,7 @@ fn build_libmupdf() {
         println!("cargo:rustc-link-lib=dylib=libmupdf");
         println!("cargo:rustc-link-lib=dylib=libthirdparty");
     } else {
-        eprintln!("failed to find devenv. Do you have it installed?");
+        panic!("failed to find devenv. Do you have it installed?");
     }
 }
 


### PR DESCRIPTION
Otherwise the build fails with linker errors at the end and no clue that MuPDF was never built.