### PR TITLE
Add support for msys2 environment

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,7 +52,29 @@ jobs:
       - name: Test package mupdf-sys
         if: matrix.os == 'ubuntu-latest'
         run: cargo package --manifest-path mupdf-sys/Cargo.toml
+  
+  test-msys:
+    name: Test Suite (MSYS2)
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        include:
+          - { sys: ucrt64,  env: ucrt-x86_64 }
+          - { sys: mingw64, env: x86_64 }
+          # - { sys: mingw32, env: i686 }
+          - { sys: clang64, env: clang-x86_64 }
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys}}
+          install: mingw-w64-${{matrix.env}}-rust base base-devel unzip git
 
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+          fetch-depth: 500
+      - run: cargo test
+  
   asan:
     name: Address Sanitizer
     runs-on: ubuntu-latest

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -59,6 +59,9 @@ fn build_libmupdf() {
     let build_dir = out_dir.join("build");
     t!(fs::create_dir_all(&build_dir));
 
+    // workaround for windows gnu toolchain, path separator is `/` but not `\`
+    let build_dir_str = build_dir.to_string_lossy().replace("\\", "/");
+
     let current_dir = env::current_dir().unwrap();
     let mupdf_src_dir = current_dir.join("mupdf");
     cp_r(&mupdf_src_dir, &build_dir);


### PR DESCRIPTION
Introducing support for the MSYS2 build environment. This addition addresses the licensing challenges faced by enterprises when using the MSVC build on Windows. Additionally, it resolves issues related to path separators. 