### PR TITLE
Clone trait implemented for Page struct

### DIFF
--- a/src/page.rs
+++ b/src/page.rs
@@ -337,6 +337,12 @@ impl Drop for Page {
     }
 }
 
+impl Clone for Page {
+    fn clone(&self) -> Self {
+        unsafe { Page::from_raw(fz_keep_page(context(), self.inner)) }
+    }
+}
+
 #[derive(Debug)]
 pub struct LinkIter {
     next: *mut fz_link,


### PR DESCRIPTION
Clone trait was implemented for Page struct in `src/page.rs` using `fz_keep_page` method which increment's MuPDF's internal reference count for the target page.

No major changes were made. All tests are passing.


Have a great day!