### PR TITLE
Allow for compilation of mupdf-sys on Windows with Visual Studio 2022

### DIFF
--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -267,7 +267,6 @@ fn build_libmupdf() {
             })
             .to_string(),
         );
-        println!("----------- USING PLATFORM TOOLSET: {}", platform_toolset);
         let d = msbuild
             .args(&[
                 "platform\\win32\\mupdf.sln",


### PR DESCRIPTION
Fixes #124 

Adds a check for an environment variable `MUPDF_MSVC_PLATFORM_TOOLSET` which can set the desired Visual Studio version to be used during compilation.

If the variable isn't set, determine the latest available version of Visual studio and use that (versions prior to v142/2019 is not supported by Mupdf).