### PR TITLE
Rework `ColorParams` internals and allow conversion from `fz_color_params`

### DIFF
--- a/src/color_params.rs
+++ b/src/color_params.rs
@@ -1,3 +1,8 @@
+use std::{
+    fmt::{self, Debug, Formatter},
+    mem,
+};
+
 use mupdf_sys::*;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -8,43 +13,26 @@ pub enum RenderingIntent {
     AbsoluteColorimetric,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ColorParams(i32);
+#[derive(Clone, Copy, PartialEq)]
+pub struct ColorParams(u8);
 
 impl ColorParams {
-    const BP: i32 = 32;
-    const OP: i32 = 64;
-    const OPM: i32 = 128;
-
-    pub fn rendering_intent(flags: i32) -> RenderingIntent {
-        match flags & 3 {
-            0 => RenderingIntent::Perceptual,
-            1 => RenderingIntent::RelativeColorimetric,
-            2 => RenderingIntent::Saturation,
-            3 => RenderingIntent::AbsoluteColorimetric,
-            _ => RenderingIntent::Perceptual,
-        }
-    }
-
-    pub fn is_bp(flags: i32) -> bool {
-        flags & Self::BP != 0
-    }
-
-    pub fn is_op(flags: i32) -> bool {
-        flags & Self::OP != 0
-    }
-
-    pub fn is_opm(flags: i32) -> bool {
-        flags & Self::OPM != 0
-    }
+    const BP: u8 = 1 << 2;
+    const OP: u8 = 1 << 3;
+    const OPM: u8 = 1 << 4;
 
     pub fn new(ri: RenderingIntent, bp: bool, op: bool, opm: bool) -> Self {
-        let mut flags = match ri {
+        let ri = match ri {
             RenderingIntent::Perceptual => 0,
             RenderingIntent::RelativeColorimetric => 1,
             RenderingIntent::Saturation => 2,
             RenderingIntent::AbsoluteColorimetric => 3,
         };
+        Self::raw_new(ri, bp, op, opm)
+    }
+
+    fn raw_new(ri: u8, bp: bool, op: bool, opm: bool) -> Self {
+        let mut flags = ri;
         if bp {
             flags |= Self::BP;
         }
@@ -56,21 +44,72 @@ impl ColorParams {
         }
         Self(flags)
     }
+
+    pub fn rendering_intent(self) -> RenderingIntent {
+        match self.0 & 3 {
+            0 => RenderingIntent::Perceptual,
+            1 => RenderingIntent::RelativeColorimetric,
+            2 => RenderingIntent::Saturation,
+            3 => RenderingIntent::AbsoluteColorimetric,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn bp(self) -> bool {
+        self.0 & Self::BP != 0
+    }
+
+    pub fn op(self) -> bool {
+        self.0 & Self::OP != 0
+    }
+
+    pub fn opm(self) -> bool {
+        self.0 & Self::OPM != 0
+    }
+}
+
+impl From<fz_color_params> for ColorParams {
+    fn from(value: fz_color_params) -> Self {
+        Self::raw_new(value.ri & 3, value.bp != 0, value.op != 0, value.opm != 0)
+    }
 }
 
 impl From<ColorParams> for fz_color_params {
     fn from(val: ColorParams) -> Self {
-        let flags = val.0;
-        let bp = ((flags >> 5) & 1) as u8;
-        let op = ((flags >> 6) & 1) as u8;
-        let opm = ((flags >> 7) & 1) as u8;
-        let ri = (flags & 32) as u8;
-        fz_color_params { ri, bp, op, opm }
+        fz_color_params {
+            ri: val.rendering_intent() as u8,
+            bp: val.bp() as u8,
+            op: val.op() as u8,
+            opm: val.opm() as u8,
+        }
+    }
+}
+
+impl Debug for ColorParams {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ColorParams")
+            .field("rendering_intent", &self.rendering_intent())
+            .field("bp", &self.bp())
+            .field("op", &self.op())
+            .field("opm", &self.opm())
+            .finish()
     }
 }
 
 impl Default for ColorParams {
     fn default() -> Self {
         Self::new(RenderingIntent::RelativeColorimetric, true, false, false)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{fz_color_params, ColorParams, RenderingIntent};
+
+    #[test]
+    fn test_roundtrip_color_params() {
+        let expected = ColorParams::new(RenderingIntent::Saturation, true, false, false);
+        let got = ColorParams::from(fz_color_params::from(expected));
+        assert_eq!(got, expected);
     }
 }

--- a/src/color_params.rs
+++ b/src/color_params.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::{self, Debug, Formatter},
-    mem,
-};
+use std::fmt::{self, Debug, Formatter};
 
 use mupdf_sys::*;
 


### PR DESCRIPTION
Shrinks `ColorParams` size from an `i32` down to a `u8` using a bitflag approach. Imagining the u8 byte as a array of bits the layout looks like this: `[0, 0, 0, opm, op, bp, ri, ri]`.

This also implements `From<fz_color_params>` and adds a Debug implementation that displays the `ColorParams` as a struct: `ColorParams { rendering_intent: Saturation, bp: true, op: false, opm: false }` for the result of `ColorParams::new(RenderingIntent::Saturation, true, false, false)`.