### PR TITLE
Make serde optional and move serde_json into dev-dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Setup msbuild
         if: matrix.os == 'windows-2019'
         uses: microsoft/setup-msbuild@v1.3.1
-      - run: cargo test
+      - run: cargo test --features serde
         timeout-minutes: 20
         if: matrix.os == 'windows-2019'
         env:
           LIBCLANG_PATH: "C:\\Program Files\\LLVM\\bin"
-      - run: cargo test
+      - run: cargo test --features serde
         if: matrix.os != 'windows-2019'
       - name: Test package mupdf-sys
         if: matrix.os == 'ubuntu-latest'
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 500
       - run: |
           rustc --version --verbose
-          cargo test
+          cargo test --features serde
 
   asan:
     name: Address Sanitizer
@@ -96,9 +96,9 @@ jobs:
         with:
           components: rust-src
       - run: sudo apt-get -y install libfontconfig1-dev
-      - name: cargo test
+      - name: cargo test --features serde
         run: |
-          cargo test -Zbuild-std --target x86_64-unknown-linux-gnu
+          cargo test -Zbuild-std --target x86_64-unknown-linux-gnu --features serde
         env:
           RUSTFLAGS: -Zsanitizer=address
 
@@ -113,7 +113,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@valgrind
       - run: sudo apt-get -y install libfontconfig1-dev
-      - run: cargo test
+      - run: cargo test --features serde
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "valgrind --error-exitcode=1 --track-origins=yes"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 500
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt-get -y install libfontconfig1-dev
-      - run: cargo clippy --tests -- -D warnings
+      - run: cargo clippy --tests --features serde -- -D warnings
 
   test:
     name: Test Suite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,14 +41,16 @@ html = ["mupdf-sys/html"]
 epub = ["mupdf-sys/epub"]
 all-fonts = ["mupdf-sys/all-fonts"]
 system-fonts = ["font-kit"]
+# Derive Serialize/Deserialize for a few structs
+serde = ["dep:serde"]
 
 [dependencies]
 mupdf-sys = { version = "0.4.4", path = "mupdf-sys" }
 once_cell = "1.3.1"
 num_enum = "0.7.0"
 bitflags = "2.0.2"
-serde = { version = "1.0.201", features = ["derive"] }
-serde_json = "1.0.117"
+serde = { version = "1.0.201", features = ["derive"], optional = true }
+zerocopy = { version = "0.8.17", features = ["derive"] }
 
 [dependencies.font-kit]
 version = "0.14.1"
@@ -62,3 +64,9 @@ members = [
 
 [dev-dependencies]
 crossbeam-utils = "0.8.1"
+serde_json = "1.0.117"
+
+[[example]]
+name = "extract_stext"
+path = "examples/extract_stext.rs"
+required-features = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ once_cell = "1.3.1"
 num_enum = "0.7.0"
 bitflags = "2.0.2"
 serde = { version = "1.0.201", features = ["derive"], optional = true }
-zerocopy = { version = "0.8.17", features = ["derive"] }
 
 [dependencies.font-kit]
 version = "0.14.1"

--- a/src/page.rs
+++ b/src/page.rs
@@ -426,7 +426,6 @@ pub struct StextPage {
 
 #[cfg(test)]
 mod test {
-    use crate::page::StextPage;
     use crate::{Document, Matrix};
 
     #[test]
@@ -441,7 +440,7 @@ mod test {
         let page = doc.load_page(0).unwrap();
         match page.stext_page_as_json_from_page(1.0) {
             Ok(stext_json) => {
-                let stext_page: serde_json::Result<StextPage> =
+                let stext_page: serde_json::Result<crate::page::StextPage> =
                     serde_json::from_str(stext_json.as_str());
                 match stext_page {
                     Ok(res) => {

--- a/src/page.rs
+++ b/src/page.rs
@@ -3,8 +3,6 @@ use std::io::Read;
 use std::ptr;
 use std::slice;
 
-use serde::{Deserialize, Serialize};
-
 use mupdf_sys::*;
 
 use crate::{
@@ -381,7 +379,8 @@ impl Iterator for LinkIter {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Font {
     pub name: String,
     pub family: String,
@@ -390,7 +389,8 @@ pub struct Font {
     pub size: u32,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct BBox {
     pub x: u32,
     pub y: u32,
@@ -398,7 +398,8 @@ pub struct BBox {
     pub h: u32,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Line {
     pub wmode: u32,
     pub bbox: BBox,
@@ -408,7 +409,8 @@ pub struct Line {
     pub text: String,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Block {
     pub r#type: String,
     pub bbox: BBox,
@@ -416,7 +418,8 @@ pub struct Block {
 }
 
 // StructuredText
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct StextPage {
     pub blocks: Vec<Block>,
 }
@@ -427,6 +430,7 @@ mod test {
     use crate::{Document, Matrix};
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_get_stext_page_as_json() {
         let path_to_doc = std::env::current_dir()
             .unwrap()


### PR DESCRIPTION
`serde`'s functionality isn't needed to make this library work and, imo, should be moved to sit behind a feature flag so that those who don't need it don't have to wait for the `derive(Serialize, Deserialize)` to run.

Also, `serde_json` isn't used at all in the main library outside of tests and examples, so I moved it `dev_dependencies`