### PR TITLE
Apply cleanups suggested by clippy and plug it into CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 500
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt-get -y install libfontconfig1-dev
-      - run: cargo check
+      - run: cargo clippy --tests -- -D warnings
 
   test:
     name: Test Suite

--- a/src/context.rs
+++ b/src/context.rs
@@ -28,7 +28,7 @@ static BASE_CONTEXT: Lazy<Mutex<BaseContext>> = Lazy::new(|| {
 });
 
 thread_local! {
-    static LOCAL_CONTEXT: RefCell<RawContext> = RefCell::new(RawContext(ptr::null_mut()));
+    static LOCAL_CONTEXT: RefCell<RawContext> = const { RefCell::new(RawContext(ptr::null_mut())) };
 }
 
 #[derive(Debug)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -76,6 +76,7 @@ impl Device {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn fill_path(
         &self,
         path: &Path,
@@ -102,6 +103,7 @@ impl Device {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn stroke_path(
         &self,
         path: &Path,
@@ -183,6 +185,7 @@ impl Device {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn stroke_text(
         &self,
         text: &Text,

--- a/src/document.rs
+++ b/src/document.rs
@@ -66,7 +66,7 @@ impl Document {
         let c_magic = CString::new(magic)?;
         let len = bytes.len();
         let mut buf = Buffer::with_capacity(len);
-        buf.write(bytes)?;
+        buf.write_all(bytes)?;
         let inner = unsafe {
             ffi_try!(mupdf_open_document_from_bytes(
                 context(),
@@ -313,7 +313,7 @@ pub struct PageIter<'a> {
     doc: &'a Document,
 }
 
-impl<'a> Iterator for PageIter<'a> {
+impl Iterator for PageIter<'_> {
     type Item = Result<Page, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,11 @@ impl fmt::Display for MuPdfError {
 
 impl std::error::Error for MuPdfError {}
 
+/// # Safety
+///
+/// * `error` must point to a non-null, well-aligned initialized instance of `mupdf_error_t`.
+///
+/// * `(*error).message` must point to a null-terminated c-string.
 pub unsafe fn ffi_error(err: *mut mupdf_error_t) -> MuPdfError {
     use std::ffi::CStr;
 

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -253,7 +253,7 @@ impl PdfDocument {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         let len = bytes.len();
         let mut buf = Buffer::with_capacity(len);
-        buf.write(bytes)?;
+        buf.write_all(bytes)?;
         unsafe {
             let inner = ffi_try!(mupdf_pdf_open_document_from_bytes(context(), buf.inner));
             Ok(Self::from_raw(inner))
@@ -645,7 +645,7 @@ impl PdfDocument {
 
         let mut refs = refs.into_iter();
         let first = refs.next().unwrap();
-        let last = refs.last().unwrap_or_else(|| first.clone());
+        let last = refs.next_back().unwrap_or_else(|| first.clone());
 
         parent.dict_put("First", first)?;
         parent.dict_put("Last", last)?;

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -3,6 +3,7 @@ use std::ffi::{CStr, CString};
 use std::fmt;
 use std::io::{self, BufReader, Read, Write};
 use std::slice;
+use std::str::FromStr;
 
 use mupdf_sys::*;
 
@@ -317,6 +318,7 @@ impl PdfObject {
         Ok(Some(Self { inner }))
     }
 
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> Result<usize, Error> {
         let size = unsafe { ffi_try!(mupdf_pdf_array_len(context(), self.inner)) };
         Ok(size as usize)

--- a/src/stroke_state.rs
+++ b/src/stroke_state.rs
@@ -41,6 +41,7 @@ pub struct StrokeState {
 }
 
 impl StrokeState {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         start_cap: LineCap,
         dash_cap: LineCap,

--- a/src/text.rs
+++ b/src/text.rs
@@ -185,7 +185,7 @@ pub struct TextItemIter<'a> {
     total: usize,
 }
 
-impl<'a> Iterator for TextItemIter<'a> {
+impl Iterator for TextItemIter<'_> {
     type Item = TextItem;
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
Just ran `cargo clippy --tests` and applied the fixes, essentially. Also changed `cargo check` in CI to run clippy instead and error if it produces any warnings.