### PR TITLE
Make loading system fonts dependent on `system-fonts` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 repository = "https://github.com/messense/mupdf-rs"
 
 [features]
-default = ["js", "xps", "svg", "cbz", "img", "html", "epub"]
+default = ["js", "xps", "svg", "cbz", "img", "html", "epub", "system-fonts"]
 # Use system libs for all thirdparty libs
 sys-lib = ["mupdf-sys/sys-lib"]
 # Use system freetype
@@ -38,13 +38,17 @@ cbz = ["mupdf-sys/cbz"]
 img = ["mupdf-sys/img"]
 html = ["mupdf-sys/html"]
 epub = ["mupdf-sys/epub"]
+system-fonts = ["font-kit"]
 
 [dependencies]
 mupdf-sys = { version = "0.3.0", path = "mupdf-sys" }
 once_cell = "1.3.1"
 num_enum = "0.5.1"
 bitflags = "1.2.1"
-font-kit = "0.11.0"
+
+[dependencies.font-kit]
+version = "0.11.0"
+optional = true
 
 [workspace]
 members = [

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,13 +6,14 @@ use std::sync::Mutex;
 use mupdf_sys::*;
 use once_cell::sync::Lazy;
 
-use crate::system_font;
 use crate::Error;
 
 static BASE_CONTEXT: Lazy<Mutex<BaseContext>> = Lazy::new(|| {
     let ctx = unsafe {
         let base_ctx = mupdf_new_base_context();
-        if cfg!(not(target_os = "android")) {
+        #[cfg(all(not(target_os = "android"), feature = "system-fonts"))]
+        {
+            use crate::system_font;
             // Android version is written in C
             fz_install_load_system_font_funcs(
                 base_ctx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,9 @@ pub mod shade;
 pub mod size;
 /// Stroke state
 pub mod stroke_state;
+
 /// System font loading
+#[cfg(feature = "system-fonts")]
 pub mod system_font;
 /// Text objects
 pub mod text;


### PR DESCRIPTION
When cross-compiling, including font-kit complicates the build process
significantly and loading system fonts is not always required.