### PR TITLE
make corrections

### DIFF
--- a/mupdf-sys/wrapper.c
+++ b/mupdf-sys/wrapper.c
@@ -722,7 +722,7 @@ fz_rect mupdf_bound_page(fz_context *ctx, fz_page *page, mupdf_error_t **errptr)
     return rect;
 }
 
-fz_pixmap *mupdf_page_to_pixmap(fz_context *ctx, fz_page *page, fz_matrix ctm, fz_colorspace *cs, float alpha, bool show_extras, mupdf_error_t **errptr)
+fz_pixmap *mupdf_page_to_pixmap(fz_context *ctx, fz_page *page, fz_matrix ctm, fz_colorspace *cs, bool alpha, bool show_extras, mupdf_error_t **errptr)
 {
     fz_pixmap *pixmap = NULL;
     fz_try(ctx)

--- a/src/page.rs
+++ b/src/page.rs
@@ -50,7 +50,7 @@ impl Page {
         &self,
         ctm: &Matrix,
         cs: &Colorspace,
-        alpha: f32,
+        alpha: bool,
         show_extras: bool,
     ) -> Result<Pixmap, Error> {
         unsafe {

--- a/tests/test_issues.rs
+++ b/tests/test_issues.rs
@@ -8,7 +8,7 @@ fn test_issue_16_pixmap_to_png() {
     let page = document.load_page(0).unwrap();
     let matrix = Matrix::new_scale(72f32 / 72f32, 72f32 / 72f32);
     let pixmap = page
-        .to_pixmap(&matrix, &Colorspace::device_rgb(), 0.0, true)
+        .to_pixmap(&matrix, &Colorspace::device_rgb(), false, true)
         .unwrap();
     pixmap
         .save_as("tests/output/test.png", ImageFormat::PNG)


### PR DESCRIPTION
- mupdf expects alpha to be a bool signifying whether to apply alpha
- mupdf can accept paths that can be opened by `open(2)` per 12.2 https://ghostscript.com/~robin/mupdf_explored.pdf#page=83