### PR TITLE
Return an Option from `outline_glyph` instead of a `Path` containing a null pointer

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -130,7 +130,7 @@ impl Font {
         self.advance_glyph_with_wmode(glyph, false)
     }
 
-    pub fn outline_glyph_with_ctm(&self, glyph: i32, ctm: &Matrix) -> Result<Path, Error> {
+    pub fn outline_glyph_with_ctm(&self, glyph: i32, ctm: &Matrix) -> Result<Option<Path>, Error> {
         unsafe {
             let inner = ffi_try!(mupdf_outline_glyph(
                 context(),
@@ -138,11 +138,14 @@ impl Font {
                 glyph,
                 ctm.into()
             ));
-            Ok(Path::from_raw(inner))
+            if inner.is_null() {
+                return Ok(None);
+            }
+            Ok(Some(Path::from_raw(inner)))
         }
     }
 
-    pub fn outline_glyph(&self, glyph: i32) -> Result<Path, Error> {
+    pub fn outline_glyph(&self, glyph: i32) -> Result<Option<Path>, Error> {
         self.outline_glyph_with_ctm(glyph, &Matrix::IDENTITY)
     }
 }


### PR DESCRIPTION
The `outline_glyph` and `outline_glyph_with_ctm` functions returned a `Path` containing a null pointer in case a glyph was unable to be outlined.

`fz_outline_glpyh` tries to avoid throwing errors, does however throw one in case allocation fails. I'm not sure if i should keep the Result for that case.