### PR TITLE
Enable parallel compilation of mupdf-sys

### DIFF
--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -234,6 +234,11 @@ fn build_libmupdf() {
     make_flags.push(format!("XCFLAGS={}", c_flags.to_string_lossy()));
     make_flags.push(format!("XCXXFLAGS={}", cxx_flags.to_string_lossy()));
 
+    // Enable parallel compilation
+    if let Ok(n) = std::thread::available_parallelism() {
+        make_flags.push(format!("-j{}", n));
+    }
+
     let make = if cfg!(any(
         target_os = "freebsd",
         target_os = "openbsd",

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -316,6 +316,8 @@ fn build_libmupdf() {
         if cfg!(not(feature = "js")) {
             cl_env.push("/DFZ_ENABLE_JS#0".to_string());
         }
+        // Enable parallel compilation
+        cl_env.push("/MP".to_string());
         let d = msbuild
             .args(&[
                 "platform\\win32\\mupdf.sln",


### PR DESCRIPTION
On my system (AMD Ryzen 3950X; 16 cores/32 threads) this drops compilation times significantly:
- Linux: 110s -> 25s
- Windows 124s -> 48s