### PR TITLE
Improve `mupdf-sys` docs

### DIFF
--- a/mupdf-sys/Cargo.toml
+++ b/mupdf-sys/Cargo.toml
@@ -90,5 +90,6 @@ tesseract = []
 bindgen = { version = "0.71", default-features = false, features = ["runtime"] }
 cc = "1.0.50"
 pkg-config = "0.3"
+regex = "1.11"
 
 [dependencies]

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -365,6 +365,115 @@ fn build_libmupdf() {
     }
 }
 
+#[derive(Debug)]
+struct Callback {
+    types: regex::Regex,
+    full_names: std::cell::RefCell<std::collections::HashMap<String, String>>,
+}
+
+impl Default for Callback {
+    fn default() -> Self {
+        Self {
+            types: regex::RegexBuilder::new("fz_[a-z_*]+")
+                .case_insensitive(true)
+                .build()
+                .unwrap(),
+            full_names: std::cell::RefCell::default(),
+        }
+    }
+}
+
+impl bindgen::callbacks::ParseCallbacks for Callback {
+    fn item_name(&self, original_item_name: &str) -> Option<String> {
+        self.full_names
+            .borrow_mut()
+            .insert(original_item_name.to_owned(), original_item_name.to_owned());
+        None
+    }
+
+    fn enum_variant_name(
+        &self,
+        enum_name: Option<&str>,
+        original_variant_name: &str,
+        _variant_value: bindgen::callbacks::EnumVariantValue,
+    ) -> Option<String> {
+        let enum_name = enum_name?;
+        if enum_name.contains("unnamed at ") {
+            return None;
+        }
+
+        let name = format!("{}_{}", enum_name, original_variant_name);
+        self.full_names
+            .borrow_mut()
+            .insert(original_variant_name.to_owned(), name);
+        None
+    }
+
+    fn process_comment(&self, comment: &str) -> Option<String> {
+        let mut output = String::new();
+        let mut newlines = 0;
+        let mut arguments = false;
+
+        for mut line in comment.split('\n') {
+            if line.is_empty() {
+                newlines += 1;
+                continue;
+            }
+
+            let mut argument = false;
+            if let Some(pline) = line.strip_prefix("@param") {
+                line = pline;
+                argument = true;
+            }
+
+            match newlines {
+                0 => {}
+                1 if !argument => output.push_str("<br>"),
+                _ => output.push_str("\n\n"),
+            };
+            newlines = 0;
+
+            if argument {
+                if !arguments {
+                    output.push_str("# Arguments\n");
+                    arguments = true;
+                }
+                output.push_str("* ");
+            }
+
+            let line = line
+                .replace('[', "\\[")
+                .replace(']', "\\]")
+                .replace('<', "\\<")
+                .replace('>', "\\>");
+            let line = self.types.replace_all(&line, |c: &regex::Captures| {
+                let name = &c[0];
+                if name.contains('*') {
+                    return format!("`{}`", name);
+                }
+
+                let full_names = self.full_names.borrow();
+                if let Some(full_name) = full_names.get(name) {
+                    return format!("[`{}`]({})", name, full_name);
+                }
+
+                if let Some(short_name) = name.strip_suffix("s") {
+                    if let Some(full_name) = full_names.get(short_name) {
+                        return format!("[`{}`]({})s", short_name, full_name);
+                    }
+                }
+
+                format!("[`{}`]", name)
+            });
+
+            output.push_str(&line);
+
+            newlines += 1;
+        }
+        Some(output)
+    }
+}
+
 fn main() {
     fail_on_empty_directory("mupdf");
     println!("cargo:rerun-if-changed=wrapper.h");
@@ -396,6 +505,7 @@ fn main() {
         .allowlist_var("PDF_.*")
         .allowlist_var("UCDN_.*")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .parse_callbacks(Box::new(Callback::default()))
         .size_t_is_usize(true)
         .generate()
         .expect("Unable to generate bindings");


### PR DESCRIPTION
Parses the mupdf docs and converts them into a more docs.rs friendly format. It links other types and functions and puts some parameter names in markdown inline code apostrophes. It also escapes `<`, `>`, `[` and `]` as docs.rs will interpret them as HTML or links otherwise, causing the `<path>` tag to disappear as in the pink highlighted example below.

It also splits at every linebreak, which sometimes looks a bit unnecessary, but cases like the last example from the table below are otherwise unreadable.

Because of the very different styles of comments across the mupdf codebase some weird formatting issues might happen with this change, but I've looked for these cases and haven't found any yet.

Here are some comparisons:
Before            | After
:-------------------------:|:-------------------------:
![imagen](https://github.com/user-attachments/assets/3d524160-0d00-48df-98e0-d6a5d1344804) | ![imagen](https://github.com/user-attachments/assets/f0b7571c-16c9-4bdb-ae71-db94d36a53be)
![imagen](https://github.com/user-attachments/assets/80932785-c2b2-4da3-ab1a-93727cf4f905) | ![imagen](https://github.com/user-attachments/assets/3c0ae94f-9aa1-4fe7-aac6-f7f63f63589d)
![imagen](https://github.com/user-attachments/assets/f25c4578-0562-4fe0-87f6-2c521f9a8aa8) | ![imagen](https://github.com/user-attachments/assets/69019bea-67a6-4c48-b026-157dd41b7b1e)
![imagen](https://github.com/user-attachments/assets/bc81f80d-10ee-4c06-bb72-0f870cf3c435) | ![imagen](https://github.com/user-attachments/assets/84dcf5f2-10e8-40c3-9aa8-e1fc96b5a40a)