### PR TITLE
WIP: Try to get it to compile on `wasm32-unknown-emscripten`

### DIFF
--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -492,7 +492,9 @@ fn main() {
             Ok(sdk) => {
                 let mut sysroot = PathBuf::from(sdk);
                 sysroot.push("upstream/emscripten/cache/sysroot");
-                bindings = bindings.clang_arg(format!("--sysroot={}", sysroot.display()));
+                bindings = bindings
+                    .clang_arg(format!("--sysroot={}", sysroot.display()))
+                    .clang_arg("-fvisibility=default");
             }
             Err(env::VarError::NotPresent) => {
                 panic!("Using emscripten requires the EMSDK environment variable to be set");


### PR DESCRIPTION
This tries to get this library to compile on `wasm32-unknown-emscripten`. I expected this to be easier than it is as [mupdf.js](https://github.com/ArtifexSoftware/mupdf.js) uses emscripten as well, but it has been more challenging than expected. It compiles for now but somehow all but `mupdf_error` is missing from the generated `bindings.rs` :/