### PR TITLE
Update to mupdf v1.26.0-rc1 and fix leak

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -80,7 +80,7 @@ impl Font {
                 context(),
                 c_name.as_ptr(),
                 index,
-                buffer.into_inner()
+                buffer.inner
             ))
         }
         .map(|inner| Self { inner })

--- a/src/stroke_state.rs
+++ b/src/stroke_state.rs
@@ -122,8 +122,9 @@ impl StrokeState {
     pub fn dashes(&self) -> Vec<f32> {
         unsafe {
             let dash_len = (*self.inner).dash_len as usize;
+            let dash_ptr = (*self.inner).dash_list.as_ptr();
             let mut dash_list = Vec::with_capacity(dash_len);
-            dash_list.extend_from_slice(&(*self.inner).dash_list[0..dash_len]);
+            dash_list.extend_from_slice(std::slice::from_raw_parts(dash_ptr, dash_len));
             dash_list
         }
     }


### PR DESCRIPTION
This is based on the work done in #129 but up-to-date with main and [fixing the leak ASAN detected](https://github.com/messense/mupdf-rs/pull/129#issuecomment-2846934722).

Currently the tests fail as a `compile_fail` doctest introduced in #121 now compiles on nightly (on stable it still fails). Will investigate later.