### PR TITLE
Allows `PathWalker` to be used without creating a vtable

### DIFF
--- a/mupdf-sys/wrapper.c
+++ b/mupdf-sys/wrapper.c
@@ -621,7 +621,7 @@ void mupdf_closepath(fz_context *ctx, fz_path *path, mupdf_error_t **errptr)
     }
 }
 
-void mupdf_rectto(fz_context *ctx, fz_path *path, int x1, int y1, int x2, int y2, mupdf_error_t **errptr)
+void mupdf_rectto(fz_context *ctx, fz_path *path, float x1, float y1, float x2, float y2, mupdf_error_t **errptr)
 {
     fz_try(ctx)
     {

--- a/src/path.rs
+++ b/src/path.rs
@@ -23,7 +23,7 @@ pub trait PathWalker {
     }
 }
 
-impl<W: PathWalker> PathWalker for &mut W {
+impl<W: PathWalker + ?Sized> PathWalker for &mut W {
     fn move_to(&mut self, x: f32, y: f32) {
         (**self).move_to(x, y)
     }
@@ -329,5 +329,8 @@ mod test {
         assert!(!walker.curve_to);
         assert_eq!(walker.close, 2);
         assert!(walker.curve_to_y);
+
+        let mut dyn_walker: &mut dyn PathWalker = &mut TestPathWalker::default();
+        path.walk(dyn_walker).unwrap();
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -169,7 +169,7 @@ impl Path {
         Ok(())
     }
 
-    pub fn rect(&mut self, x1: i32, y1: i32, x2: i32, y2: i32) -> Result<(), Error> {
+    pub fn rect(&mut self, x1: f32, y1: f32, x2: f32, y2: f32) -> Result<(), Error> {
         unsafe {
             ffi_try!(mupdf_rectto(context(), self.inner, x1, y1, x2, y2));
         }


### PR DESCRIPTION
This removes the creation of a vtable optional for `PathWalker` by making the `Path::walk` method generic over `PathWalker`. As `PathWalker` is implemented for all `&mut PathWalker` passing `&mut PathWalker` or `&mut dyn PathWalker` to the `walk` method is still possible.

It also adds the optional `curve_to_y` and `rect` methods to the trait that default to calling the methods that mupdf would call as well if the function pointers in the `fz_path_walker` struct were `None`. This can sadly not be done for `curve_to_v` and `quad_to` as both of them require knowledge of the start position to call the default, which is not available to as as the trait.

This also changes the parameter type of the `Path::rect` function from `i32` to `f32` as this is what the C API seems to pass to us.