### PR TITLE
Don't short-circuit in ffi_try

### DIFF
--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -15,8 +15,8 @@ pub struct Bitmap {
 
 impl Bitmap {
     pub fn from_pixmap(pixmap: &Pixmap) -> Result<Self, Error> {
-        let inner = unsafe { ffi_try!(mupdf_new_bitmap_from_pixmap(context(), pixmap.inner)) };
-        Ok(Self { inner })
+        unsafe { ffi_try!(mupdf_new_bitmap_from_pixmap(context(), pixmap.inner)) }
+            .map(|inner| Self { inner })
     }
 
     /// Width of the region in pixels.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -20,8 +20,8 @@ impl FromStr for Buffer {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let c_str = CString::new(s)?;
-        let inner = unsafe { ffi_try!(mupdf_buffer_from_str(context(), c_str.as_ptr())) };
-        Ok(Self { inner, offset: 0 })
+        unsafe { ffi_try!(mupdf_buffer_from_str(context(), c_str.as_ptr())) }
+            .map(|inner| Self { inner, offset: 0 })
     }
 }
 
@@ -39,8 +39,8 @@ impl Buffer {
 
     pub fn from_base64(str: &str) -> Result<Self, Error> {
         let c_str = CString::new(str)?;
-        let inner = unsafe { ffi_try!(mupdf_buffer_from_base64(context(), c_str.as_ptr())) };
-        Ok(Self { inner, offset: 0 })
+        unsafe { ffi_try!(mupdf_buffer_from_base64(context(), c_str.as_ptr())) }
+            .map(|inner| Self { inner, offset: 0 })
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
@@ -78,7 +78,7 @@ impl Buffer {
                 buf.as_mut_ptr(),
                 len
             ))
-        };
+        }?;
         self.offset += read_len as usize;
         Ok(read_len)
     }
@@ -92,7 +92,7 @@ impl Buffer {
                 buf.as_ptr(),
                 len
             ))
-        };
+        }?;
         Ok(len)
     }
 }

--- a/src/colorspace.rs
+++ b/src/colorspace.rs
@@ -109,7 +109,7 @@ impl Colorspace {
                 out.as_mut_ptr(),
                 via,
                 params.into()
-            ));
+            ))?;
             out.set_len(to_n);
             Ok(out)
         }
@@ -138,7 +138,7 @@ impl Colorspace {
                 out.as_mut_ptr(),
                 via,
                 params.into()
-            ));
+            ))?;
             Ok(n)
         }
     }

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -13,8 +13,7 @@ pub struct Cookie {
 
 impl Cookie {
     pub fn new() -> Result<Self, Error> {
-        let inner = unsafe { ffi_try!(mupdf_new_cookie(context())) };
-        Ok(Self { inner })
+        unsafe { ffi_try!(mupdf_new_cookie(context())) }.map(|inner| Self { inner })
     }
 
     /// Abort rendering

--- a/src/device.rs
+++ b/src/device.rs
@@ -187,11 +187,12 @@ impl Device {
     }
 
     pub fn from_pixmap_with_clip(pixmap: &Pixmap, clip: IRect) -> Result<Self, Error> {
-        let dev = unsafe { ffi_try!(mupdf_new_draw_device(context(), pixmap.inner, clip.into())) };
-        Ok(Self {
-            dev,
-            list: ptr::null_mut(),
-        })
+        unsafe { ffi_try!(mupdf_new_draw_device(context(), pixmap.inner, clip.into())) }.map(
+            |dev| Self {
+                dev,
+                list: ptr::null_mut(),
+            },
+        )
     }
 
     pub fn from_pixmap(pixmap: &Pixmap) -> Result<Self, Error> {
@@ -199,22 +200,21 @@ impl Device {
     }
 
     pub fn from_display_list(list: &DisplayList) -> Result<Self, Error> {
-        let dev = unsafe { ffi_try!(mupdf_new_display_list_device(context(), list.inner)) };
-        Ok(Self {
+        unsafe { ffi_try!(mupdf_new_display_list_device(context(), list.inner)) }.map(|dev| Self {
             dev,
             list: list.inner,
         })
     }
 
     pub fn from_text_page(page: &TextPage, opts: TextPageOptions) -> Result<Self, Error> {
-        let dev = unsafe {
+        unsafe {
             ffi_try!(mupdf_new_stext_device(
                 context(),
                 page.inner,
                 opts.bits() as _
             ))
-        };
-        Ok(Self {
+        }
+        .map(|dev| Self {
             dev,
             list: ptr::null_mut(),
         })
@@ -242,9 +242,8 @@ impl Device {
                 color.as_ptr(),
                 alpha,
                 cp.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -269,9 +268,8 @@ impl Device {
                 color.as_ptr(),
                 alpha,
                 cp.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn clip_path(&self, path: &Path, even_odd: bool, ctm: &Matrix) -> Result<(), Error> {
@@ -282,9 +280,8 @@ impl Device {
                 path.inner,
                 even_odd,
                 ctm.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn clip_stroke_path(
@@ -300,9 +297,8 @@ impl Device {
                 path.inner,
                 stroke.inner,
                 ctm.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn fill_text(
@@ -324,9 +320,8 @@ impl Device {
                 color.as_ptr(),
                 alpha,
                 cp.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -351,14 +346,12 @@ impl Device {
                 color.as_ptr(),
                 alpha,
                 cp.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn clip_text(&self, text: &Text, ctm: &Matrix) -> Result<(), Error> {
         unsafe { ffi_try!(mupdf_clip_text(context(), self.dev, text.inner, ctm.into())) }
-        Ok(())
     }
 
     pub fn clip_stroke_text(
@@ -374,9 +367,8 @@ impl Device {
                 text.inner,
                 stroke.inner,
                 ctm.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn ignore_text(&self, text: &Text, ctm: &Matrix) -> Result<(), Error> {
@@ -386,9 +378,8 @@ impl Device {
                 self.dev,
                 text.inner,
                 ctm.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn fill_shade(
@@ -406,9 +397,8 @@ impl Device {
                 ctm.into(),
                 alpha,
                 cp.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn fill_image(
@@ -426,9 +416,8 @@ impl Device {
                 ctm.into(),
                 alpha,
                 cp.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn fill_image_mask(
@@ -450,9 +439,8 @@ impl Device {
                 color.as_ptr(),
                 alpha,
                 cp.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn clip_image_mask(&self, image: &Image, ctm: &Matrix) -> Result<(), Error> {
@@ -462,16 +450,12 @@ impl Device {
                 self.dev,
                 image.inner,
                 ctm.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn pop_clip(&self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_pop_clip(context(), self.dev));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_pop_clip(context(), self.dev)) }
     }
 
     pub fn begin_mask(
@@ -491,9 +475,8 @@ impl Device {
                 cs.inner,
                 bc.as_ptr(),
                 cp.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn end_mask(&self, f: Option<&Function>) -> Result<(), Error> {
@@ -502,9 +485,8 @@ impl Device {
                 context(),
                 self.dev,
                 f.map_or(ptr::null_mut(), |f| f.inner)
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn begin_group(
@@ -526,16 +508,12 @@ impl Device {
                 knockout,
                 blend_mode as _,
                 alpha
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn end_group(&self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_end_group(context(), self.dev));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_end_group(context(), self.dev)) }
     }
 
     pub fn begin_tile(
@@ -547,7 +525,7 @@ impl Device {
         ctm: &Matrix,
         id: Option<NonZero<i32>>,
     ) -> Result<Option<NonZero<i32>>, Error> {
-        let i = unsafe {
+        unsafe {
             ffi_try!(mupdf_begin_tile(
                 context(),
                 self.dev,
@@ -558,30 +536,21 @@ impl Device {
                 ctm.into(),
                 id.map_or(0, NonZero::get)
             ))
-        };
-        Ok(NonZero::new(i))
+        }
+        .map(NonZero::new)
     }
 
     pub fn end_tile(&self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_end_tile(context(), self.dev));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_end_tile(context(), self.dev)) }
     }
 
     pub fn begin_layer(&self, name: &str) -> Result<(), Error> {
         let c_name = CString::new(name)?;
-        unsafe {
-            ffi_try!(mupdf_begin_layer(context(), self.dev, c_name.as_ptr()));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_begin_layer(context(), self.dev, c_name.as_ptr())) }
     }
 
     pub fn end_layer(&self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_end_layer(context(), self.dev));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_end_layer(context(), self.dev)) }
     }
 
     pub fn begin_structure(&self, standard: Structure, raw: &str, idx: i32) -> Result<(), Error> {
@@ -593,16 +562,12 @@ impl Device {
                 standard as _,
                 c_raw.as_ptr(),
                 idx as _
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn end_structure(&self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_end_structure(context(), self.dev));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_end_structure(context(), self.dev)) }
     }
 
     pub fn begin_metatext(&self, meta: Metatext, text: &str) -> Result<(), Error> {
@@ -613,16 +578,12 @@ impl Device {
                 self.dev,
                 meta as _,
                 c_text.as_ptr()
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn end_metatext(&self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_end_metatext(context(), self.dev));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_end_metatext(context(), self.dev)) }
     }
 }
 

--- a/src/device/native.rs
+++ b/src/device/native.rs
@@ -363,7 +363,7 @@ impl<T: NativeDevice + ?Sized> NativeDevice for &mut T {
 pub(crate) fn create<D: NativeDevice>(device: D) -> Result<Device, Error> {
     let ret = unsafe {
         let c_device: *mut CDevice<D> =
-            ffi_try!(mupdf_new_derived_device(context(), c"RustDevice"));
+            ffi_try!(mupdf_new_derived_device(context(), c"RustDevice"))?;
         ptr::write(&raw mut (*c_device).rust_device, device);
 
         (*c_device).base.close_device = Some(close_device::<D>);

--- a/src/document_writer.rs
+++ b/src/document_writer.rs
@@ -15,38 +15,35 @@ impl DocumentWriter {
         let c_filename = CString::new(filename)?;
         let c_format = CString::new(format)?;
         let c_options = CString::new(options)?;
-        let inner = unsafe {
+        unsafe {
             ffi_try!(mupdf_new_document_writer(
                 context(),
                 c_filename.as_ptr(),
                 c_format.as_ptr(),
                 c_options.as_ptr()
             ))
-        };
-        Ok(Self { inner })
+        }
+        .map(|inner| Self { inner })
     }
 
     pub fn begin_page(&mut self, media_box: Rect) -> Result<Device, Error> {
         unsafe {
-            let dev = ffi_try!(mupdf_document_writer_begin_page(
+            ffi_try!(mupdf_document_writer_begin_page(
                 context(),
                 self.inner,
                 media_box.into()
-            ));
-            Ok(Device::from_raw(dev, ptr::null_mut()))
+            ))
         }
+        .map(|dev| unsafe { Device::from_raw(dev, ptr::null_mut()) })
     }
 
     pub fn end_page(&mut self, mut device: Device) -> Result<(), Error> {
-        unsafe {
-            // End page closes and drops the device. Prevent dropping it twice
-            // by setting the inner device to null here. Order is important here,
-            // because the ffi_try! on the end page can return early while already
-            // having dropped the device, causing a double-free anyway.
-            device.dev = ptr::null_mut();
-            ffi_try!(mupdf_document_writer_end_page(context(), self.inner));
-        }
-        Ok(())
+        // End page closes and drops the device. Prevent dropping it twice
+        // by setting the inner device to null here. Order is important here,
+        // because the ffi_try! on the end page can return early while already
+        // having dropped the device, causing a double-free anyway.
+        device.dev = ptr::null_mut();
+        unsafe { ffi_try!(mupdf_document_writer_end_page(context(), self.inner)) }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,12 +55,12 @@ macro_rules! ffi_try {
         let mut err = ptr::null_mut();
         // SAFETY: Upheld by the caller of the macro
         let res = $func($($arg),+, (&mut err) as *mut *mut ::mupdf_sys::mupdf_error_t);
-        if let Some(err) = ::core::ptr::NonNull::new(err) {
-            // SAFETY: We're trusting the FFI call to provide us with a valid ptr if it is not
-            // null.
-            return Err($crate::ffi_error(err).into());
-        }
-        res
+        ::core::ptr::NonNull::new(err)
+            .map_or(Ok(res), |err| Err(
+                // SAFETY: We're trusting the FFI call to provide us with a valid ptr if it is not
+                // null.
+                $crate::Error::MuPdf($crate::ffi_error(err))
+            ))
     });
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -15,26 +15,26 @@ impl Image {
     }
 
     pub fn from_pixmap(pixmap: &Pixmap) -> Result<Self, Error> {
-        let inner = unsafe { ffi_try!(mupdf_new_image_from_pixmap(context(), pixmap.inner)) };
-        Ok(Self { inner })
+        unsafe { ffi_try!(mupdf_new_image_from_pixmap(context(), pixmap.inner)) }
+            .map(|inner| Self { inner })
     }
 
     pub fn from_file(filename: &str) -> Result<Self, Error> {
         let c_filename = CString::new(filename)?;
-        let inner = unsafe { ffi_try!(mupdf_new_image_from_file(context(), c_filename.as_ptr())) };
-        Ok(Self { inner })
+        unsafe { ffi_try!(mupdf_new_image_from_file(context(), c_filename.as_ptr())) }
+            .map(|inner| Self { inner })
     }
 
     pub fn from_display_list(list: &DisplayList, width: f32, height: f32) -> Result<Self, Error> {
-        let inner = unsafe {
+        unsafe {
             ffi_try!(mupdf_new_image_from_display_list(
                 context(),
                 list.inner,
                 width,
                 height
             ))
-        };
-        Ok(Self { inner })
+        }
+        .map(|inner| Self { inner })
     }
 
     pub fn width(&self) -> u32 {
@@ -75,10 +75,8 @@ impl Image {
     }
 
     pub fn to_pixmap(&self) -> Result<Pixmap, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_get_pixmap_from_image(context(), self.inner));
-            Ok(Pixmap::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_get_pixmap_from_image(context(), self.inner)) }
+            .map(|inner| unsafe { Pixmap::from_raw(inner) })
     }
 
     pub fn interpolate(&self) -> bool {

--- a/src/page.rs
+++ b/src/page.rs
@@ -43,8 +43,7 @@ impl Page {
     }
 
     pub fn bounds(&self) -> Result<Rect, Error> {
-        let rect = unsafe { ffi_try!(mupdf_bound_page(context(), self.as_ptr() as *mut _)) };
-        Ok(rect.into())
+        unsafe { ffi_try!(mupdf_bound_page(context(), self.as_ptr() as *mut _)) }.map(Into::into)
     }
 
     pub fn to_pixmap(
@@ -55,43 +54,43 @@ impl Page {
         show_extras: bool,
     ) -> Result<Pixmap, Error> {
         unsafe {
-            let inner = ffi_try!(mupdf_page_to_pixmap(
+            ffi_try!(mupdf_page_to_pixmap(
                 context(),
                 self.as_ptr() as *mut _,
                 ctm.into(),
                 cs.inner,
                 alpha,
                 show_extras
-            ));
-            Ok(Pixmap::from_raw(inner))
+            ))
         }
+        .map(|inner| unsafe { Pixmap::from_raw(inner) })
     }
 
     pub fn to_svg(&self, ctm: &Matrix) -> Result<String, Error> {
-        let mut buf = unsafe {
-            let inner = ffi_try!(mupdf_page_to_svg(
+        let inner = unsafe {
+            ffi_try!(mupdf_page_to_svg(
                 context(),
                 self.as_ptr() as *mut _,
                 ctm.into(),
                 ptr::null_mut()
-            ));
-            Buffer::from_raw(inner)
-        };
+            ))
+        }?;
+        let mut buf = unsafe { Buffer::from_raw(inner) };
         let mut svg = String::new();
         buf.read_to_string(&mut svg)?;
         Ok(svg)
     }
 
     pub fn to_svg_with_cookie(&self, ctm: &Matrix, cookie: &Cookie) -> Result<String, Error> {
-        let mut buf = unsafe {
-            let inner = ffi_try!(mupdf_page_to_svg(
+        let inner = unsafe {
+            ffi_try!(mupdf_page_to_svg(
                 context(),
                 self.as_ptr() as *mut _,
                 ctm.into(),
                 cookie.inner
-            ));
-            Buffer::from_raw(inner)
-        };
+            ))
+        }?;
+        let mut buf = unsafe { Buffer::from_raw(inner) };
         let mut svg = String::new();
         buf.read_to_string(&mut svg)?;
         Ok(svg)
@@ -99,24 +98,24 @@ impl Page {
 
     pub fn to_text_page(&self, opts: TextPageOptions) -> Result<TextPage, Error> {
         unsafe {
-            let inner = ffi_try!(mupdf_page_to_text_page(
+            ffi_try!(mupdf_page_to_text_page(
                 context(),
                 self.as_ptr() as *mut _,
                 opts.bits() as _
-            ));
-            Ok(TextPage::from_raw(inner))
+            ))
         }
+        .map(|inner| unsafe { TextPage::from_raw(inner) })
     }
 
     pub fn to_display_list(&self, annotations: bool) -> Result<DisplayList, Error> {
         unsafe {
-            let inner = ffi_try!(mupdf_page_to_display_list(
+            ffi_try!(mupdf_page_to_display_list(
                 context(),
                 self.as_ptr() as *mut _,
                 annotations
-            ));
-            Ok(DisplayList::from_raw(inner))
+            ))
         }
+        .map(|inner| unsafe { DisplayList::from_raw(inner) })
     }
 
     pub fn run(&self, device: &Device, ctm: &Matrix) -> Result<(), Error> {
@@ -129,7 +128,6 @@ impl Page {
                 ptr::null_mut()
             ))
         }
-        Ok(())
     }
 
     pub fn run_with_cookie(
@@ -147,7 +145,6 @@ impl Page {
                 cookie.inner
             ))
         }
-        Ok(())
     }
 
     pub fn run_contents(&self, device: &Device, ctm: &Matrix) -> Result<(), Error> {
@@ -160,7 +157,6 @@ impl Page {
                 ptr::null_mut()
             ))
         }
-        Ok(())
     }
 
     pub fn run_contents_with_cookie(
@@ -178,7 +174,6 @@ impl Page {
                 cookie.inner
             ))
         }
-        Ok(())
     }
 
     pub fn run_annotations(&self, device: &Device, ctm: &Matrix) -> Result<(), Error> {
@@ -191,7 +186,6 @@ impl Page {
                 ptr::null_mut()
             ))
         }
-        Ok(())
     }
 
     pub fn run_annotations_with_cookie(
@@ -209,7 +203,6 @@ impl Page {
                 cookie.inner
             ))
         }
-        Ok(())
     }
 
     pub fn run_widgets(&self, device: &Device, ctm: &Matrix) -> Result<(), Error> {
@@ -222,7 +215,6 @@ impl Page {
                 ptr::null_mut()
             ))
         }
-        Ok(())
     }
 
     pub fn run_widgets_with_cookie(
@@ -240,83 +232,73 @@ impl Page {
                 cookie.inner
             ))
         }
-        Ok(())
     }
 
     pub fn to_html(&self) -> Result<String, Error> {
-        let mut buf = unsafe {
-            let inner = ffi_try!(mupdf_page_to_html(context(), self.as_ptr() as *mut _));
-            Buffer::from_raw(inner)
-        };
+        let inner = unsafe { ffi_try!(mupdf_page_to_html(context(), self.as_ptr() as *mut _)) }?;
+        let mut buf = unsafe { Buffer::from_raw(inner) };
         let mut out = String::new();
         buf.read_to_string(&mut out)?;
         Ok(out)
     }
 
     pub fn stext_page_as_json_from_page(&self, scale: f32) -> Result<String, Error> {
-        let mut buf = unsafe {
-            let inner = ffi_try!(mupdf_stext_page_as_json_from_page(
+        let inner = unsafe {
+            ffi_try!(mupdf_stext_page_as_json_from_page(
                 context(),
                 self.as_ptr() as *mut _,
                 scale
-            ));
-            Buffer::from_raw(inner)
-        };
+            ))
+        }?;
+        let mut buf = unsafe { Buffer::from_raw(inner) };
         let mut res = String::new();
         buf.read_to_string(&mut res).unwrap();
         Ok(res)
     }
 
     pub fn to_xhtml(&self) -> Result<String, Error> {
-        let mut buf = unsafe {
-            let inner = ffi_try!(mupdf_page_to_xhtml(context(), self.as_ptr() as *mut _));
-            Buffer::from_raw(inner)
-        };
+        let inner = unsafe { ffi_try!(mupdf_page_to_xhtml(context(), self.as_ptr() as *mut _)) }?;
+        let mut buf = unsafe { Buffer::from_raw(inner) };
         let mut out = String::new();
         buf.read_to_string(&mut out)?;
         Ok(out)
     }
 
     pub fn to_xml(&self) -> Result<String, Error> {
-        let mut buf = unsafe {
-            let inner = ffi_try!(mupdf_page_to_xml(context(), self.as_ptr() as *mut _));
-            Buffer::from_raw(inner)
-        };
+        let inner = unsafe { ffi_try!(mupdf_page_to_xml(context(), self.as_ptr() as *mut _)) }?;
+        let mut buf = unsafe { Buffer::from_raw(inner) };
         let mut out = String::new();
         buf.read_to_string(&mut out)?;
         Ok(out)
     }
 
     pub fn to_text(&self) -> Result<String, Error> {
-        let mut buf = unsafe {
-            let inner = ffi_try!(mupdf_page_to_text(context(), self.as_ptr() as *mut _));
-            Buffer::from_raw(inner)
-        };
+        let inner = unsafe { ffi_try!(mupdf_page_to_text(context(), self.as_ptr() as *mut _)) }?;
+        let mut buf = unsafe { Buffer::from_raw(inner) };
         let mut out = String::new();
         buf.read_to_string(&mut out)?;
         Ok(out)
     }
 
     pub fn links(&self) -> Result<LinkIter, Error> {
-        let next = unsafe { ffi_try!(mupdf_load_links(context(), self.as_ptr() as *mut _)) };
-        Ok(LinkIter {
-            next,
-            doc: self.doc,
+        unsafe { ffi_try!(mupdf_load_links(context(), self.as_ptr() as *mut _)) }.map(|next| {
+            LinkIter {
+                next,
+                doc: self.doc,
+            }
         })
     }
 
     pub fn separations(&self) -> Result<Separations, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_page_separations(context(), self.as_ptr() as *mut _));
-            Ok(Separations::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_page_separations(context(), self.as_ptr() as *mut _)) }
+            .map(|inner| unsafe { Separations::from_raw(inner) })
     }
 
     pub fn search(&self, needle: &str, hit_max: u32) -> Result<FzArray<Quad>, Error> {
         let c_needle = CString::new(needle)?;
         let hit_max = if hit_max < 1 { 16 } else { hit_max };
         let mut hit_count = 0;
-        let quads = unsafe {
+        unsafe {
             ffi_try!(mupdf_search_page(
                 context(),
                 self.as_ptr() as *mut fz_page,
@@ -324,9 +306,8 @@ impl Page {
                 hit_max as c_int,
                 &mut hit_count
             ))
-        };
-
-        unsafe { rust_vec_from_ffi_ptr(quads, hit_count) }
+        }
+        .and_then(|quads| unsafe { rust_vec_from_ffi_ptr(quads, hit_count) })
     }
 }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -119,13 +119,11 @@ impl Path {
     }
 
     pub fn new() -> Result<Self, Error> {
-        let inner = unsafe { ffi_try!(mupdf_new_path(context())) };
-        Ok(Self { inner })
+        unsafe { ffi_try!(mupdf_new_path(context())) }.map(|inner| Self { inner })
     }
 
     pub fn try_clone(&self) -> Result<Self, Error> {
-        let inner = unsafe { ffi_try!(mupdf_clone_path(context(), self.inner)) };
-        Ok(Self { inner })
+        unsafe { ffi_try!(mupdf_clone_path(context(), self.inner)) }.map(|inner| Self { inner })
     }
 
     pub fn walk<W: PathWalker>(&self, walker: W) -> Result<(), Error> {
@@ -146,7 +144,7 @@ impl Path {
                 self.inner,
                 &c_walker,
                 raw_ptr.cast()
-            ));
+            ))?;
             drop(Box::from_raw(raw_ptr));
         }
         Ok(())
@@ -158,17 +156,11 @@ impl Path {
     }
 
     pub fn move_to(&mut self, x: f32, y: f32) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_moveto(context(), self.inner, x, y));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_moveto(context(), self.inner, x, y)) }
     }
 
     pub fn line_to(&mut self, x: f32, y: f32) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_lineto(context(), self.inner, x, y));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_lineto(context(), self.inner, x, y)) }
     }
 
     pub fn curve_to(
@@ -190,63 +182,44 @@ impl Path {
                 cy2,
                 ex,
                 ey
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn curve_to_v(&mut self, cx: f32, cy: f32, ex: f32, ey: f32) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_curvetov(context(), self.inner, cx, cy, ex, ey));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_curvetov(context(), self.inner, cx, cy, ex, ey)) }
     }
 
     pub fn curve_to_y(&mut self, cx: f32, cy: f32, ex: f32, ey: f32) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_curvetoy(context(), self.inner, cx, cy, ex, ey));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_curvetoy(context(), self.inner, cx, cy, ex, ey)) }
     }
 
     pub fn rect(&mut self, x1: f32, y1: f32, x2: f32, y2: f32) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_rectto(context(), self.inner, x1, y1, x2, y2));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_rectto(context(), self.inner, x1, y1, x2, y2)) }
     }
 
     pub fn close(&mut self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_closepath(context(), self.inner));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_closepath(context(), self.inner)) }
     }
 
     pub fn transform(&mut self, mat: &Matrix) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_transform_path(context(), self.inner, mat.into()));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_transform_path(context(), self.inner, mat.into())) }
     }
 
     pub fn bounds(&self, stroke: &StrokeState, ctm: &Matrix) -> Result<Rect, Error> {
-        let rect = unsafe {
+        unsafe {
             ffi_try!(mupdf_bound_path(
                 context(),
                 self.inner,
                 stroke.inner,
                 ctm.into()
             ))
-        };
-        Ok(rect.into())
+        }
+        .map(Into::into)
     }
 
     pub fn trim(&mut self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_trim_path(context(), self.inner));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_trim_path(context(), self.inner)) }
     }
 }
 

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -254,10 +254,8 @@ impl PdfDocument {
         let len = bytes.len();
         let mut buf = Buffer::with_capacity(len);
         buf.write_all(bytes)?;
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_open_document_from_bytes(context(), buf.inner));
-            Ok(Self::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_open_document_from_bytes(context(), buf.inner)) }
+            .map(|inner| unsafe { Self::from_raw(inner) })
     }
 
     pub fn new_null(&self) -> PdfObject {
@@ -285,85 +283,64 @@ impl PdfDocument {
     }
 
     pub fn new_indirect(&self, num: i32, gen: i32) -> Result<PdfObject, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_new_indirect(context(), self.inner, num, gen));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_new_indirect(context(), self.inner, num, gen)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn new_array(&self) -> Result<PdfObject, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_new_array(context(), self.inner, 0));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_new_array(context(), self.inner, 0)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn new_dict(&self) -> Result<PdfObject, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_new_dict(context(), self.inner, 0));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_new_dict(context(), self.inner, 0)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn new_graft_map(&self) -> Result<PdfGraftMap, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_new_graft_map(context(), self.inner));
-            Ok(PdfGraftMap::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_new_graft_map(context(), self.inner)) }
+            .map(|inner| unsafe { PdfGraftMap::from_raw(inner) })
     }
 
     pub fn new_object_from_str(&self, src: &str) -> Result<PdfObject, Error> {
         let c_src = CString::new(src)?;
         unsafe {
-            let inner = ffi_try!(mupdf_pdf_obj_from_str(
+            ffi_try!(mupdf_pdf_obj_from_str(
                 context(),
                 self.inner,
                 c_src.as_ptr()
-            ));
-            Ok(PdfObject::from_raw(inner))
+            ))
         }
+        .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn graft_object(&self, obj: &PdfObject) -> Result<PdfObject, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_graft_object(context(), self.inner, obj.inner));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_graft_object(context(), self.inner, obj.inner)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn add_object(&mut self, obj: &PdfObject) -> Result<PdfObject, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_add_object(context(), self.inner, obj.inner));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_add_object(context(), self.inner, obj.inner)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn create_object(&mut self) -> Result<PdfObject, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_create_object(context(), self.inner));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_create_object(context(), self.inner)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn delete_object(&mut self, num: i32) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_pdf_delete_object(context(), self.inner, num));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_pdf_delete_object(context(), self.inner, num)) }
     }
 
     pub fn add_image(&mut self, obj: &Image) -> Result<PdfObject, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_add_image(context(), self.inner, obj.inner));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_add_image(context(), self.inner, obj.inner)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn add_font(&mut self, font: &Font) -> Result<PdfObject, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_add_font(context(), self.inner, font.inner));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_add_font(context(), self.inner, font.inner)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn add_cjk_font(
@@ -374,16 +351,16 @@ impl PdfDocument {
         serif: bool,
     ) -> Result<PdfObject, Error> {
         unsafe {
-            let inner = ffi_try!(mupdf_pdf_add_cjk_font(
+            ffi_try!(mupdf_pdf_add_cjk_font(
                 context(),
                 self.inner,
                 font.inner,
                 ordering as i32,
                 wmode as i32,
                 serif
-            ));
-            Ok(PdfObject::from_raw(inner))
+            ))
         }
+        .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn add_simple_font(
@@ -392,14 +369,14 @@ impl PdfDocument {
         encoding: SimpleFontEncoding,
     ) -> Result<PdfObject, Error> {
         unsafe {
-            let inner = ffi_try!(mupdf_pdf_add_simple_font(
+            ffi_try!(mupdf_pdf_add_simple_font(
                 context(),
                 self.inner,
                 font.inner,
                 encoding as i32
-            ));
-            Ok(PdfObject::from_raw(inner))
+            ))
         }
+        .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn has_unsaved_changes(&self) -> bool {
@@ -422,54 +399,39 @@ impl PdfDocument {
                 self.inner,
                 c_name.as_ptr(),
                 options.inner
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn enable_js(&mut self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_pdf_enable_js(context(), self.inner));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_pdf_enable_js(context(), self.inner)) }
     }
 
     pub fn disable_js(&mut self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_pdf_disable_js(context(), self.inner));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_pdf_disable_js(context(), self.inner)) }
     }
 
     pub fn is_js_supported(&self) -> Result<bool, Error> {
-        let supported = unsafe { ffi_try!(mupdf_pdf_js_supported(context(), self.inner)) };
-        Ok(supported)
+        unsafe { ffi_try!(mupdf_pdf_js_supported(context(), self.inner)) }
     }
 
     pub fn calculate_form(&mut self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_pdf_calculate_form(context(), self.inner));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_pdf_calculate_form(context(), self.inner)) }
     }
 
     pub fn trailer(&self) -> Result<PdfObject, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_trailer(context(), self.inner));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_trailer(context(), self.inner)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn catalog(&self) -> Result<PdfObject, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_catalog(context(), self.inner));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_catalog(context(), self.inner)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn count_objects(&self) -> Result<u32, Error> {
-        let count = unsafe { ffi_try!(mupdf_pdf_count_objects(context(), self.inner)) };
-        Ok(count as u32)
+        unsafe { ffi_try!(mupdf_pdf_count_objects(context(), self.inner)) }
+            .map(|count| count as u32)
     }
 
     pub fn has_acro_form(&self) -> Result<bool, Error> {
@@ -507,13 +469,13 @@ impl PdfDocument {
 
     fn write_with_options(&self, options: PdfWriteOptions) -> Result<Buffer, Error> {
         unsafe {
-            let buf = ffi_try!(mupdf_pdf_write_document(
+            ffi_try!(mupdf_pdf_write_document(
                 context(),
                 self.inner,
                 options.inner
-            ));
-            Ok(Buffer::from_raw(buf))
+            ))
         }
+        .map(|buf| unsafe { Buffer::from_raw(buf) })
     }
 
     pub fn write_to_with_options<W: Write>(
@@ -530,10 +492,8 @@ impl PdfDocument {
     }
 
     pub fn find_page(&self, page_no: i32) -> Result<PdfObject, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_lookup_page_obj(context(), self.inner, page_no));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_lookup_page_obj(context(), self.inner, page_no)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn new_page_at<T: Into<Size>>(&mut self, page_no: i32, size: T) -> Result<PdfPage, Error> {
@@ -546,7 +506,7 @@ impl PdfDocument {
                 size.width,
                 size.height
             ))
-        };
+        }?;
         let inner = NonNull::new(inner).ok_or(Error::UnexpectedNullPtr)?;
         Ok(unsafe { PdfPage::from_raw(inner) })
     }
@@ -562,16 +522,12 @@ impl PdfDocument {
                 self.inner,
                 page_no,
                 page.inner
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn delete_page(&mut self, page_no: i32) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_pdf_delete_page(context(), self.inner, page_no));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_pdf_delete_page(context(), self.inner, page_no)) }
     }
 
     pub fn set_outlines(&mut self, toc: &[Outline]) -> Result<(), Error> {

--- a/src/pdf/graft_map.rs
+++ b/src/pdf/graft_map.rs
@@ -14,13 +14,13 @@ impl PdfGraftMap {
 
     pub fn graft_object(&mut self, obj: &PdfObject) -> Result<PdfObject, Error> {
         unsafe {
-            let inner = ffi_try!(mupdf_pdf_graft_mapped_object(
+            ffi_try!(mupdf_pdf_graft_mapped_object(
                 context(),
                 self.inner,
                 obj.inner
-            ));
-            Ok(PdfObject::from_raw(inner))
+            ))
         }
+        .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 }
 

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -48,8 +48,7 @@ impl PdfObject {
     }
 
     pub fn try_clone(&self) -> Result<Self, Error> {
-        let inner = unsafe { ffi_try!(mupdf_pdf_clone_obj(context(), self.inner)) };
-        Ok(Self { inner })
+        unsafe { ffi_try!(mupdf_pdf_clone_obj(context(), self.inner)) }.map(|inner| Self { inner })
     }
 
     pub fn new_null() -> PdfObject {
@@ -67,138 +66,107 @@ impl PdfObject {
     }
 
     pub fn new_int(i: i32) -> Result<PdfObject, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_new_int(context(), i));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_new_int(context(), i)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn new_real(f: f32) -> Result<PdfObject, Error> {
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_new_real(context(), f));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_new_real(context(), f)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn new_string(s: &str) -> Result<PdfObject, Error> {
         let c_str = CString::new(s)?;
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_new_string(context(), c_str.as_ptr()));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_new_string(context(), c_str.as_ptr())) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn new_name(name: &str) -> Result<PdfObject, Error> {
         let c_name = CString::new(name)?;
-        unsafe {
-            let inner = ffi_try!(mupdf_pdf_new_name(context(), c_name.as_ptr()));
-            Ok(PdfObject::from_raw(inner))
-        }
+        unsafe { ffi_try!(mupdf_pdf_new_name(context(), c_name.as_ptr())) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
     pub fn is_indirect(&self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_is_indirect(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_is_indirect(context(), self.inner)) }
     }
 
     pub fn is_null(&self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_is_null(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_is_null(context(), self.inner)) }
     }
 
     pub fn is_bool(&self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_is_bool(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_is_bool(context(), self.inner)) }
     }
 
     pub fn is_int(&self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_is_int(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_is_int(context(), self.inner)) }
     }
 
     pub fn is_real(&self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_is_real(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_is_real(context(), self.inner)) }
     }
 
     pub fn is_number(&self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_is_number(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_is_number(context(), self.inner)) }
     }
 
     pub fn is_string(&self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_is_string(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_is_string(context(), self.inner)) }
     }
 
     pub fn is_name(&self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_is_name(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_is_name(context(), self.inner)) }
     }
 
     pub fn is_array(&self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_is_array(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_is_array(context(), self.inner)) }
     }
 
     pub fn is_dict(&self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_is_dict(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_is_dict(context(), self.inner)) }
     }
 
     pub fn is_stream(&self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_is_stream(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_is_stream(context(), self.inner)) }
     }
 
     pub fn as_bool(&self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_to_bool(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_to_bool(context(), self.inner)) }
     }
 
     pub fn as_int(&self) -> Result<i32, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_to_int(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_to_int(context(), self.inner)) }
     }
 
     pub fn as_float(&self) -> Result<f32, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_to_float(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_to_float(context(), self.inner)) }
     }
 
     pub fn as_indirect(&self) -> Result<i32, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_to_indirect(context(), self.inner)) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_to_indirect(context(), self.inner)) }
     }
 
     pub fn as_name(&self) -> Result<&[u8], Error> {
-        unsafe {
-            let name_ptr = ffi_try!(mupdf_pdf_to_name(context(), self.inner));
-            let c_name = CStr::from_ptr(name_ptr);
-            Ok(c_name.to_bytes())
-        }
+        let name_ptr = unsafe { ffi_try!(mupdf_pdf_to_name(context(), self.inner)) }?;
+        let c_name = unsafe { CStr::from_ptr(name_ptr) };
+        Ok(c_name.to_bytes())
     }
 
     pub fn as_string(&self) -> Result<&str, Error> {
-        unsafe {
-            let str_ptr = ffi_try!(mupdf_pdf_to_string(context(), self.inner));
-            let c_str = CStr::from_ptr(str_ptr);
-            let string = c_str.to_str().unwrap();
-            Ok(string)
-        }
+        let str_ptr = unsafe { ffi_try!(mupdf_pdf_to_string(context(), self.inner)) }?;
+        let c_str = unsafe { CStr::from_ptr(str_ptr) };
+        Ok(c_str.to_str().unwrap())
     }
 
     pub fn as_bytes(&self) -> Result<&[u8], Error> {
         let mut len = 0;
-        unsafe {
-            let ptr = ffi_try!(mupdf_pdf_to_bytes(context(), self.inner, &mut len));
-            let byte_slice = slice::from_raw_parts(ptr, len);
-            Ok(byte_slice)
-        }
+        let ptr = unsafe { ffi_try!(mupdf_pdf_to_bytes(context(), self.inner, &mut len)) }?;
+        Ok(unsafe { slice::from_raw_parts(ptr, len) })
     }
 
     pub fn resolve(&self) -> Result<Option<Self>, Error> {
-        let inner = unsafe { ffi_try!(mupdf_pdf_resolve_indirect(context(), self.inner)) };
+        let inner = unsafe { ffi_try!(mupdf_pdf_resolve_indirect(context(), self.inner)) }?;
         if inner.is_null() {
             return Ok(None);
         }
@@ -206,7 +174,7 @@ impl PdfObject {
     }
 
     pub fn read_stream(&self) -> Result<Vec<u8>, Error> {
-        let inner = unsafe { ffi_try!(mupdf_pdf_read_stream(context(), self.inner)) };
+        let inner = unsafe { ffi_try!(mupdf_pdf_read_stream(context(), self.inner)) }?;
         let buf = unsafe { Buffer::from_raw(inner) };
         let buf_len = buf.len();
         let mut reader = BufReader::new(buf);
@@ -216,7 +184,7 @@ impl PdfObject {
     }
 
     pub fn read_raw_stream(&self) -> Result<Vec<u8>, Error> {
-        let inner = unsafe { ffi_try!(mupdf_pdf_read_raw_stream(context(), self.inner)) };
+        let inner = unsafe { ffi_try!(mupdf_pdf_read_raw_stream(context(), self.inner)) }?;
         let buf = unsafe { Buffer::from_raw(inner) };
         let buf_len = buf.len();
         let mut reader = BufReader::new(buf);
@@ -226,10 +194,7 @@ impl PdfObject {
     }
 
     pub fn write_object(&mut self, obj: &PdfObject) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_pdf_write_object(context(), self.inner, obj.inner));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_pdf_write_object(context(), self.inner, obj.inner)) }
     }
 
     pub fn write_stream_buffer(&mut self, buf: &Buffer) -> Result<(), Error> {
@@ -239,9 +204,8 @@ impl PdfObject {
                 self.inner,
                 buf.inner,
                 0
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn write_stream_string(&mut self, string: &str) -> Result<(), Error> {
@@ -256,9 +220,8 @@ impl PdfObject {
                 self.inner,
                 buf.inner,
                 1
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn write_raw_stream_string(&mut self, string: &str) -> Result<(), Error> {
@@ -267,7 +230,7 @@ impl PdfObject {
     }
 
     pub fn get_array(&self, index: i32) -> Result<Option<Self>, Error> {
-        let inner = unsafe { ffi_try!(mupdf_pdf_array_get(context(), self.inner, index)) };
+        let inner = unsafe { ffi_try!(mupdf_pdf_array_get(context(), self.inner, index)) }?;
         if inner.is_null() {
             return Ok(None);
         }
@@ -275,19 +238,18 @@ impl PdfObject {
     }
 
     pub fn dict_len(&self) -> Result<usize, Error> {
-        let size = unsafe { ffi_try!(mupdf_pdf_dict_len(context(), self.inner)) };
-        Ok(size as usize)
+        unsafe { ffi_try!(mupdf_pdf_dict_len(context(), self.inner)) }.map(|size| size as usize)
     }
 
     pub fn get_dict_val(&self, idx: i32) -> Result<Option<Self>, Error> {
-        let inner = unsafe { ffi_try!(mupdf_pdf_dict_get_val(context(), self.inner, idx)) };
+        let inner = unsafe { ffi_try!(mupdf_pdf_dict_get_val(context(), self.inner, idx)) }?;
         if inner.is_null() {
             return Ok(None);
         }
         Ok(Some(Self { inner }))
     }
     pub fn get_dict_key(&self, idx: i32) -> Result<Option<Self>, Error> {
-        let inner = unsafe { ffi_try!(mupdf_pdf_dict_get_key(context(), self.inner, idx)) };
+        let inner = unsafe { ffi_try!(mupdf_pdf_dict_get_key(context(), self.inner, idx)) }?;
         if inner.is_null() {
             return Ok(None);
         }
@@ -296,7 +258,7 @@ impl PdfObject {
 
     pub fn get_dict<K: IntoPdfDictKey>(&self, key: K) -> Result<Option<Self>, Error> {
         let key = key.into_pdf_dict_key()?;
-        let inner = unsafe { ffi_try!(mupdf_pdf_dict_get(context(), self.inner, key.inner)) };
+        let inner = unsafe { ffi_try!(mupdf_pdf_dict_get(context(), self.inner, key.inner)) }?;
         if inner.is_null() {
             return Ok(None);
         }
@@ -311,7 +273,7 @@ impl PdfObject {
                 self.inner,
                 key.inner
             ))
-        };
+        }?;
         if inner.is_null() {
             return Ok(None);
         }
@@ -320,8 +282,7 @@ impl PdfObject {
 
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> Result<usize, Error> {
-        let size = unsafe { ffi_try!(mupdf_pdf_array_len(context(), self.inner)) };
-        Ok(size as usize)
+        unsafe { ffi_try!(mupdf_pdf_array_len(context(), self.inner)) }.map(|size| size as usize)
     }
 
     pub fn array_put(&mut self, index: i32, value: Self) -> Result<(), Error> {
@@ -331,23 +292,16 @@ impl PdfObject {
                 self.inner,
                 index,
                 value.inner
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn array_push(&mut self, value: Self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_pdf_array_push(context(), self.inner, value.inner));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_pdf_array_push(context(), self.inner, value.inner)) }
     }
 
     pub fn array_delete(&mut self, index: i32) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_pdf_array_delete(context(), self.inner, index));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_pdf_array_delete(context(), self.inner, index)) }
     }
 
     pub fn dict_put<K: IntoPdfDictKey>(&mut self, key: K, value: Self) -> Result<(), Error> {
@@ -358,27 +312,22 @@ impl PdfObject {
                 self.inner,
                 key_obj.inner,
                 value.inner
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn dict_delete<K: IntoPdfDictKey>(&mut self, key: K) -> Result<(), Error> {
         let key_obj = key.into_pdf_dict_key()?;
-        unsafe {
-            ffi_try!(mupdf_pdf_dict_delete(context(), self.inner, key_obj.inner));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_pdf_dict_delete(context(), self.inner, key_obj.inner)) }
     }
 
     fn print(&self, tight: bool, ascii: bool) -> Result<String, Error> {
-        unsafe {
-            let ptr = ffi_try!(mupdf_pdf_obj_to_string(context(), self.inner, tight, ascii));
-            let c_str = CStr::from_ptr(ptr);
-            let s = c_str.to_string_lossy().into_owned();
-            fz_free(context(), ptr as _);
-            Ok(s)
-        }
+        let ptr =
+            unsafe { ffi_try!(mupdf_pdf_obj_to_string(context(), self.inner, tight, ascii)) }?;
+        let c_str = unsafe { CStr::from_ptr(ptr) };
+        let s = c_str.to_string_lossy().into_owned();
+        unsafe { fz_free(context(), ptr as _) };
+        Ok(s)
     }
 
     pub fn document(&self) -> Option<PdfDocument> {
@@ -392,10 +341,7 @@ impl PdfObject {
     }
 
     pub fn page_ctm(&self) -> Result<Matrix, Error> {
-        let matrix =
-            unsafe { ffi_try!(mupdf_pdf_page_obj_transform(context(), self.inner)).into() };
-
-        Ok(matrix)
+        unsafe { ffi_try!(mupdf_pdf_page_obj_transform(context(), self.inner)) }.map(Into::into)
     }
 }
 

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -46,13 +46,13 @@ impl PdfPage {
         subtype: PdfAnnotationType,
     ) -> Result<PdfAnnotation, Error> {
         unsafe {
-            let annot = ffi_try!(mupdf_pdf_create_annot(
+            ffi_try!(mupdf_pdf_create_annot(
                 context(),
                 self.as_mut_ptr(),
                 subtype as i32
-            ));
-            Ok(PdfAnnotation::from_raw(annot))
+            ))
         }
+        .map(|annot| unsafe { PdfAnnotation::from_raw(annot) })
     }
 
     pub fn delete_annotation(&mut self, annot: &PdfAnnotation) -> Result<(), Error> {
@@ -61,9 +61,8 @@ impl PdfPage {
                 context(),
                 self.as_mut_ptr(),
                 annot.inner
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn annotations(&self) -> AnnotationIter {
@@ -72,13 +71,11 @@ impl PdfPage {
     }
 
     pub fn update(&mut self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_update_page(context(), self.as_mut_ptr())) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_update_page(context(), self.as_mut_ptr())) }
     }
 
     pub fn redact(&mut self) -> Result<bool, Error> {
-        let ret = unsafe { ffi_try!(mupdf_pdf_redact_page(context(), self.as_mut_ptr())) };
-        Ok(ret)
+        unsafe { ffi_try!(mupdf_pdf_redact_page(context(), self.as_mut_ptr())) }
     }
 
     pub fn object(&self) -> PdfObject {
@@ -101,9 +98,8 @@ impl PdfPage {
                 context(),
                 self.as_mut_ptr(),
                 rotate
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn media_box(&self) -> Result<Rect, Error> {
@@ -128,14 +124,13 @@ impl PdfPage {
                 context(),
                 self.as_mut_ptr(),
                 crop_box.into()
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn ctm(&self) -> Result<Matrix, Error> {
-        let m = unsafe { ffi_try!(mupdf_pdf_page_transform(context(), self.as_ptr() as *mut _)) };
-        Ok(m.into())
+        unsafe { ffi_try!(mupdf_pdf_page_transform(context(), self.as_ptr() as *mut _)) }
+            .map(fz_matrix::into)
     }
 
     pub fn filter(&mut self, mut opt: PdfFilterOptions) -> Result<(), Error> {
@@ -146,8 +141,6 @@ impl PdfPage {
                 &mut opt.inner as *mut _
             ))
         }
-
-        Ok(())
     }
 }
 

--- a/src/pixmap.rs
+++ b/src/pixmap.rs
@@ -42,9 +42,8 @@ impl Pixmap {
         h: i32,
         alpha: bool,
     ) -> Result<Self, Error> {
-        let ctx = context();
-        let inner = unsafe { ffi_try!(mupdf_new_pixmap(ctx, cs.inner, x, y, w, h, alpha)) };
-        Ok(Self { inner })
+        unsafe { ffi_try!(mupdf_new_pixmap(context(), cs.inner, x, y, w, h, alpha)) }
+            .map(|inner| Self { inner })
     }
 
     /// Create an empty pixmap of size and origin given by the rectangle.
@@ -168,10 +167,7 @@ impl Pixmap {
 
     /// Initialize the samples area with 0x00
     pub fn clear(&mut self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_clear_pixmap(context(), self.inner));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_clear_pixmap(context(), self.inner)) }
     }
 
     /// Initialize the samples area
@@ -180,10 +176,7 @@ impl Pixmap {
     ///
     /// * `value` - values from 0 to 255 are valid. Each color byte of each pixel will be set to this value, while alpha will be set to 255 (non-transparent) if present
     pub fn clear_with(&mut self, value: i32) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_clear_pixmap_with_value(context(), self.inner, value));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_clear_pixmap_with_value(context(), self.inner, value)) }
     }
 
     pub fn save_as(&self, filename: &str, format: ImageFormat) -> Result<(), Error> {
@@ -194,16 +187,12 @@ impl Pixmap {
                 self.inner,
                 c_filename.as_ptr(),
                 format as i32
-            ));
+            ))
         }
-        Ok(())
     }
 
     pub fn invert(&mut self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_invert_pixmap(context(), self.inner));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_invert_pixmap(context(), self.inner)) }
     }
 
     /// Apply a gamma factor to a pixmap, i.e. lighten or darken it.
@@ -214,30 +203,23 @@ impl Pixmap {
     ///
     /// * `gamma` - gamma = 1.0 does nothing, gamma < 1.0 lightens, gamma > 1.0 darkens the image.
     pub fn gamma(&mut self, gamma: f32) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_gamma_pixmap(context(), self.inner, gamma));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_gamma_pixmap(context(), self.inner, gamma)) }
     }
 
     /// Tint pixmap with color
     pub fn tint(&mut self, black: i32, white: i32) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(mupdf_tint_pixmap(context(), self.inner, black, white));
-        }
-        Ok(())
+        unsafe { ffi_try!(mupdf_tint_pixmap(context(), self.inner, black, white)) }
     }
 
     fn get_image_data(&self, format: ImageFormat) -> Result<Buffer, Error> {
-        let buf = unsafe {
-            let inner = ffi_try!(mupdf_pixmap_get_image_data(
+        unsafe {
+            ffi_try!(mupdf_pixmap_get_image_data(
                 context(),
                 self.inner,
                 format as i32
-            ));
-            Buffer::from_raw(inner)
-        };
-        Ok(buf)
+            ))
+        }
+        .map(|inner| unsafe { Buffer::from_raw(inner) })
     }
 
     pub fn write_to<W: Write>(&self, w: &mut W, format: ImageFormat) -> Result<u64, Error> {
@@ -246,8 +228,7 @@ impl Pixmap {
     }
 
     pub fn try_clone(&self) -> Result<Self, Error> {
-        let inner = unsafe { ffi_try!(mupdf_clone_pixmap(context(), self.inner)) };
-        Ok(Self { inner })
+        unsafe { ffi_try!(mupdf_clone_pixmap(context(), self.inner)) }.map(|inner| Self { inner })
     }
 }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -174,15 +174,15 @@ impl Rect {
 
     pub fn adjust_for_stroke(&self, stroke: &StrokeState, ctm: &Matrix) -> Result<Self, Error> {
         let r = (*self).into();
-        let new_rect = unsafe {
+        unsafe {
             ffi_try!(mupdf_adjust_rect_for_stroke(
                 context(),
                 r,
                 stroke.inner,
                 ctm.into()
             ))
-        };
-        Ok(new_rect.into())
+        }
+        .map(fz_rect::into)
     }
 }
 

--- a/src/stroke_state.rs
+++ b/src/stroke_state.rs
@@ -53,7 +53,7 @@ impl StrokeState {
         dash: &[f32],
     ) -> Result<Self, Error> {
         let dash_len = dash.len() as i32;
-        let inner = unsafe {
+        unsafe {
             ffi_try!(mupdf_new_stroke_state(
                 context(),
                 start_cap as fz_linecap,
@@ -66,8 +66,8 @@ impl StrokeState {
                 dash.as_ptr(),
                 dash_len
             ))
-        };
-        Ok(Self { inner })
+        }
+        .map(|inner| Self { inner })
     }
 
     pub fn try_clone(&self) -> Result<Self, Error> {

--- a/src/text.rs
+++ b/src/text.rs
@@ -13,20 +13,19 @@ pub struct Text {
 
 impl Text {
     pub fn new() -> Result<Self, Error> {
-        let inner = unsafe { ffi_try!(mupdf_new_text(context())) };
-        Ok(Self { inner })
+        unsafe { ffi_try!(mupdf_new_text(context())) }.map(|inner| Self { inner })
     }
 
     pub fn bounds(&self, stroke: &StrokeState, ctm: &Matrix) -> Result<Rect, Error> {
-        let rect = unsafe {
+        unsafe {
             ffi_try!(mupdf_bound_text(
                 context(),
                 self.inner,
                 stroke.inner,
                 ctm.into()
             ))
-        };
-        Ok(rect.into())
+        }
+        .map(fz_rect::into)
     }
 
     pub fn spans(&self) -> TextSpanIter {


### PR DESCRIPTION
This allows us to remove a lot of eyes of sauron (`Ok(())`) and just clean a lot of stuff up, generally

This also helps with some more work I'd like to do related to #109 (specifically in enabling `clippy::multiple_unsafe_ops_per_block`).