### PR TITLE
Set outlines of PDF

### DIFF
--- a/mupdf-sys/wrapper.c
+++ b/mupdf-sys/wrapper.c
@@ -3070,6 +3070,20 @@ fz_matrix mupdf_pdf_page_transform(fz_context *ctx, pdf_page *page, mupdf_error_
     return ctm;
 }
 
+fz_matrix mupdf_pdf_page_obj_transform(fz_context *ctx, pdf_obj *page, mupdf_error_t **errptr)
+{
+    fz_matrix ctm = fz_identity;
+    fz_try(ctx)
+    {
+        pdf_page_obj_transform(ctx, page, NULL, &ctm);
+    }
+    fz_catch(ctx)
+    {
+        mupdf_save_error(ctx, errptr);
+    }
+    return ctm;
+}
+
 /* PDFAnnotation */
 int mupdf_pdf_annot_type(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
 {

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -1,0 +1,90 @@
+use crate::pdf::PdfObject;
+use crate::Error;
+
+#[derive(Debug, Clone)]
+pub struct Destination {
+    /// Indirect reference to page object.
+    pub page: PdfObject,
+    pub kind: DestinationKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DestinationKind {
+    /// Display the page at a scale which just fits the whole page
+    /// in the window both horizontally and vertically.
+    Fit,
+    /// Display the page with the vertical coordinate `top` at the top edge of the window,
+    /// and the magnification set to fit the document horizontally.
+    FitH { top: f32 },
+    /// Display the page with the horizontal coordinate `left` at the left edge of the window,
+    /// and the magnification set to fit the document vertically.
+    FitV { left: f32 },
+    /// Display the page with (`left`, `top`) at the upper-left corner
+    /// of the window and the page magnified by factor `zoom`.
+    XYZ { left: f32, top: f32, zoom: f32 },
+    /// Display the page zoomed to show the rectangle specified by `left`, `bottom`, `right`, and `top`.
+    FitR {
+        left: f32,
+        bottom: f32,
+        right: f32,
+        top: f32,
+    },
+    /// Display the page like `/Fit`, but use the bounding box of the page’s contents,
+    /// rather than the crop box.
+    FitB,
+    /// Display the page like `/FitH`, but use the bounding box of the page’s contents,
+    /// rather than the crop box.
+    FitBH { top: f32 },
+    /// Display the page like `/FitV`, but use the bounding box of the page’s contents,
+    /// rather than the crop box.
+    FitBV { left: f32 },
+}
+
+impl Destination {
+    /// Encode destination into a PDF array.
+    pub(crate) fn encode_into(self, array: &mut PdfObject) -> Result<(), Error> {
+        debug_assert_eq!(array.len()?, 0);
+
+        array.array_push(self.page)?;
+        match self.kind {
+            DestinationKind::Fit => array.array_push(PdfObject::new_name("Fit")?)?,
+            DestinationKind::FitH { top } => {
+                array.array_push(PdfObject::new_name("FitH")?)?;
+                array.array_push(PdfObject::new_real(top)?)?;
+            }
+            DestinationKind::FitV { left } => {
+                array.array_push(PdfObject::new_name("FitV")?)?;
+                array.array_push(PdfObject::new_real(left)?)?;
+            }
+            DestinationKind::XYZ { left, top, zoom } => {
+                array.array_push(PdfObject::new_name("XYZ")?)?;
+                array.array_push(PdfObject::new_real(left)?)?;
+                array.array_push(PdfObject::new_real(top)?)?;
+                array.array_push(PdfObject::new_real(zoom)?)?;
+            }
+            DestinationKind::FitR {
+                left,
+                bottom,
+                right,
+                top,
+            } => {
+                array.array_push(PdfObject::new_name("FitR")?)?;
+                array.array_push(PdfObject::new_real(left)?)?;
+                array.array_push(PdfObject::new_real(bottom)?)?;
+                array.array_push(PdfObject::new_real(right)?)?;
+                array.array_push(PdfObject::new_real(top)?)?;
+            }
+            DestinationKind::FitB => array.array_push(PdfObject::new_name("FitB")?)?,
+            DestinationKind::FitBH { top } => {
+                array.array_push(PdfObject::new_name("FitBH")?)?;
+                array.array_push(PdfObject::new_real(top)?)?;
+            }
+            DestinationKind::FitBV { left } => {
+                array.array_push(PdfObject::new_name("FitBV")?)?;
+                array.array_push(PdfObject::new_real(left)?)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ pub mod colorspace;
 pub mod context;
 /// Provide two-way communication between application and library
 pub mod cookie;
+/// Destination
+pub mod destination;
 /// Device interface
 pub mod device;
 /// A way of packaging up a stream of graphical operations
@@ -72,6 +74,7 @@ pub use colorspace::Colorspace;
 pub(crate) use context::context;
 pub use context::Context;
 pub use cookie::Cookie;
+pub use destination::{Destination, DestinationKind};
 pub use device::{BlendMode, Device};
 pub use display_list::DisplayList;
 pub use document::{Document, MetadataName};

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -7,7 +7,7 @@ use std::slice;
 use mupdf_sys::*;
 
 use crate::pdf::PdfDocument;
-use crate::{context, Buffer, Error};
+use crate::{context, Buffer, Error, Matrix};
 
 pub trait IntoPdfDictKey {
     fn into_pdf_dict_key(self) -> Result<PdfObject, Error>;
@@ -387,6 +387,13 @@ impl PdfObject {
             }
             Some(PdfDocument::from_raw(ptr))
         }
+    }
+
+    pub fn page_ctm(&self) -> Result<Matrix, Error> {
+        let matrix =
+            unsafe { ffi_try!(mupdf_pdf_page_obj_transform(context(), self.inner)).into() };
+
+        Ok(matrix)
     }
 }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,4 +1,6 @@
-use mupdf_sys::fz_point;
+use mupdf_sys::{fz_point, fz_transform_point};
+
+use crate::Matrix;
 
 /// A point in a two-dimensional space.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -11,11 +13,33 @@ impl Point {
     pub const fn new(x: f32, y: f32) -> Self {
         Self { x, y }
     }
+
+    /// Apply a transformation to a point.
+    ///
+    /// The NaN coordinates will be reset to 0.0,
+    /// which make `fz_transform_point` works normally.
+    /// Otherwise `(NaN, NaN)` will be returned.
+    pub fn transform(mut self, matrix: &Matrix) -> Self {
+        if self.x.is_nan() {
+            self.x = 0.0;
+        }
+        if self.y.is_nan() {
+            self.y = 0.0;
+        }
+
+        unsafe { fz_transform_point(self.into(), matrix.into()).into() }
+    }
 }
 
 impl From<fz_point> for Point {
     fn from(p: fz_point) -> Self {
         Self { x: p.x, y: p.y }
+    }
+}
+
+impl From<Point> for fz_point {
+    fn from(p: Point) -> Self {
+        fz_point { x: p.x, y: p.y }
     }
 }
 


### PR DESCRIPTION
## TODO APIs

- [x] `PdfDocument::delete_outlines`
- [x] `PdfDocument::set_outlines`

Resolve https://github.com/messense/mupdf-rs/issues/54 .