### PR TITLE
Fix typo in the `sys-lib-tesseract` feature

### DIFF
--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -158,7 +158,7 @@ fn build_libmupdf() {
     add_lib("LEPTONICA", "lept");
 
     #[cfg(feature = "sys-lib-tesseract")]
-    add_lib("TESSARACT", "tessaract");
+    add_lib("TESSERACT", "tesseract");
 
     //
     // The mupdf Makefile does not do a very good job of detecting


### PR DESCRIPTION
Hello, I noticed that with `cargo build --all-features`, `pkg-config` can't find the tesseract library. Here's a small change to fix this.