### PR TITLE
Clone traits implemented

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -300,6 +300,12 @@ impl Drop for Document {
     }
 }
 
+impl Clone for Document {
+    fn clone(&self) -> Self {
+        unsafe { Document::from_raw(fz_keep_document(context(), self.inner)) }
+    }
+}
+
 #[derive(Debug)]
 pub struct PageIter<'a> {
     index: i32,

--- a/src/page.rs
+++ b/src/page.rs
@@ -337,6 +337,12 @@ impl Drop for Page {
     }
 }
 
+impl Clone for Page {
+    fn clone(&self) -> Self {
+        unsafe { Page::from_raw(fz_keep_page(context(), self.inner)) }
+    }
+}
+
 #[derive(Debug)]
 pub struct LinkIter {
     next: *mut fz_link,


### PR DESCRIPTION
Clone trait was implemented for Page and Document structs in `src/page.rs` and `src/document.rs` using `fz_keep_page` and `fz_keep_document` methods which increment's MuPDF's internal reference count for the target structures.

Otherwise no major changes were made. All tests are passing.

Have a great day!
