### PR TITLE
Overhaul many parts of unsafe semantics using zerocopy and NonNulls

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -101,6 +101,7 @@ jobs:
           cargo test -Zbuild-std --target x86_64-unknown-linux-gnu --features serde
         env:
           RUSTFLAGS: -Zsanitizer=address
+          LSAN_OPTIONS: report_objects=1
 
   valgrind:
     name: Valgrind

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ once_cell = "1.3.1"
 num_enum = "0.7.0"
 bitflags = "2.0.2"
 serde = { version = "1.0.201", features = ["derive"], optional = true }
+zerocopy = { version = "0.8.17", features = ["derive"] }
 
 [dependencies.font-kit]
 version = "0.14.1"

--- a/mupdf-sys/Cargo.toml
+++ b/mupdf-sys/Cargo.toml
@@ -93,3 +93,4 @@ pkg-config = "0.3"
 regex = "1.11"
 
 [dependencies]
+zerocopy = { version = "0.8.17", features = ["derive"] }

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -432,6 +432,23 @@ impl bindgen::callbacks::ParseCallbacks for Callback {
         }
         Some(output)
     }
+
+    fn add_derives(&self, info: &bindgen::callbacks::DeriveInfo<'_>) -> Vec<String> {
+        static ZEROCOPY_TYPES: [&str; 2] = ["fz_point", "fz_quad"];
+
+        if ZEROCOPY_TYPES.contains(&info.name) {
+            [
+                "zerocopy::FromBytes",
+                "zerocopy::IntoBytes",
+                "zerocopy::Immutable",
+            ]
+            .into_iter()
+            .map(ToString::to_string)
+            .collect()
+        } else {
+            vec![]
+        }
+    }
 }
 
 fn main() {

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -15,7 +15,7 @@ const SKIP_FONTS: [&str; 6] = [
 ];
 
 macro_rules! t {
-    ($e:expr) => {
+    ($e:expr ) => {
         match $e {
             Ok(n) => n,
             Err(e) => panic!("\n{} failed with {}\n", stringify!($e), e),
@@ -29,7 +29,8 @@ fn cp_r(dir: &Path, dest: &Path) {
         let path = entry.path();
         let dst = dest.join(path.file_name().expect("Failed to get filename of path"));
         if t!(fs::metadata(&path)).is_file() {
-            t!(fs::copy(path, dst));
+            fs::copy(&path, &dst)
+                .unwrap_or_else(|e| panic!("Couldn't fs::copy {path:?} to {dst:?}: {e}"));
         } else {
             t!(fs::create_dir_all(&dst));
             cp_r(&path, &dst);

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -31,8 +32,9 @@ fn cp_r(dir: &Path, dest: &Path, excluding_dir_names: &'static [&'static str]) {
         if t!(fs::metadata(&path)).is_file() {
             fs::copy(&path, &dst)
                 .unwrap_or_else(|e| panic!("Couldn't fs::copy {path:?} to {dst:?}: {e}"));
-        } else if dst
-            .to_str()
+        } else if path
+            .file_name()
+            .and_then(OsStr::to_str)
             .is_none_or(|dst| !excluding_dir_names.contains(&dst))
         {
             t!(fs::create_dir_all(&dst));

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -31,7 +31,10 @@ fn cp_r(dir: &Path, dest: &Path, excluding_dir_names: &'static [&'static str]) {
         if t!(fs::metadata(&path)).is_file() {
             fs::copy(&path, &dst)
                 .unwrap_or_else(|e| panic!("Couldn't fs::copy {path:?} to {dst:?}: {e}"));
-        } else if dst.to_str().is_none_or(|dst| !excluding_dir_names.contains(&dst)) {
+        } else if dst
+            .to_str()
+            .is_none_or(|dst| !excluding_dir_names.contains(&dst))
+        {
             t!(fs::create_dir_all(&dst));
             cp_r(&path, &dst, excluding_dir_names);
         }

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,6 +1,5 @@
 use std::{
     ffi::c_void,
-    num::NonZero,
     ops::{Deref, DerefMut},
     ptr::{self, NonNull},
     slice,
@@ -99,7 +98,7 @@ impl<T> IntoIterator for FzArray<T> {
 
 pub struct FzIter<T> {
     _kept_to_be_dropped: FzArray<T>,
-    next_item_and_end: Option<(NonNull<T>, NonZero<usize>)>,
+    next_item_and_end: Option<(NonNull<T>, usize)>,
 }
 
 impl<T> Iterator for FzIter<T> {

--- a/src/array.rs
+++ b/src/array.rs
@@ -14,8 +14,8 @@ use crate::context;
 /// allocator API is stable, as we need to be able to free this with `fz_free` instead of the
 /// system allocator.
 pub struct FzArray<T> {
-    pub(crate) ptr: NonNull<T>,
-    pub(crate) len: usize,
+    ptr: NonNull<T>,
+    len: usize,
 }
 
 impl<T> FzArray<T> {

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,0 +1,99 @@
+use std::{
+    ffi::c_void,
+    num::NonZero,
+    ops::{Deref, DerefMut},
+    ptr::{self, NonNull},
+    slice,
+};
+
+use mupdf_sys::fz_free;
+
+use crate::context;
+
+/// Essentially a [`Box`]`<[T], A>` with `fz_calloc` as the allocator. Necessary until the
+/// allocator API is stable, as we need to be able to free this with `fz_free` instead of the
+/// system allocator.
+pub struct FzArray<T> {
+    pub(crate) ptr: NonNull<T>,
+    pub(crate) len: usize,
+}
+
+impl<T> FzArray<T> {
+    /// # Safety
+    ///
+    /// * `ptr` must point to an array of at least `len` instances of `T`. There may be more than
+    ///   `len` instances, but only `len` will be accessed by this struct.
+    ///
+    /// * If `len > 0`, the memory it points to also must be allocated by `fz_calloc` inside a
+    ///   mupdf FFI call. `ptr` may be dangling or not well-aligned if `len == 0`
+    pub(crate) unsafe fn from_parts(ptr: NonNull<T>, len: usize) -> Self {
+        Self { ptr, len }
+    }
+}
+
+impl<T> Default for FzArray<T> {
+    fn default() -> Self {
+        Self {
+            ptr: NonNull::dangling(),
+            len: 0,
+        }
+    }
+}
+
+impl<T> Deref for FzArray<T> {
+    type Target = [T];
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: `self.ptr.as_ptr()` is not non-null (as it's a NonNull) and the creator has
+        // promised us that it does point to a valid slice. Also, if it does point to a
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+}
+
+impl<T> DerefMut for FzArray<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let ptr = unsafe { self.ptr.as_mut() };
+        unsafe { slice::from_raw_parts_mut(ptr, self.len) }
+    }
+}
+
+impl<T> Drop for FzArray<T> {
+    fn drop(&mut self) {
+        if self.len != 0 {
+            // SAFETY: Upheld by constructor - this must point to something allocated by fz_calloc
+            unsafe { fz_free(context(), self.ptr.as_ptr() as *mut c_void) };
+        }
+    }
+}
+
+impl<T> IntoIterator for FzArray<T> {
+    type IntoIter = FzIter<T>;
+    type Item = T;
+    fn into_iter(self) -> Self::IntoIter {
+        let next_item = self.ptr;
+        let end_addr = unsafe { self.ptr.add(self.len) }.addr();
+        FzIter {
+            _kept_to_be_dropped: self,
+            next_item,
+            end_addr,
+        }
+    }
+}
+
+pub struct FzIter<T> {
+    _kept_to_be_dropped: FzArray<T>,
+    next_item: NonNull<T>,
+    end_addr: NonZero<usize>,
+}
+
+impl<T> Iterator for FzIter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next_item.addr() == self.end_addr {
+            return None;
+        }
+
+        let ret = unsafe { ptr::read(self.next_item.as_ptr()) };
+        self.next_item = unsafe { self.next_item.add(1) };
+        Some(ret)
+    }
+}

--- a/src/array.rs
+++ b/src/array.rs
@@ -32,7 +32,10 @@ impl<T> FzArray<T> {
     /// * If `len > 0`, the memory it points to also must be allocated by `fz_calloc` inside a
     ///   mupdf FFI call. `ptr` may be dangling or not well-aligned if `len == 0`
     pub(crate) unsafe fn from_parts(ptr: NonNull<T>, len: usize) -> Self {
-        Self { ptr: Some(ptr), len }
+        Self {
+            ptr: Some(ptr),
+            len,
+        }
     }
 
     /// # Safety
@@ -51,7 +54,7 @@ impl<T> Deref for FzArray<T> {
             // SAFETY: `self.ptr.as_ptr()` is not non-null (as it's a NonNull) and the creator has
             // promised us that it does point to a valid slice. Also, if it does point to a
             Some(ptr) => unsafe { slice::from_raw_parts(ptr.as_ptr(), self.len) },
-            None => &[]
+            None => &[],
         }
     }
 }
@@ -62,8 +65,8 @@ impl<T> DerefMut for FzArray<T> {
             Some(ptr) => {
                 let ptr = unsafe { ptr.as_mut() };
                 unsafe { slice::from_raw_parts_mut(ptr, self.len) }
-            },
-            None => &mut []
+            }
+            None => &mut [],
         }
     }
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -16,10 +16,15 @@ use crate::context;
 // pointer, allocated from `fz_calloc`, but says the length of items behind it is 0, you still have
 // to `fz_free` that pointer. It's probably lying about the length behind it being 0 - it was
 // probably part of an allocation bigger than 0, but of which 0 bytes were actually written to.
-#[derive(Default)]
 pub struct FzArray<T> {
     ptr: Option<NonNull<T>>,
     len: usize,
+}
+
+impl<T> Default for FzArray<T> {
+    fn default() -> Self {
+        Self { ptr: None, len: 0 }
+    }
 }
 
 impl<T> FzArray<T> {

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,6 +1,6 @@
 use std::ffi::{CStr, CString};
 use std::io::Write;
-use std::ptr::{self, NonNull};
+use std::ptr;
 
 use mupdf_sys::*;
 
@@ -215,8 +215,8 @@ impl Document {
 
     pub fn load_page(&self, page_no: i32) -> Result<Page, Error> {
         let fz_page = unsafe { ffi_try!(mupdf_load_page(context(), self.inner, page_no)) };
-        let inner = NonNull::new(fz_page).ok_or(Error::UnexpectedNullPtr)?;
-        Ok(unsafe { Page::from_raw(inner) })
+        // SAFETY: We're trusting the FFI layer here to provide a valid pointer
+        unsafe { Page::from_raw(fz_page) }
     }
 
     pub fn pages(&self) -> Result<PageIter, Error> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,16 +51,16 @@ pub unsafe fn ffi_error(ptr: NonNull<mupdf_error_t>) -> MuPdfError {
 
 macro_rules! ffi_try {
     ($func:ident($($arg:expr),+)) => ({
-            use std::ptr;
-            let mut err = ptr::null_mut();
-            // SAFETY: Upheld by the caller of the macro
-            let res = $func($($arg),+, &mut err);
-            if let Some(err) = ::core::ptr::NonNull::new(err) {
-                // SAFETY: We're trusting the FFI call to provide us with a valid ptr if it is not
-                // null.
-                return Err($crate::ffi_error(err).into());
-            }
-            res
+        use std::ptr;
+        let mut err = ptr::null_mut();
+        // SAFETY: Upheld by the caller of the macro
+        let res = $func($($arg),+, &mut err);
+        if let Some(err) = ::core::ptr::NonNull::new(err) {
+            // SAFETY: We're trusting the FFI call to provide us with a valid ptr if it is not
+            // null.
+            return Err($crate::ffi_error(err).into());
+        }
+        res
     });
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,7 +54,7 @@ macro_rules! ffi_try {
         use std::ptr;
         let mut err = ptr::null_mut();
         // SAFETY: Upheld by the caller of the macro
-        let res = $func($($arg),+, &mut err);
+        let res = $func($($arg),+, (&mut err) as *mut *mut ::mupdf_sys::mupdf_error_t);
         if let Some(err) = ::core::ptr::NonNull::new(err) {
             // SAFETY: We're trusting the FFI call to provide us with a valid ptr if it is not
             // null.

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,12 +26,12 @@ impl std::error::Error for MuPdfError {}
 
 /// # Safety
 ///
-/// * `err` must point to a valid, well-aligned instance of [`mupdf_error_t`].
+/// * `ptr` must point to a valid, well-aligned instance of [`mupdf_error_t`].
 ///
-/// * The pointers stored in this `mupdf_error_t` must also be non-null, well-aligned, and point to
-///   valid instances of what they claim to represent.
+/// * The pointers stored in this [`mupdf_error_t`] must also be non-null, well-aligned, and point
+///   to valid instances of what they claim to represent.
 ///
-/// * The `message` ptr in `mupdf_error_t` must point to a null-terminated c-string.
+/// * The [`field@mupdf_error_t::message`] ptr in `ptr` must point to a null-terminated c-string
 pub unsafe fn ffi_error(ptr: NonNull<mupdf_error_t>) -> MuPdfError {
     use std::ffi::CStr;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub mod text;
 /// Text page
 pub mod text_page;
 
-/// Contains a special [`array::Array`] type which wraps an allocation from the `fz_calloc`
+/// Contains a special [`array::FzArray`] type which wraps an allocation from the `fz_calloc`
 /// allocation fn that mupdf uses internally. Ideally this will eventually be replaced with
 /// `Box<[_], A>` once the allocator api is stabilized.
 pub mod array;

--- a/src/page.rs
+++ b/src/page.rs
@@ -4,6 +4,7 @@ use std::ptr::{self, NonNull};
 
 use mupdf_sys::*;
 
+use crate::array::FzArray;
 use crate::{
     context, rust_vec_from_ffi_ptr, unsafe_impl_ffi_wrapper, Buffer, Colorspace, Cookie, Device,
     DisplayList, Error, FFIWrapper, Link, Matrix, Pixmap, Quad, Rect, Separations, TextPage,
@@ -311,7 +312,7 @@ impl Page {
         }
     }
 
-    pub fn search(&self, needle: &str, hit_max: u32) -> Result<Vec<Quad>, Error> {
+    pub fn search(&self, needle: &str, hit_max: u32) -> Result<FzArray<Quad>, Error> {
         let c_needle = CString::new(needle)?;
         let hit_max = if hit_max < 1 { 16 } else { hit_max };
         let mut hit_count = 0;
@@ -326,7 +327,7 @@ impl Page {
         };
 
         if hit_count == 0 {
-            return Ok(Vec::new());
+            return Ok(FzArray::default());
         }
 
         unsafe { rust_vec_from_ffi_ptr(quads, hit_count) }
@@ -430,7 +431,7 @@ pub struct StextPage {
 
 #[cfg(test)]
 mod test {
-    use crate::{Document, Matrix};
+    use crate::{array::FzArray, Document, Matrix};
 
     #[test]
     #[cfg(feature = "serde")]
@@ -552,7 +553,7 @@ mod test {
         let hits = page0.search("Dummy", 1).unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(
-            hits,
+            &*hits,
             [Quad {
                 ul: Point {
                     x: 56.8,

--- a/src/page.rs
+++ b/src/page.rs
@@ -1,4 +1,4 @@
-use std::ffi::{CStr, CString};
+use std::ffi::{c_int, CStr, CString};
 use std::io::Read;
 use std::ptr::{self, NonNull};
 
@@ -319,16 +319,12 @@ impl Page {
         let quads = unsafe {
             ffi_try!(mupdf_search_page(
                 context(),
-                self.as_ptr() as *mut _,
+                self.as_ptr() as *mut fz_page,
                 c_needle.as_ptr(),
-                hit_max as _,
+                hit_max as c_int,
                 &mut hit_count
             ))
         };
-
-        if hit_count == 0 {
-            return Ok(FzArray::default());
-        }
 
         unsafe { rust_vec_from_ffi_ptr(quads, hit_count) }
     }

--- a/src/page.rs
+++ b/src/page.rs
@@ -431,7 +431,7 @@ pub struct StextPage {
 
 #[cfg(test)]
 mod test {
-    use crate::{array::FzArray, Document, Matrix};
+    use crate::{Document, Matrix};
 
     #[test]
     #[cfg(feature = "serde")]

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -1,4 +1,8 @@
-use std::{mem::ManuallyDrop, ops::{Deref, DerefMut}, ptr::NonNull};
+use std::{
+    mem::ManuallyDrop,
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+};
 
 use mupdf_sys::*;
 

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -29,11 +29,15 @@ pub struct PdfPage {
 unsafe_impl_ffi_wrapper!(PdfPage, pdf_page, pdf_drop_page);
 
 impl PdfPage {
+    /// # Safety
+    ///
+    /// * `ptr` must point to a valid, well-aligned instance of [`pdf_page`]
     pub(crate) unsafe fn from_raw(ptr: NonNull<pdf_page>) -> Self {
         Self {
             inner: ptr,
             // This cast is safe because the first member of the `pdf_page` struct is a `fz_page`
-            page: ManuallyDrop::new(Page::from_raw(ptr.cast())),
+            // SAFETY: Upheld by caller
+            page: ManuallyDrop::new(unsafe { Page::from_non_null(ptr.cast()) }),
         }
     }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -3,9 +3,12 @@ use mupdf_sys::{fz_point, fz_transform_point};
 use crate::{impl_ffi_traits, Matrix};
 
 /// A point in a two-dimensional space.
+/// This is marked `repr(c)` to ensure compatibility with the FFI analogue, [`fz_point`], so that
+/// [`zerocopy::transmute`]ing between the two always preseves information correctly
 #[derive(
     Debug, Clone, Copy, PartialEq, zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::Immutable,
 )]
+#[repr(C)]
 pub struct Point {
     pub x: f32,
     pub y: f32,

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,9 +1,11 @@
 use mupdf_sys::{fz_point, fz_transform_point};
 
-use crate::Matrix;
+use crate::{impl_ffi_traits, Matrix};
 
 /// A point in a two-dimensional space.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::Immutable,
+)]
 pub struct Point {
     pub x: f32,
     pub y: f32,
@@ -31,18 +33,6 @@ impl Point {
     }
 }
 
-impl From<fz_point> for Point {
-    fn from(p: fz_point) -> Self {
-        Self { x: p.x, y: p.y }
-    }
-}
-
-impl From<Point> for fz_point {
-    fn from(p: Point) -> Self {
-        fz_point { x: p.x, y: p.y }
-    }
-}
-
 impl From<(f32, f32)> for Point {
     fn from(p: (f32, f32)) -> Self {
         Self { x: p.0, y: p.1 }
@@ -57,3 +47,5 @@ impl From<(i32, i32)> for Point {
         }
     }
 }
+
+impl_ffi_traits!(Point, fz_point);

--- a/src/quad.rs
+++ b/src/quad.rs
@@ -1,9 +1,11 @@
-use mupdf_sys::*;
+use mupdf_sys::fz_quad;
 
-use crate::Point;
+use crate::{impl_ffi_traits, Point};
 
 /// A representation for a region defined by 4 points
-#[derive(Debug, Clone, PartialEq)]
+#[derive(
+    Debug, Clone, PartialEq, zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::Immutable,
+)]
 pub struct Quad {
     pub ul: Point,
     pub ur: Point,
@@ -17,13 +19,4 @@ impl Quad {
     }
 }
 
-impl From<fz_quad> for Quad {
-    fn from(quad: fz_quad) -> Self {
-        Self {
-            ul: quad.ul.into(),
-            ur: quad.ur.into(),
-            ll: quad.ll.into(),
-            lr: quad.lr.into(),
-        }
-    }
-}
+impl_ffi_traits!(Quad, fz_quad);

--- a/src/quad.rs
+++ b/src/quad.rs
@@ -3,9 +3,12 @@ use mupdf_sys::fz_quad;
 use crate::{impl_ffi_traits, Point};
 
 /// A representation for a region defined by 4 points
+/// This is marked `repr(c)` to ensure compatibility with the FFI analogue, [`fz_quad`], so that
+/// [`zerocopy::transmute`]ing between the two always preseves information correctly
 #[derive(
     Debug, Clone, PartialEq, zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::Immutable,
 )]
+#[repr(C)]
 pub struct Quad {
     pub ul: Point,
     pub ur: Point,

--- a/src/text_page.rs
+++ b/src/text_page.rs
@@ -8,9 +8,9 @@ use bitflags::bitflags;
 use mupdf_sys::*;
 use num_enum::TryFromPrimitive;
 
-use crate::rust_vec_from_ffi_ptr;
 use crate::{
-    context, rust_slice_to_ffi_ptr, Buffer, Error, Image, Matrix, Point, Quad, Rect, WriteMode,
+    array::FzArray, context, rust_slice_to_ffi_ptr, rust_vec_from_ffi_ptr, Buffer, Error, Image,
+    Matrix, Point, Quad, Rect, WriteMode,
 };
 
 bitflags! {
@@ -53,7 +53,7 @@ impl TextPage {
         }
     }
 
-    pub fn search(&self, needle: &str, hit_max: u32) -> Result<Vec<Quad>, Error> {
+    pub fn search(&self, needle: &str, hit_max: u32) -> Result<FzArray<Quad>, Error> {
         let c_needle = CString::new(needle)?;
         let hit_max = if hit_max < 1 { 16 } else { hit_max };
         let mut hit_count = 0;
@@ -277,7 +277,7 @@ mod test {
         let hits = text_page.search("Dummy", 1).unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(
-            hits,
+            &*hits,
             [Quad {
                 ul: Point {
                     x: 56.8,


### PR DESCRIPTION
This is a kinda gnarly PR, and I honestly don't expect it to go through 100% as-is since it's quite opinionated.

The main things it does are:
1. Introduces `zerocopy` as a dependency so that we can use their `IntoBytes` & `FromBytes` traits along with the `transmute!` macro to make some conversions zero-cost.
2. Introduces two more traits, `FFIAnalogue` and `FFIWrapper` to implement for rust types which mirror or wrap FFI types (e.g. `FFIAnalogue` for when something has the same fields as the FFI type and `FFIWrapper` when it just contains a pointer to the `FFI` type). These, along with macros to implement them, allow us deduplicate a lot of code (e.g. `Drop` impls, get rid of a lot of `unsafe { *self.inner }.whatever` and just use `self.as_ref().whatever` instead)
3. Change a lot of `*mut _` to `NonNull<_>` where it would be unsound for those pointers to be null. Technically this is no longer a zero-cost abstraction, but it brings us the benefit of niche optimization, which is something that I, at least, would benefit from in my uses of `mupdf`.
4. Implements `FFIAnalogue` and `FFIWrapper` for a few structs, but not all. I didn't want to do all of them in this PR as that would be changing an immense amount of code, and that might not be worth my time if it's not the direction you'd want to go with this.

A few other minor things:
1. I changed the `impl From<Page> for PdfPage` to be a `TryFrom` impl instead since we need to convert a `fz_page` to a `pdf_page` through an FFI interface which could give us back a null pointer (and we need to handle the potential for that null pointer)
2. I made `PdfPage` hold its inner `Page` as a `ManuallyDrop` instead of just avoiding implementing `Drop` for `PdfPage`. At time of writing, this shouldn't actually change any functionality or fix anything, but it should future-proof it. Previously, we were letting `Page` get dropped, which would call `fz_drop_page` on its inner pointer. That was fine because that's exactly what `pdf_drop_page` did as well, so dropping `PdfPage` with `pdf_page_drop` doesn't change anything. However, if, at some point, more functionality is added to `pdf_page_drop` outside of `fz_drop_page`, this change will make sure these bindings don't leak memory.
3. Adds bindings for the `fz_highlight_selection` function to demonstrate the usage of `rust_slice_to_ffi_ptr` (and also because I would like to use this API :))

Let me know what you think. I'm very happy to discuss all of this design; I'm not stuck to it. I just would like to use the type system more to enable us to do more zero-cost sound transformations and function calls.