### PR TITLE
Add the ability to write `Device`s in Rust

### DIFF
--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -118,8 +118,8 @@ fn build_libmupdf() {
     ];
 
     // this may be unused if none of the features below are enabled
-    #[allow(unused_variables)]
-    let add_lib = |cflags_name: &'static str, pkgcfg_name: &'static str| {
+    #[allow(unused_variables, unused_mut)]
+    let mut add_lib = |cflags_name: &'static str, pkgcfg_name: &'static str| {
         make_flags.push(format!(
             "SYS_{cflags_name}_CFLAGS={}",
             pkg_config::probe_library(pkgcfg_name)

--- a/mupdf-sys/src/lib.rs
+++ b/mupdf-sys/src/lib.rs
@@ -11,13 +11,8 @@ use core::{
 };
 
 /// This function allocates a new device and returns a pointer to it if no error occured. For the
-/// required structure of `T` check the example below.
-///
-/// The pointer `errptr` points to is expected to be null at the time this function is called.
-/// If an error occurs this inner pointer will be set to the error and null returned from this
-/// function. Was this inner pointer non-null before this function was called a new device will be
-/// allocated but the function will assume that an error has occured and will return null. This device
-/// will not be freed. It will, however, not cause unsafe behavior either.
+/// required structure of `T` check the example below. If an error occurs the pointer `errptr` points
+/// to will be set to to a pointer pointing to the error and null returned from this function.
 ///
 /// # Safety
 ///
@@ -55,10 +50,6 @@ pub unsafe fn mupdf_new_derived_device<T>(
     };
 
     let device = mupdf_new_device_of_size(ctx, SIZE, errptr);
-    if !(*errptr).is_null() {
-        return ptr::null_mut();
-    }
-
     let label = Memento_label(device.cast(), label.as_ptr());
     label.cast()
 }

--- a/mupdf-sys/src/lib.rs
+++ b/mupdf-sys/src/lib.rs
@@ -4,3 +4,13 @@
 #![allow(clippy::all)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+pub unsafe fn mupdf_new_derived_device<T>(
+    ctx: *mut fz_context,
+    label: *const std::ffi::c_char,
+) -> *mut T {
+    let size = std::ffi::c_int::try_from(size_of::<T>()).unwrap();
+    let device = fz_new_device_of_size(ctx, size);
+    let label = Memento_label(device.cast(), label);
+    label.cast()
+}

--- a/mupdf-sys/src/lib.rs
+++ b/mupdf-sys/src/lib.rs
@@ -5,12 +5,60 @@
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
+use core::{
+    ffi::{c_int, CStr},
+    ptr,
+};
+
+/// This function allocates a new device and returns a pointer to it if no error occured. For the
+/// required structure of `T` check the example below.
+///
+/// The pointer `errptr` points to is expected to be null at the time this function is called.
+/// If an error occurs this inner pointer will be set to the error and null returned from this
+/// function. Was this inner pointer non-null before this function was called a new device will be
+/// allocated but the function will assume that an error has occured and will return null. This device
+/// will not be freed. It will, however, not cause unsafe behavior either.
+///
+/// # Safety
+///
+/// The caller must ensure `ctx` and `errptr` to be a valid pointers.
+///
+/// It must also ensure `T` to be a type that starts with `fz_device`. Memory will be allocated for
+/// a new instance of `T`, but only the `fz_device` portion will be initialized. The rest is
+/// currently being zero-initialized, but this might change in the future.
+///
+/// # Example
+///
+/// This is how a compliant `T` might look like. The `repr(C)` is necessary as `repr(Rust)` does
+/// not guarantee stable field orderings.
+///
+/// ```rust
+/// use mupdf_sys::fz_device;
+///
+/// #[repr(C)]
+/// struct MyDevice {
+///     base: fz_device,
+///     foo: u32,
+/// }
+/// ```
 pub unsafe fn mupdf_new_derived_device<T>(
     ctx: *mut fz_context,
-    label: *const std::ffi::c_char,
+    label: &'static CStr,
+    errptr: *mut *mut mupdf_error_t,
 ) -> *mut T {
-    let size = std::ffi::c_int::try_from(size_of::<T>()).unwrap();
-    let device = fz_new_device_of_size(ctx, size);
-    let label = Memento_label(device.cast(), label);
+    let SIZE: c_int = const {
+        if (c_int::MAX as usize) < size_of::<T>() {
+            panic!("device too big")
+        } else {
+            size_of::<T>() as c_int
+        }
+    };
+
+    let device = mupdf_new_device_of_size(ctx, SIZE, errptr);
+    if !(*errptr).is_null() {
+        return ptr::null_mut();
+    }
+
+    let label = Memento_label(device.cast(), label.as_ptr());
     label.cast()
 }

--- a/mupdf-sys/src/lib.rs
+++ b/mupdf-sys/src/lib.rs
@@ -5,10 +5,7 @@
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-use core::{
-    ffi::{c_int, CStr},
-    ptr,
-};
+use core::ffi::{c_int, CStr};
 
 /// This function allocates a new device and returns a pointer to it if no error occured. For the
 /// required structure of `T` check the example below. If an error occurs the pointer `errptr` points

--- a/mupdf-sys/wrapper.c
+++ b/mupdf-sys/wrapper.c
@@ -2875,11 +2875,11 @@ void mupdf_begin_mask(fz_context *ctx, fz_device *device, fz_rect area, bool lum
     }
 }
 
-void mupdf_end_mask(fz_context *ctx, fz_device *device, mupdf_error_t **errptr)
+void mupdf_end_mask(fz_context *ctx, fz_device *device, fz_function *fn, mupdf_error_t **errptr)
 {
     fz_try(ctx)
     {
-        fz_end_mask(ctx, device);
+        fz_end_mask_tr(ctx, device, fn);
     }
     fz_catch(ctx)
     {

--- a/mupdf-sys/wrapper.c
+++ b/mupdf-sys/wrapper.c
@@ -2640,6 +2640,20 @@ fz_device *mupdf_new_draw_device(fz_context *ctx, fz_pixmap *pixmap, fz_irect cl
     return device;
 }
 
+fz_device *mupdf_new_device_of_size(fz_context *ctx, int size, mupdf_error_t **errptr)
+{
+    fz_device *device = NULL;
+    fz_try(ctx)
+    {
+        device = fz_new_device_of_size(ctx, size);
+    }
+    fz_catch(ctx)
+    {
+        mupdf_save_error(ctx, errptr);
+    }
+    return device;
+}
+
 fz_device *mupdf_new_display_list_device(fz_context *ctx, fz_display_list *list, mupdf_error_t **errptr)
 {
     fz_device *device = NULL;

--- a/mupdf-sys/wrapper.c
+++ b/mupdf-sys/wrapper.c
@@ -2863,6 +2863,54 @@ void mupdf_end_layer(fz_context *ctx, fz_device *device, mupdf_error_t **errptr)
     }
 }
 
+void mupdf_begin_structure(fz_context *ctx, fz_device *device, fz_structure standard, const char *raw, int idx, mupdf_error_t **errptr)
+{
+    fz_try(ctx)
+    {
+        fz_begin_structure(ctx, device, standard, raw, idx);
+    }
+    fz_catch(ctx)
+    {
+        mupdf_save_error(ctx, errptr);
+    }
+}
+
+void mupdf_end_structure(fz_context *ctx, fz_device *device, mupdf_error_t **errptr)
+{
+    fz_try(ctx)
+    {
+        fz_end_structure(ctx, device);
+    }
+    fz_catch(ctx)
+    {
+        mupdf_save_error(ctx, errptr);
+    }
+}
+
+void mupdf_begin_metatext(fz_context *ctx, fz_device *device, fz_metatext meta, const char *text, mupdf_error_t **errptr)
+{
+    fz_try(ctx)
+    {
+        fz_begin_metatext(ctx, device, meta, text);
+    }
+    fz_catch(ctx)
+    {
+        mupdf_save_error(ctx, errptr);
+    }
+}
+
+void mupdf_end_metatext(fz_context *ctx, fz_device *device, mupdf_error_t **errptr)
+{
+    fz_try(ctx)
+    {
+        fz_end_metatext(ctx, device);
+    }
+    fz_catch(ctx)
+    {
+        mupdf_save_error(ctx, errptr);
+    }
+}
+
 void mupdf_begin_mask(fz_context *ctx, fz_device *device, fz_rect area, bool luminosity, fz_colorspace *cs, const float *color, fz_color_params cp, mupdf_error_t **errptr)
 {
     fz_try(ctx)

--- a/src/device.rs
+++ b/src/device.rs
@@ -114,7 +114,7 @@ pub enum Structure {
     Quote = fz_structure_FZ_STRUCTURE_QUOTE as _,
     Note = fz_structure_FZ_STRUCTURE_NOTE as _,
     Reference = fz_structure_FZ_STRUCTURE_REFERENCE as _,
-    Bibentry = fz_structure_FZ_STRUCTURE_BIBENTRY as _,
+    BibEntry = fz_structure_FZ_STRUCTURE_BIBENTRY as _,
     Code = fz_structure_FZ_STRUCTURE_CODE as _,
     Link = fz_structure_FZ_STRUCTURE_LINK as _,
     Annot = fz_structure_FZ_STRUCTURE_ANNOT as _,
@@ -580,6 +580,47 @@ impl Device {
     pub fn end_layer(&self) -> Result<(), Error> {
         unsafe {
             ffi_try!(mupdf_end_layer(context(), self.dev));
+        }
+        Ok(())
+    }
+
+    pub fn begin_structure(&self, standard: Structure, raw: &str, idx: i32) -> Result<(), Error> {
+        let c_raw = CString::new(raw)?;
+        unsafe {
+            ffi_try!(mupdf_begin_structure(
+                context(),
+                self.dev,
+                standard as _,
+                c_raw.as_ptr(),
+                idx as _
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn end_structure(&self) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(mupdf_end_structure(context(), self.dev));
+        }
+        Ok(())
+    }
+
+    pub fn begin_metatext(&self, meta: Metatext, text: &str) -> Result<(), Error> {
+        let c_text = CString::new(text)?;
+        unsafe {
+            ffi_try!(mupdf_begin_metatext(
+                context(),
+                self.dev,
+                meta as _,
+                c_text.as_ptr()
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn end_metatext(&self) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(mupdf_end_metatext(context(), self.dev));
         }
         Ok(())
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,6 +1,7 @@
 use std::ptr;
 use std::{ffi::CString, num::NonZero};
 
+use bitflags::bitflags;
 use mupdf_sys::*;
 use num_enum::TryFromPrimitive;
 
@@ -33,6 +34,54 @@ pub enum BlendMode {
     Saturation = FZ_BLEND_SATURATION as u32,
     Color = FZ_BLEND_COLOR as u32,
     Luminosity = FZ_BLEND_LUMINOSITY as u32,
+}
+
+bitflags! {
+    pub struct DeviceFlag: u32 {
+        const MASK = FZ_DEVFLAG_MASK as _;
+        const COLOR = FZ_DEVFLAG_COLOR as _;
+        const UNCACHEABLE = FZ_DEVFLAG_UNCACHEABLE as _;
+        const FILLCOLOR_UNDEFINED = FZ_DEVFLAG_FILLCOLOR_UNDEFINED as _;
+        const STROKECOLOR_UNDEFINED = FZ_DEVFLAG_STROKECOLOR_UNDEFINED as _;
+        const STARTCAP_UNDEFINED = FZ_DEVFLAG_STARTCAP_UNDEFINED as _;
+        const DASHCAP_UNDEFINED = FZ_DEVFLAG_DASHCAP_UNDEFINED as _;
+        const ENDCAP_UNDEFINED = FZ_DEVFLAG_ENDCAP_UNDEFINED as _;
+        const LINEJOIN_UNDEFINED = FZ_DEVFLAG_LINEJOIN_UNDEFINED as _;
+        const MITERLIMIT_UNDEFINED = FZ_DEVFLAG_MITERLIMIT_UNDEFINED as _;
+        const LINEWIDTH_UNDEFINED = FZ_DEVFLAG_LINEWIDTH_UNDEFINED as _;
+        const BBOX_DEFINED = FZ_DEVFLAG_BBOX_DEFINED as _;
+        const GRIDFIT_AS_TILED = FZ_DEVFLAG_GRIDFIT_AS_TILED as _;
+        // will probably be released in 1.26.x
+        // const DASH_PATTERN_UNDEFINED = FZ_DEVFLAG_DASH_PATTERN_UNDEFINED as _;
+    }
+}
+
+pub struct DefaultColorspaces {
+    pub(crate) inner: *mut fz_default_colorspaces,
+}
+
+impl DefaultColorspaces {
+    pub fn gray(&self) -> Colorspace {
+        unsafe { Colorspace::from_raw((*self.inner).gray) }
+    }
+
+    pub fn rgb(&self) -> Colorspace {
+        unsafe { Colorspace::from_raw((*self.inner).rgb) }
+    }
+
+    pub fn cmyk(&self) -> Colorspace {
+        unsafe { Colorspace::from_raw((*self.inner).cmyk) }
+    }
+
+    pub fn oi(&self) -> Colorspace {
+        unsafe { Colorspace::from_raw((*self.inner).oi) }
+    }
+}
+
+impl Drop for DefaultColorspaces {
+    fn drop(&mut self) {
+        unsafe { fz_drop_default_colorspaces(context(), self.inner) }
+    }
 }
 
 pub struct Function {

--- a/src/device.rs
+++ b/src/device.rs
@@ -56,6 +56,101 @@ bitflags! {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
+#[repr(i32)]
+pub enum Structure {
+    Invalid = fz_structure_FZ_STRUCTURE_INVALID as _,
+
+    /* Grouping elements (PDF 1.7 - Table 10.20) */
+    Document = fz_structure_FZ_STRUCTURE_DOCUMENT as _,
+    Part = fz_structure_FZ_STRUCTURE_PART as _,
+    Art = fz_structure_FZ_STRUCTURE_ART as _,
+    Sect = fz_structure_FZ_STRUCTURE_SECT as _,
+    Div = fz_structure_FZ_STRUCTURE_DIV as _,
+    BlockQuote = fz_structure_FZ_STRUCTURE_BLOCKQUOTE as _,
+    Caption = fz_structure_FZ_STRUCTURE_CAPTION as _,
+    TOC = fz_structure_FZ_STRUCTURE_TOC as _,
+    TOCI = fz_structure_FZ_STRUCTURE_TOCI as _,
+    Index = fz_structure_FZ_STRUCTURE_INDEX as _,
+    NonStruct = fz_structure_FZ_STRUCTURE_NONSTRUCT as _,
+    Private = fz_structure_FZ_STRUCTURE_PRIVATE as _,
+    /* Grouping elements (PDF 2.0 - Table 364) */
+    DocumentFragment = fz_structure_FZ_STRUCTURE_DOCUMENTFRAGMENT as _,
+    /* Grouping elements (PDF 2.0 - Table 365) */
+    Aside = fz_structure_FZ_STRUCTURE_ASIDE as _,
+    /* Grouping elements (PDF 2.0 - Table 366) */
+    Title = fz_structure_FZ_STRUCTURE_TITLE as _,
+    FENote = fz_structure_FZ_STRUCTURE_FENOTE as _,
+    /* Grouping elements (PDF 2.0 - Table 367) */
+    Sub = fz_structure_FZ_STRUCTURE_SUB as _,
+
+    /* Paragraphlike elements (PDF 1.7 - Table 10.21) */
+    P = fz_structure_FZ_STRUCTURE_P as _,
+    H = fz_structure_FZ_STRUCTURE_H as _,
+    H1 = fz_structure_FZ_STRUCTURE_H1 as _,
+    H2 = fz_structure_FZ_STRUCTURE_H2 as _,
+    H3 = fz_structure_FZ_STRUCTURE_H3 as _,
+    H4 = fz_structure_FZ_STRUCTURE_H4 as _,
+    H5 = fz_structure_FZ_STRUCTURE_H5 as _,
+    H6 = fz_structure_FZ_STRUCTURE_H6 as _,
+
+    /* List elements (PDF 1.7 - Table 10.23) */
+    List = fz_structure_FZ_STRUCTURE_LIST as _,
+    ListItem = fz_structure_FZ_STRUCTURE_LISTITEM as _,
+    Label = fz_structure_FZ_STRUCTURE_LABEL as _,
+    ListBody = fz_structure_FZ_STRUCTURE_LISTBODY as _,
+
+    /* Table elements (PDF 1.7 - Table 10.24) */
+    Table = fz_structure_FZ_STRUCTURE_TABLE as _,
+    TR = fz_structure_FZ_STRUCTURE_TR as _,
+    TH = fz_structure_FZ_STRUCTURE_TH as _,
+    TD = fz_structure_FZ_STRUCTURE_TD as _,
+    THead = fz_structure_FZ_STRUCTURE_THEAD as _,
+    TBody = fz_structure_FZ_STRUCTURE_TBODY as _,
+    TFoot = fz_structure_FZ_STRUCTURE_TFOOT as _,
+
+    /* Inline elements (PDF 1.7 - Table 10.25) */
+    Span = fz_structure_FZ_STRUCTURE_SPAN as _,
+    Quote = fz_structure_FZ_STRUCTURE_QUOTE as _,
+    Note = fz_structure_FZ_STRUCTURE_NOTE as _,
+    Reference = fz_structure_FZ_STRUCTURE_REFERENCE as _,
+    Bibentry = fz_structure_FZ_STRUCTURE_BIBENTRY as _,
+    Code = fz_structure_FZ_STRUCTURE_CODE as _,
+    Link = fz_structure_FZ_STRUCTURE_LINK as _,
+    Annot = fz_structure_FZ_STRUCTURE_ANNOT as _,
+    /* Inline elements (PDF 2.0 - Table 368) */
+    Em = fz_structure_FZ_STRUCTURE_EM as _,
+    Strong = fz_structure_FZ_STRUCTURE_STRONG as _,
+
+    /* Ruby inline element (PDF 1.7 - Table 10.26) */
+    Ruby = fz_structure_FZ_STRUCTURE_RUBY as _,
+    RB = fz_structure_FZ_STRUCTURE_RB as _,
+    RT = fz_structure_FZ_STRUCTURE_RT as _,
+    RP = fz_structure_FZ_STRUCTURE_RP as _,
+
+    /* Warichu inline element (PDF 1.7 - Table 10.26) */
+    Warichu = fz_structure_FZ_STRUCTURE_WARICHU as _,
+    WT = fz_structure_FZ_STRUCTURE_WT as _,
+    WP = fz_structure_FZ_STRUCTURE_WP as _,
+
+    /* Illustration elements (PDF 1.7 - Table 10.27) */
+    Figure = fz_structure_FZ_STRUCTURE_FIGURE as _,
+    Formula = fz_structure_FZ_STRUCTURE_FORMULA as _,
+    Form = fz_structure_FZ_STRUCTURE_FORM as _,
+
+    /* Artifact structure type (PDF 2.0 - Table 375) */
+    Artifact = fz_structure_FZ_STRUCTURE_ARTIFACT as _,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
+#[repr(u32)]
+pub enum Metatext {
+    ActualText = fz_metatext_FZ_METATEXT_ACTUALTEXT as _,
+    Alt = fz_metatext_FZ_METATEXT_ALT as _,
+    Abbreviation = fz_metatext_FZ_METATEXT_ABBREVIATION as _,
+    Title = fz_metatext_FZ_METATEXT_TITLE as _,
+}
+
 pub struct DefaultColorspaces {
     pub(crate) inner: *mut fz_default_colorspaces,
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -8,6 +8,9 @@ use crate::{
     Shade, StrokeState, Text, TextPage, TextPageOptions,
 };
 
+mod custom;
+pub use custom::CustomDevice;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub enum BlendMode {
@@ -40,6 +43,10 @@ pub struct Device {
 impl Device {
     pub(crate) unsafe fn from_raw(dev: *mut fz_device, list: *mut fz_display_list) -> Self {
         Self { dev, list }
+    }
+
+    pub fn from_custom<D: CustomDevice>(device: D) -> Self {
+        custom::create(device)
     }
 
     pub fn from_pixmap_with_clip(pixmap: &Pixmap, clip: IRect) -> Result<Self, Error> {

--- a/src/device.rs
+++ b/src/device.rs
@@ -60,24 +60,6 @@ pub struct DefaultColorspaces {
     pub(crate) inner: *mut fz_default_colorspaces,
 }
 
-impl DefaultColorspaces {
-    pub fn gray(&self) -> Colorspace {
-        unsafe { Colorspace::from_raw((*self.inner).gray) }
-    }
-
-    pub fn rgb(&self) -> Colorspace {
-        unsafe { Colorspace::from_raw((*self.inner).rgb) }
-    }
-
-    pub fn cmyk(&self) -> Colorspace {
-        unsafe { Colorspace::from_raw((*self.inner).cmyk) }
-    }
-
-    pub fn oi(&self) -> Colorspace {
-        unsafe { Colorspace::from_raw((*self.inner).oi) }
-    }
-}
-
 impl Drop for DefaultColorspaces {
     fn drop(&mut self) {
         unsafe { fz_drop_default_colorspaces(context(), self.inner) }

--- a/src/device.rs
+++ b/src/device.rs
@@ -182,7 +182,7 @@ impl Device {
         Self { dev, list }
     }
 
-    pub fn from_native<D: NativeDevice>(device: D) -> Self {
+    pub fn from_native<D: NativeDevice>(device: D) -> Result<Self, Error> {
         native::create(device)
     }
 

--- a/src/device/custom.rs
+++ b/src/device/custom.rs
@@ -2,7 +2,10 @@ use std::{ffi::c_int, mem, ptr, slice};
 
 use mupdf_sys::*;
 
-use crate::{context, ColorParams, Colorspace, Device, Matrix, Path, Rect, StrokeState, Text};
+use crate::{
+    context, BlendMode, ColorParams, Colorspace, Device, Function, Image, Matrix, Path, Rect,
+    Shade, StrokeState, Text,
+};
 
 #[allow(unused_variables)]
 pub trait CustomDevice {
@@ -78,6 +81,50 @@ pub trait CustomDevice {
     }
 
     fn ignore_text(&mut self, text: &Text, cmt: Matrix) {}
+
+    fn fill_shade(&mut self, shade: &Shade, cmt: Matrix, alpha: f32, cp: ColorParams) {}
+
+    fn fill_image(&mut self, img: &Image, cmt: Matrix, alpha: f32, cp: ColorParams) {}
+
+    fn fill_image_mask(
+        &mut self,
+        img: &Image,
+        cmt: Matrix,
+        color_space: Colorspace,
+        color: &[f32],
+        alpha: f32,
+        cp: ColorParams,
+    ) {
+    }
+
+    fn clip_image_mask(&mut self, img: &Image, cmt: Matrix, scissor: Rect) {}
+
+    fn pop_clip(&mut self) {}
+
+    fn begin_mask(
+        &mut self,
+        area: Rect,
+        luminosity: bool,
+        color_space: Colorspace,
+        color: &[f32],
+        cp: ColorParams,
+    ) {
+    }
+
+    fn end_mask(&mut self, f: &Function) {}
+
+    fn begin_group(
+        &mut self,
+        area: Rect,
+        cs: Colorspace,
+        isolated: bool,
+        knockout: bool,
+        blendmode: BlendMode,
+        alpha: f32,
+    ) {
+    }
+
+    fn end_group(&mut self) {}
 }
 
 impl<T: CustomDevice + ?Sized> CustomDevice for &mut T {
@@ -167,6 +214,65 @@ impl<T: CustomDevice + ?Sized> CustomDevice for &mut T {
     fn ignore_text(&mut self, text: &Text, cmt: Matrix) {
         (**self).ignore_text(text, cmt);
     }
+
+    fn fill_shade(&mut self, shade: &Shade, cmt: Matrix, alpha: f32, cp: ColorParams) {
+        (**self).fill_shade(shade, cmt, alpha, cp);
+    }
+
+    fn fill_image(&mut self, img: &Image, cmt: Matrix, alpha: f32, cp: ColorParams) {
+        (**self).fill_image(img, cmt, alpha, cp);
+    }
+
+    fn fill_image_mask(
+        &mut self,
+        img: &Image,
+        cmt: Matrix,
+        color_space: Colorspace,
+        color: &[f32],
+        alpha: f32,
+        cp: ColorParams,
+    ) {
+        (**self).fill_image_mask(img, cmt, color_space, color, alpha, cp);
+    }
+
+    fn clip_image_mask(&mut self, img: &Image, cmt: Matrix, scissor: Rect) {
+        (**self).clip_image_mask(img, cmt, scissor);
+    }
+
+    fn pop_clip(&mut self) {
+        (**self).pop_clip();
+    }
+
+    fn begin_mask(
+        &mut self,
+        area: Rect,
+        luminosity: bool,
+        color_space: Colorspace,
+        color: &[f32],
+        cp: ColorParams,
+    ) {
+        (**self).begin_mask(area, luminosity, color_space, color, cp);
+    }
+
+    fn end_mask(&mut self, f: &Function) {
+        (**self).end_mask(f);
+    }
+
+    fn begin_group(
+        &mut self,
+        area: Rect,
+        cs: Colorspace,
+        isolated: bool,
+        knockout: bool,
+        blendmode: BlendMode,
+        alpha: f32,
+    ) {
+        (**self).begin_group(area, cs, isolated, knockout, blendmode, alpha);
+    }
+
+    fn end_group(&mut self) {
+        (**self).end_group();
+    }
 }
 
 pub(crate) fn create<D: CustomDevice>(device: D) -> Device {
@@ -176,15 +282,29 @@ pub(crate) fn create<D: CustomDevice>(device: D) -> Device {
 
         (*c_device).base.close_device = Some(close_device::<D>);
         (*c_device).base.drop_device = Some(drop_device::<D>);
+
         (*c_device).base.fill_path = Some(fill_path::<D>);
         (*c_device).base.stroke_path = Some(stroke_path::<D>);
         (*c_device).base.clip_path = Some(clip_path::<D>);
         (*c_device).base.clip_stroke_path = Some(clip_stroke_path::<D>);
+
         (*c_device).base.fill_text = Some(fill_text::<D>);
         (*c_device).base.stroke_text = Some(stroke_text::<D>);
         (*c_device).base.clip_text = Some(clip_text::<D>);
         (*c_device).base.clip_stroke_text = Some(clip_stroke_text::<D>);
         (*c_device).base.ignore_text = Some(ignore_text::<D>);
+
+        (*c_device).base.fill_shade = Some(fill_shade::<D>);
+        (*c_device).base.fill_image = Some(fill_image::<D>);
+        (*c_device).base.fill_image_mask = Some(fill_image_mask::<D>);
+        (*c_device).base.clip_image_mask = Some(clip_image_mask::<D>);
+
+        (*c_device).base.pop_clip = Some(pop_clip::<D>);
+
+        (*c_device).base.begin_mask = Some(begin_mask::<D>);
+        (*c_device).base.end_mask = Some(end_mask::<D>);
+        (*c_device).base.begin_group = Some(begin_group::<D>);
+        (*c_device).base.end_group = Some(end_group::<D>);
 
         Device::from_raw(c_device.cast(), ptr::null_mut())
     };
@@ -440,5 +560,159 @@ unsafe extern "C" fn ignore_text<D: CustomDevice>(
         dev.ignore_text(&text, cmt.into());
 
         mem::forget(text);
+    });
+}
+
+unsafe extern "C" fn fill_shade<D: CustomDevice>(
+    _ctx: *mut fz_context,
+    dev: *mut fz_device,
+    shd: *mut fz_shade,
+    ctm: fz_matrix,
+    alpha: f32,
+    color_params: fz_color_params,
+) {
+    with_rust_device::<D>(dev, |dev| {
+        let shade = Shade { inner: shd };
+
+        dev.fill_shade(&shade, ctm.into(), alpha, color_params.into());
+
+        mem::forget(shade);
+    });
+}
+
+unsafe extern "C" fn fill_image<D: CustomDevice>(
+    _ctx: *mut fz_context,
+    dev: *mut fz_device,
+    img: *mut fz_image,
+    ctm: fz_matrix,
+    alpha: f32,
+    color_params: fz_color_params,
+) {
+    with_rust_device::<D>(dev, |dev| {
+        let img = Image::from_raw(img);
+
+        dev.fill_image(&img, ctm.into(), alpha, color_params.into());
+
+        mem::forget(img);
+    });
+}
+
+unsafe extern "C" fn fill_image_mask<D: CustomDevice>(
+    _ctx: *mut fz_context,
+    dev: *mut fz_device,
+    img: *mut fz_image,
+    ctm: fz_matrix,
+    color_space: *mut fz_colorspace,
+    color: *const f32,
+    alpha: f32,
+    color_params: fz_color_params,
+) {
+    with_rust_device::<D>(dev, |dev| {
+        let cs = Colorspace::from_raw(color_space);
+        let cs_n = cs.n() as usize;
+
+        let img = Image::from_raw(img);
+
+        dev.fill_image_mask(
+            &img,
+            ctm.into(),
+            cs,
+            slice::from_raw_parts(color, cs_n),
+            alpha,
+            color_params.into(),
+        );
+
+        mem::forget(img);
+    });
+}
+
+unsafe extern "C" fn clip_image_mask<D: CustomDevice>(
+    _ctx: *mut fz_context,
+    dev: *mut fz_device,
+    img: *mut fz_image,
+    cmt: fz_matrix,
+    scissor: fz_rect,
+) {
+    with_rust_device::<D>(dev, |dev| {
+        let img = Image::from_raw(img);
+
+        dev.clip_image_mask(&img, cmt.into(), scissor.into());
+
+        mem::forget(img);
+    });
+}
+
+unsafe extern "C" fn pop_clip<D: CustomDevice>(_ctx: *mut fz_context, dev: *mut fz_device) {
+    with_rust_device::<D>(dev, |dev| {
+        dev.pop_clip();
+    });
+}
+
+unsafe extern "C" fn begin_mask<D: CustomDevice>(
+    _ctx: *mut fz_context,
+    dev: *mut fz_device,
+    area: fz_rect,
+    luminosity: c_int,
+    color_space: *mut fz_colorspace,
+    color: *const f32,
+    color_params: fz_color_params,
+) {
+    with_rust_device::<D>(dev, |dev| {
+        let cs = Colorspace::from_raw(color_space);
+        let cs_n = cs.n() as usize;
+
+        dev.begin_mask(
+            area.into(),
+            luminosity != 0,
+            cs,
+            slice::from_raw_parts(color, cs_n),
+            color_params.into(),
+        );
+    });
+}
+
+unsafe extern "C" fn end_mask<D: CustomDevice>(
+    _ctx: *mut fz_context,
+    dev: *mut fz_device,
+    f: *mut fz_function,
+) {
+    with_rust_device::<D>(dev, |dev| {
+        let f = Function { inner: f };
+
+        dev.end_mask(&f);
+
+        mem::forget(f);
+    });
+}
+
+unsafe extern "C" fn begin_group<D: CustomDevice>(
+    _ctx: *mut fz_context,
+    dev: *mut fz_device,
+    area: fz_rect,
+    color_space: *mut fz_colorspace,
+    isolated: c_int,
+    knockout: c_int,
+    blendmode: c_int,
+    alpha: f32,
+) {
+    with_rust_device::<D>(dev, |dev| {
+        let cs = Colorspace::from_raw(color_space);
+
+        let blendmode = BlendMode::try_from(blendmode as u32).unwrap();
+
+        dev.begin_group(
+            area.into(),
+            cs,
+            isolated != 0,
+            knockout != 0,
+            blendmode,
+            alpha,
+        );
+    });
+}
+
+unsafe extern "C" fn end_group<D: CustomDevice>(_ctx: *mut fz_context, dev: *mut fz_device) {
+    with_rust_device::<D>(dev, |dev| {
+        dev.end_group();
     });
 }

--- a/src/device/custom.rs
+++ b/src/device/custom.rs
@@ -1,0 +1,225 @@
+use std::{ffi::c_int, mem, ptr, slice};
+
+use mupdf_sys::*;
+
+use crate::{context, ColorParams, Colorspace, Device, Matrix, Path, StrokeState, Text};
+
+#[allow(unused_variables)]
+pub trait CustomDevice {
+    fn close_device(&mut self) {}
+
+    fn fill_path(
+        &mut self,
+        path: &Path,
+        even_odd: bool,
+        cmt: Matrix,
+        color_space: Colorspace,
+        color: &[f32],
+        alpha: f32,
+        cp: ColorParams,
+    ) {
+    }
+
+    fn stroke_path(
+        &mut self,
+        path: &Path,
+        stroke_state: &StrokeState,
+        cmt: Matrix,
+        color_space: Colorspace,
+        color: &[f32],
+        alpha: f32,
+        cp: ColorParams,
+    ) {
+    }
+
+    fn fill_text(
+        &mut self,
+        text: &Text,
+        cmt: Matrix,
+        color_space: Colorspace,
+        color: &[f32],
+        alpha: f32,
+        cp: ColorParams,
+    ) {
+    }
+}
+
+impl<T: CustomDevice + ?Sized> CustomDevice for &mut T {
+    fn close_device(&mut self) {
+        (**self).close_device();
+    }
+
+    fn fill_path(
+        &mut self,
+        path: &Path,
+        even_odd: bool,
+        cmt: Matrix,
+        color_space: Colorspace,
+        color: &[f32],
+        alpha: f32,
+        cp: ColorParams,
+    ) {
+        (**self).fill_path(path, even_odd, cmt, color_space, color, alpha, cp);
+    }
+
+    fn stroke_path(
+        &mut self,
+        path: &Path,
+        stroke_state: &StrokeState,
+        cmt: Matrix,
+        color_space: Colorspace,
+        color: &[f32],
+        alpha: f32,
+        cp: ColorParams,
+    ) {
+        (**self).stroke_path(path, stroke_state, cmt, color_space, color, alpha, cp);
+    }
+
+    fn fill_text(
+        &mut self,
+        text: &Text,
+        cmt: Matrix,
+        color_space: Colorspace,
+        color: &[f32],
+        alpha: f32,
+        cp: ColorParams,
+    ) {
+        (**self).fill_text(text, cmt, color_space, color, alpha, cp);
+    }
+}
+
+pub(crate) fn create<D: CustomDevice>(device: D) -> Device {
+    let d = unsafe {
+        let c_device = mupdf_new_derived_device::<CDevice<D>>(context(), c"RustDevice".as_ptr());
+        ptr::write(&raw mut (*c_device).rust_device, device);
+
+        (*c_device).base.close_device = Some(close_device::<D>);
+        (*c_device).base.drop_device = Some(drop_device::<D>);
+        (*c_device).base.fill_path = Some(fill_path::<D>);
+        (*c_device).base.stroke_path = Some(stroke_path::<D>);
+        (*c_device).base.fill_text = Some(fill_text::<D>);
+
+        Device::from_raw(c_device.cast(), ptr::null_mut())
+    };
+    d
+}
+
+#[repr(C)]
+struct CDevice<D> {
+    base: fz_device,
+    rust_device: D,
+}
+
+unsafe fn with_rust_device<'a, D: CustomDevice>(dev: *mut fz_device, f: impl FnOnce(&mut D)) {
+    let c_device: *mut CDevice<D> = dev.cast();
+    let rust_device = &mut (*c_device).rust_device;
+    f(rust_device);
+    let _ = rust_device;
+}
+
+unsafe extern "C" fn close_device<D: CustomDevice>(_ctx: *mut fz_context, dev: *mut fz_device) {
+    with_rust_device::<D>(dev, |dev| dev.close_device());
+}
+
+unsafe extern "C" fn drop_device<D: CustomDevice>(_ctx: *mut fz_context, dev: *mut fz_device) {
+    let c_device: *mut CDevice<D> = dev.cast();
+    let rust_device = &raw mut (*c_device).rust_device;
+
+    ptr::drop_in_place(rust_device);
+}
+
+unsafe extern "C" fn fill_path<D: CustomDevice>(
+    _ctx: *mut fz_context,
+    dev: *mut fz_device,
+    path: *const fz_path,
+    even_odd: c_int,
+    cmt: fz_matrix,
+    color_space: *mut fz_colorspace,
+    color: *const f32,
+    alpha: f32,
+    color_params: fz_color_params,
+) {
+    with_rust_device::<D>(dev, |dev| {
+        let cs = Colorspace::from_raw(color_space);
+        let cs_n = cs.n() as usize;
+
+        let path = Path::from_raw(path.cast_mut());
+
+        dev.fill_path(
+            &path,
+            even_odd != 0,
+            cmt.into(),
+            cs,
+            slice::from_raw_parts(color, cs_n),
+            alpha,
+            color_params.into(),
+        );
+
+        mem::forget(path);
+    });
+}
+
+unsafe extern "C" fn stroke_path<D: CustomDevice>(
+    _ctx: *mut fz_context,
+    dev: *mut fz_device,
+    path: *const fz_path,
+    stroke_state: *const fz_stroke_state,
+    cmt: fz_matrix,
+    color_space: *mut fz_colorspace,
+    color: *const f32,
+    alpha: f32,
+    color_params: fz_color_params,
+) {
+    with_rust_device::<D>(dev, |dev| {
+        let cs = Colorspace::from_raw(color_space);
+        let cs_n = cs.n() as usize;
+
+        let path = Path::from_raw(path.cast_mut());
+        let stroke_state = StrokeState {
+            inner: stroke_state.cast_mut(),
+        };
+
+        dev.stroke_path(
+            &path,
+            &stroke_state,
+            cmt.into(),
+            cs,
+            slice::from_raw_parts(color, cs_n),
+            alpha,
+            color_params.into(),
+        );
+
+        mem::forget(stroke_state);
+        mem::forget(path);
+    });
+}
+
+unsafe extern "C" fn fill_text<D: CustomDevice>(
+    _ctx: *mut fz_context,
+    dev: *mut fz_device,
+    text: *const fz_text,
+    cmt: fz_matrix,
+    color_space: *mut fz_colorspace,
+    color: *const f32,
+    alpha: f32,
+    color_params: fz_color_params,
+) {
+    with_rust_device::<D>(dev, |dev| {
+        let text = Text {
+            inner: text.cast_mut(),
+        };
+
+        let cs = Colorspace::from_raw(color_space);
+        let cs_n = cs.n() as usize;
+        dev.fill_text(
+            &text,
+            cmt.into(),
+            cs,
+            slice::from_raw_parts(color, cs_n),
+            alpha,
+            color_params.into(),
+        );
+
+        mem::forget(text);
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub(crate) use context::context;
 pub use context::Context;
 pub use cookie::Cookie;
 pub use destination::{Destination, DestinationKind};
-pub use device::{BlendMode, Device};
+pub use device::{BlendMode, CustomDevice, Device};
 pub use display_list::DisplayList;
 pub use document::{Document, MetadataName};
 pub use document_writer::DocumentWriter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub(crate) use context::context;
 pub use context::Context;
 pub use cookie::Cookie;
 pub use destination::{Destination, DestinationKind};
-pub use device::{BlendMode, CustomDevice, Device, Function};
+pub use device::{BlendMode, Device, Function, NativeDevice};
 pub use display_list::DisplayList;
 pub use document::{Document, MetadataName};
 pub use document_writer::DocumentWriter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub(crate) use context::context;
 pub use context::Context;
 pub use cookie::Cookie;
 pub use destination::{Destination, DestinationKind};
-pub use device::{BlendMode, CustomDevice, Device};
+pub use device::{BlendMode, CustomDevice, Device, Function};
 pub use display_list::DisplayList;
 pub use document::{Document, MetadataName};
 pub use document_writer::DocumentWriter;


### PR DESCRIPTION
This allows creating `Device`s in Rust by implementing the `NativeDevice` trait and calling the `Device::from_native()` function.