### PR TITLE
Add FilePath newtype

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
+use std::ffi::NulError;
 use std::fmt;
 use std::io;
-use std::ffi::NulError;
 use std::num::TryFromIntError;
 use std::ptr::NonNull;
 
@@ -73,7 +73,8 @@ pub enum Error {
     MuPdf(MuPdfError),
     Nul(NulError),
     IntConversion(TryFromIntError),
-    UnexpectedNullPtr
+    InvalidUtf8,
+    UnexpectedNullPtr,
 }
 
 impl fmt::Display for Error {
@@ -85,7 +86,11 @@ impl fmt::Display for Error {
             Error::MuPdf(ref err) => err.fmt(f),
             Error::Nul(ref err) => err.fmt(f),
             Error::IntConversion(ref err) => err.fmt(f),
-            Error::UnexpectedNullPtr => write!(f, "An FFI function call returned a null ptr when we expected a non-null ptr")
+            Error::InvalidUtf8 => f.write_str("string contained invalid utf-8"),
+            Error::UnexpectedNullPtr => write!(
+                f,
+                "An FFI function call returned a null ptr when we expected a non-null ptr"
+            ),
         }
     }
 }

--- a/src/file_path.rs
+++ b/src/file_path.rs
@@ -189,7 +189,7 @@ mod test {
 
         #[cfg(windows)]
         {
-            use std::os::windows::ffi::OsStringExt;
+            use std::{ffi::OsString, os::windows::ffi::OsStringExt};
 
             let source = [
                 b'n' as u16,

--- a/src/file_path.rs
+++ b/src/file_path.rs
@@ -1,0 +1,95 @@
+use std::mem::transmute;
+
+use std::ffi::OsStr;
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(target_os = "wasi")]
+use std::os::wasi::ffi::OsStrExt;
+
+/// Path to a file, required to be UTF-8 on windows
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct FilePath(#[cfg(windows)] str, #[cfg(not(windows))] [u8]);
+
+impl FilePath {
+    pub fn new<P: AsRef<FilePath>>(p: &P) -> &Self {
+        p.as_ref()
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.as_ref()
+    }
+}
+
+impl AsRef<FilePath> for str {
+    fn as_ref(&self) -> &FilePath {
+        #[cfg(windows)]
+        // SAFETY: On windows FilePath is a str. As `self` is a str as well
+        // and FilePath is repr(transparent) this is sound.
+        unsafe {
+            transmute(self)
+        }
+
+        #[cfg(not(windows))]
+        self.as_bytes().as_ref()
+    }
+}
+
+impl AsRef<FilePath> for String {
+    fn as_ref(&self) -> &FilePath {
+        self.as_str().as_ref()
+    }
+}
+
+#[cfg(not(windows))]
+impl AsRef<FilePath> for [u8] {
+    fn as_ref(&self) -> &FilePath {
+        // SAFETY: On non-windows FilePath is a byte slice. As `self` is a byte slice as well
+        // and FilePath is repr(transparent) this is sound.
+        unsafe { transmute(self) }
+    }
+}
+
+#[cfg(any(unix, target_os = "wasi"))]
+impl AsRef<FilePath> for OsStr {
+    fn as_ref(&self) -> &FilePath {
+        self.as_bytes().as_ref()
+    }
+}
+
+#[cfg(any(unix, target_os = "wasi"))]
+impl AsRef<FilePath> for std::path::Path {
+    fn as_ref(&self) -> &FilePath {
+        self.as_os_str().as_ref()
+    }
+}
+
+impl AsRef<[u8]> for FilePath {
+    fn as_ref(&self) -> &[u8] {
+        #[cfg(windows)]
+        {
+            self.0.as_ref()
+        }
+
+        #[cfg(not(windows))]
+        {
+            &self.0
+        }
+    }
+}
+
+#[cfg(any(windows, unix, target_os = "wasi"))]
+impl AsRef<OsStr> for FilePath {
+    fn as_ref(&self) -> &OsStr {
+        #[cfg(any(windows))]
+        {
+            self.0.as_ref()
+        }
+
+        #[cfg(any(unix, target_os = "wasi"))]
+        {
+            OsStr::from_bytes(&self.0)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub mod display_list;
 pub mod document;
 /// Easy creation of new documents
 pub mod document_writer;
+/// File paths
+pub mod file_path;
 /// Font
 pub mod font;
 /// Glyph
@@ -87,6 +89,7 @@ pub use document::{Document, MetadataName};
 pub use document_writer::DocumentWriter;
 pub(crate) use error::ffi_error;
 pub use error::Error;
+pub use file_path::FilePath;
 pub use font::{CjkFontOrdering, Font, SimpleFontEncoding, WriteMode};
 pub use glyph::Glyph;
 pub use image::Image;

--- a/tests/test_issues.rs
+++ b/tests/test_issues.rs
@@ -1,6 +1,9 @@
 use mupdf::pdf::PdfDocument;
 use mupdf::{Colorspace, Error, ImageFormat, Matrix, TextPageOptions};
 
+#[cfg(feature = "serde")]
+use mupdf::page::StextPage;
+
 #[test]
 fn test_issue_16_pixmap_to_png() {
     let document = PdfDocument::open("tests/files/dummy.pdf").unwrap();

--- a/tests/test_issues.rs
+++ b/tests/test_issues.rs
@@ -1,4 +1,3 @@
-use mupdf::page::StextPage;
 use mupdf::pdf::PdfDocument;
 use mupdf::{Colorspace, Error, ImageFormat, Matrix, TextPageOptions};
 


### PR DESCRIPTION
This creates a `FilePath` newtype, as mupdf requires paths to be UTF-8 on windows.

It supports `AsRef`ing from:
 - `str` on all platforms
 - `[u8]` on all platforms, but windows
 - `OsStr` and `Path` on unix and wasi

On top of that `Debug` is implemented and  `TryFrom` is implemented for `OsStr` and `Path`.

Thanks to @kirawi for discovering this limitation of mupdf and implementing it in mupdf-rs in #122.