### PR TITLE
Refactor mupdf-sys build script

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: 500
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019, windows-2022, windows-2025]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: 500
@@ -52,7 +52,7 @@ jobs:
     name: Test Suite (Emscripten)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: 500
@@ -82,7 +82,7 @@ jobs:
           msystem: ${{matrix.sys}}
           install: mingw-w64-${{matrix.env}}-rust mingw-w64-${{matrix.env}}-clang base base-devel unzip git
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: 500
@@ -94,7 +94,7 @@ jobs:
     name: Address Sanitizer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: 500
@@ -113,7 +113,7 @@ jobs:
     name: Valgrind
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: 500
@@ -128,7 +128,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,7 @@ jobs:
         run: cargo package --manifest-path mupdf-sys/Cargo.toml
 
   test-wasm:
-    name: Test WASM Emscripten
+    name: Test Suite (Emscripten)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 500
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-emscripten
       - uses: mymindstorm/setup-emsdk@v14
 
       - run: cargo test --target wasm32-unknown-emscripten --features serde

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,6 +56,10 @@ jobs:
         with:
           submodules: "recursive"
           fetch-depth: 500
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-emscripten

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,24 +38,30 @@ jobs:
           submodules: "recursive"
           fetch-depth: 500
       - uses: dtolnay/rust-toolchain@stable
+
       - run: sudo apt-get -y install libfontconfig1-dev
         if: matrix.os == 'ubuntu-latest'
-      - name: Install LLVM
-        if: matrix.os == 'windows-2019'
-        run: choco install -y llvm
-      - name: Setup msbuild
-        if: matrix.os == 'windows-2019'
-        uses: microsoft/setup-msbuild@v1.3.1
+
       - run: cargo test --features serde
-        timeout-minutes: 20
-        if: matrix.os == 'windows-2019'
-        env:
-          LIBCLANG_PATH: "C:\\Program Files\\LLVM\\bin"
-      - run: cargo test --features serde
-        if: matrix.os != 'windows-2019'
+
       - name: Test package mupdf-sys
         if: matrix.os == 'ubuntu-latest'
         run: cargo package --manifest-path mupdf-sys/Cargo.toml
+
+  test-wasm:
+    name: Test WASM Emscripten
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+          fetch-depth: 500
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: mymindstorm/setup-emsdk@v14
+
+      - run: cargo test --target wasm32-unknown-emscripten --features serde
 
   test-msys:
     name: Test Suite (MSYS2)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,7 @@ jobs:
           targets: wasm32-unknown-emscripten
       - uses: mymindstorm/setup-emsdk@v14
 
-      - run: cargo test --target wasm32-unknown-emscripten --features serde
+      - run: cargo test --target wasm32-unknown-emscripten --config "target.wasm32-unknown-emscripten.runner = 'node'" --features serde
 
   test-msys:
     name: Test Suite (MSYS2)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,8 @@ bitflags = "2.0.2"
 serde = { version = "1.0.201", features = ["derive"], optional = true }
 zerocopy = { version = "0.8.17", features = ["derive"] }
 
-[dependencies.font-kit]
-version = "0.14.1"
-optional = true
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+font-kit = { version = "0.14.1", optional = true }
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/messense/mupdf-rs"
 
 [features]
-default = ["js", "xps", "svg", "cbz", "img", "html", "epub", "system-fonts", "tesseract"]
+default = ["js", "xps", "svg", "cbz", "img", "html", "epub", "system-fonts"]
 
 # Use system libs for all thirdparty libs
 sys-lib = ["mupdf-sys/sys-lib"]
@@ -58,7 +58,7 @@ libarchive = ["mupdf-sys/libarchive"]
 serde = ["dep:serde"]
 
 [dependencies]
-mupdf-sys = { version = "0.5.0", path = "mupdf-sys" }
+mupdf-sys = { version = "0.5.0", path = "mupdf-sys", features = ["zerocopy"] }
 once_cell = "1.3.1"
 num_enum = "0.7.0"
 bitflags = "2.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/messense/mupdf-rs"
 
 [features]
-default = ["js", "xps", "svg", "cbz", "img", "html", "epub", "system-fonts"]
+default = ["js", "xps", "svg", "cbz", "img", "html", "epub", "system-fonts", "tesseract"]
 
 # Use system libs for all thirdparty libs
 sys-lib = ["mupdf-sys/sys-lib"]

--- a/mupdf-sys/Cargo.toml
+++ b/mupdf-sys/Cargo.toml
@@ -97,6 +97,8 @@ tesseract = []
 zxingcpp = []
 libarchive = []
 
+zerocopy = ["dep:zerocopy"]
+
 [build-dependencies]
 bindgen = { version = "0.71", default-features = false, features = ["runtime"] }
 cc = "1.0.50"
@@ -104,4 +106,5 @@ pkg-config = "0.3"
 regex = "1.11"
 
 [dependencies]
-zerocopy = { version = "0.8.17", features = ["derive"] }
+zerocopy = { version = "0.8.17", features = ["derive"], optional = true }
+

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -62,6 +62,9 @@ fn run() -> Result<()> {
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-changed=wrapper.c");
 
+    #[cfg(feature = "tesseract")]
+    println!("cargo:rustc-flags=-l dylib=c++");
+
     Build::new(&target).run(&target, build_dir)?;
     build_wrapper(&target).map_err(|e| format!("Unable to compile mupdf wrapper:\n  {e}"))?;
 

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -1,6 +1,6 @@
 use std::env::{self, current_dir};
 use std::error::Error;
-use std::fs::remove_dir_all;
+use std::fs::{create_dir, remove_dir_all};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::exit;
@@ -51,6 +51,12 @@ fn run() -> Result<()> {
     if let Err(e) = remove_dir_all(build_dir) {
         if e.kind() != ErrorKind::NotFound {
             println!("cargo:warning=Unable to clear {build_dir:?}. This may lead to flaky builds that might not incorporate configurations changes: {e}");
+        }
+    }
+
+    if let Err(e) = create_dir(build_dir) {
+        if e.kind() != ErrorKind::AlreadyExists {
+            Err(format!("Unable to create {build_dir:?}: {e}"))?;
         }
     }
 

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -1,12 +1,105 @@
-use std::env;
-use std::ffi::OsStr;
-use std::fs;
+use std::env::{self, current_dir};
+use std::error::Error;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::process::exit;
+use std::{fs, result};
+
+mod docs;
+use docs::DocsCallbacks;
+
+#[cfg(not(target_env = "msvc"))]
+mod make;
+#[cfg(not(target_env = "msvc"))]
+use make::Make as BuildTool;
+
+#[cfg(target_env = "msvc")]
+mod msbuild;
+#[cfg(target_env = "msvc")]
+use msbuild::Msbuild as BuildTool;
+
+pub type Result<T> = result::Result<T, Box<dyn Error>>;
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("\n{e}");
+        exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    if fs::read_dir("mupdf").is_ok_and(|d| d.count() == 0) {
+        Err(
+            "The `mupdf` directory is empty, did you forget to pull the submodules?\n\
+            Try `git submodule update --init --recursive`",
+        )?
+    }
+
+    let target = Target::from_cargo().map_err(|e| {
+        format!(
+            "Unable to detect target: {e}\n\
+            Cargo is required to build mupdf"
+        )
+    })?;
+
+    let src_dir = current_dir().unwrap().join("mupdf");
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
+    let build_dir = out_dir.join("build");
+    let build_dir = build_dir.to_str().ok_or_else(|| {
+        format!("Build dir path is required to be valid UTF-8, got {build_dir:?}")
+    })?;
+
+    println!("cargo:rerun-if-changed=wrapper.h");
+    println!("cargo:rerun-if-changed=wrapper.c");
+
+    Build::default().run(&target, &src_dir, build_dir)?;
+    build_wrapper(&target).map_err(|e| format!("Unable to compile mupdf wrapper:\n  {e}"))?;
+
+    generate_bindings(&out_dir.join("bindings.rs"))
+        .map_err(|e| format!("Unable to generate mupdf bindings using bindgen:\n  {e}"))?;
+
+    Ok(())
+}
+
+fn build_wrapper(target: &Target) -> Result<()> {
+    let mut build = cc::Build::new();
+    build.file("wrapper.c").include("mupdf/include");
+    if target.os == "android" {
+        build.define("HAVE_ANDROID", None);
+    }
+    build.try_compile("mupdf-wrapper")?;
+    Ok(())
+}
+
+fn generate_bindings(path: &Path) -> Result<()> {
+    let builder = bindgen::builder()
+        .clang_arg("-Imupdf/include")
+        .header("wrapper.h")
+        .header("wrapper.c")
+        .allowlist_item("fz_.*")
+        .allowlist_item("FZ_.*")
+        .allowlist_item("pdf_.*")
+        .allowlist_item("PDF_.*")
+        .allowlist_item("ucdn_.*")
+        .allowlist_item("UCDN_.*")
+        .allowlist_item("Memento_.*")
+        .allowlist_item("mupdf_.*")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .parse_callbacks(Box::new(DocsCallbacks::default()));
+
+    #[cfg(feature = "zerocopy")]
+    let builder = builder.parse_callbacks(Box::new(ZerocopyDeriveCallbacks));
+
+    builder
+        .size_t_is_usize(true)
+        .generate()?
+        .write_to_file(path)?;
+
+    Ok(())
+}
 
 // see https://github.com/ArtifexSoftware/mupdf/blob/master/source/fitz/noto.c
-#[cfg(not(feature = "all-fonts"))]
-const SKIP_FONTS: [&str; 6] = [
+const FONTS: [&str; 6] = [
     "TOFU",
     "TOFU_CJK",
     "TOFU_NOTO",
@@ -15,548 +108,93 @@ const SKIP_FONTS: [&str; 6] = [
     "TOFU_SIL",
 ];
 
-macro_rules! t {
-    ($e:expr ) => {
-        match $e {
-            Ok(n) => n,
-            Err(e) => panic!("\n{} failed with {}\n", stringify!($e), e),
-        }
-    };
+#[derive(Default)]
+struct Build {
+    tool: BuildTool,
 }
 
-fn cp_r(dir: &Path, dest: &Path, excluding_dir_names: &'static [&'static str]) {
-    for entry in t!(fs::read_dir(dir)) {
-        let entry = t!(entry);
-        let path = entry.path();
-        let dst = dest.join(path.file_name().expect("Failed to get filename of path"));
-        if t!(fs::metadata(&path)).is_file() {
-            fs::copy(&path, &dst)
-                .unwrap_or_else(|e| panic!("Couldn't fs::copy {path:?} to {dst:?}: {e}"));
-        } else if path
-            .file_name()
-            .and_then(OsStr::to_str)
-            .is_none_or(|dst| !excluding_dir_names.contains(&dst))
-        {
-            t!(fs::create_dir_all(&dst));
-            cp_r(&path, &dst, excluding_dir_names);
-        }
-    }
-}
-
-const CPU_FLAGS: &[(&str, &str, &str, Option<&str>)] = &[
-    ("sse4.1", "-msse4.1", "HAVE_SSE4_1", Some("ARCH_HAS_SSE")),
-    ("avx", "-mavx", "HAVE_AVX", None),
-    ("avx2", "-mavx2", "HAVE_AVX2", None),
-    ("fma", "-mfma", "HAVE_FMA", None),
-    ("neon", "-mfpu=neon", "HAVE_NEON", Some("ARCH_HAS_NEON")),
-];
-
-#[cfg(not(target_env = "msvc"))]
-fn build_libmupdf() {
-    use std::process::Command;
-
-    let features_var =
-        std::env::var("CARGO_CFG_TARGET_FEATURE").expect("We need cargo to build this");
-    let target_features = features_var.split(',').collect::<Vec<_>>();
-
-    let profile = match &*env::var("PROFILE").unwrap_or("debug".to_owned()) {
-        "bench" | "release" => "release",
-        _ => "debug",
-    };
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let build_dir = out_dir.join("build");
-    t!(fs::create_dir_all(&build_dir));
-
-    // workaround for windows gnu toolchain, path separator is `/` but not `\`
-    let build_dir_str = build_dir.to_string_lossy().replace("\\", "/");
-
-    let current_dir = env::current_dir().unwrap();
-    let mupdf_src_dir = current_dir.join("mupdf");
-    cp_r(&mupdf_src_dir, &build_dir, &[".git"]);
-
-    let mut build = cc::Build::new();
-    #[cfg(not(feature = "xps"))]
-    build.define("FZ_ENABLE_XPS", Some("0"));
-    #[cfg(not(feature = "svg"))]
-    build.define("FZ_ENABLE_SVG", Some("0"));
-    #[cfg(not(feature = "cbz"))]
-    build.define("FZ_ENABLE_CBZ", Some("0"));
-    #[cfg(not(feature = "img"))]
-    build.define("FZ_ENABLE_IMG", Some("0"));
-    #[cfg(not(feature = "html"))]
-    build.define("FZ_ENABLE_HTML", Some("0"));
-    #[cfg(not(feature = "epub"))]
-    build.define("FZ_ENABLE_EPUB", Some("0"));
-    #[cfg(not(feature = "js"))]
-    build.define("FZ_ENABLE_JS", Some("0"));
-
-    #[cfg(not(feature = "all-fonts"))]
-    SKIP_FONTS.iter().for_each(|font| {
-        build.define(font, None);
-    });
-
-    let mut make_flags = vec![
-        "libs".to_owned(),
-        format!("build={}", profile),
-        format!("OUT={}", &build_dir_str),
-        #[cfg(not(feature = "tesseract"))]
-        "USE_TESSERACT=no".to_owned(),
-        #[cfg(not(feature = "libarchive"))]
-        "USE_LIBARCHIVE=no".to_owned(),
-        #[cfg(not(feature = "zxingcpp"))]
-        "USE_ZXINGCPP=no".to_owned(),
-        #[cfg(feature = "sys-lib")]
-        "USE_SYSTEM_LIBS=yes".to_owned(),
-        "HAVE_X11=no".to_owned(),
-        "HAVE_GLUT=no".to_owned(),
-        "HAVE_CURL=no".to_owned(),
-        "verbose=yes".to_owned(),
-    ];
-
-    for (feature, flag, make_flag, define) in CPU_FLAGS {
-        let contains = target_features.contains(feature);
-        if contains {
-            build.flag_if_supported(flag);
-
-            make_flags.push(format!("{make_flag}=yes"));
-        }
-
-        if let Some(define) = define {
-            build.define(define, if contains { "1" } else { "0" });
-        }
+impl Build {
+    fn define_bool(&mut self, var: &str, val: bool) {
+        self.tool.define(var, if val { "1" } else { "0" });
     }
 
-    // this may be unused if none of the features below are enabled
-    #[allow(unused_variables, unused_mut)]
-    let mut add_lib = |cflags_name: &'static str, pkgcfg_names: &[&str]| {
-        make_flags.push(format!("USE_SYSTEM_{cflags_name}=yes"));
-        for pkgcfg_name in pkgcfg_names {
-            let cflags = pkg_config::probe_library(pkgcfg_name)
-                .unwrap()
-                .include_paths
-                .iter()
-                .map(|p| format!("-I{}", p.display()))
-                .collect::<Vec<_>>()
-                .join(" ");
-            make_flags.push(format!("SYS_{cflags_name}_CFLAGS={cflags}"));
-        }
-    };
-
-    #[cfg(any(feature = "sys-lib", feature = "sys-lib-freetype"))]
-    add_lib("FREETYPE", &["freetype2"]);
-
-    #[cfg(any(feature = "sys-lib", feature = "sys-lib-gumbo"))]
-    add_lib("GUMBO", &["gumbo"]);
-
-    #[cfg(any(feature = "sys-lib", feature = "sys-lib-harfbuzz"))]
-    add_lib("HARFBUZZ", &["harfbuzz"]);
-
-    #[cfg(any(feature = "sys-lib", feature = "sys-lib-jbig2dec"))]
-    add_lib("JBIG2DEC", &["jbig2dec"]);
-
-    // Exluded from sys-lib feature
-    #[cfg(feature = "sys-lib-jpegxr")]
-    add_lib("JPEGXR", &["jpegxr"]);
-
-    // Exluded from sys-lib feature
-    #[cfg(feature = "sys-lib-lcms2")]
-    add_lib("LCMS2", &["lcms2"]);
-
-    #[cfg(any(feature = "sys-lib", feature = "sys-lib-libjpeg"))]
-    add_lib("LIBJPEG", &["libjpeg"]);
-
-    #[cfg(any(feature = "sys-lib", feature = "sys-lib-openjpeg"))]
-    add_lib("OPENJPEG", &["libopenjp2"]);
-
-    #[cfg(any(feature = "sys-lib", feature = "sys-lib-zlib"))]
-    add_lib("ZLIB", &["zlib"]);
-
-    #[cfg(feature = "tesseract")]
-    {
-        #[cfg(any(feature = "sys-lib", feature = "sys-lib-leptonica"))]
-        add_lib("LEPTONICA", &["lept"]);
-
-        #[cfg(any(feature = "sys-lib", feature = "sys-lib-tesseract"))]
-        add_lib("TESSERACT", &["tesseract"]);
+    fn fz_enable(&mut self, name: &str, enable: bool) {
+        self.define_bool(&format!("FZ_ENABLE_{name}"), enable);
     }
 
-    #[cfg(all(
-        feature = "zxingcpp",
-        any(feature = "sys-lib", feature = "sys-lib-zxingcpp")
-    ))]
-    // zint is required as well, but it (or distro for that matter,
-    // i checked debian, fedora and arch) distribute a pkg-config file
-    add_lib("ZXINGCPP", &["zxing"]);
+    fn run(mut self, target: &Target, src_dir: &Path, build_dir: &str) -> Result<()> {
+        self.fz_enable("XPS", cfg!(feature = "xps"));
+        self.fz_enable("SVG", cfg!(feature = "svg"));
+        self.fz_enable("CBZ", cfg!(feature = "cbz"));
+        self.fz_enable("IMG", cfg!(feature = "img"));
+        self.fz_enable("HTML", cfg!(feature = "html"));
+        self.fz_enable("EPUB", cfg!(feature = "epub"));
+        self.fz_enable("JS", cfg!(feature = "js"));
 
-    #[cfg(feature = "libarchive")]
-    add_lib("LIBARCHIVE", &["libarchive"]);
-
-    #[cfg(any(feature = "sys-lib", feature = "sys-lib-brotli"))]
-    add_lib("BROTLI", &["libbrotlidec", "libbrotlienc"]);
-
-    // The mupdf Makefile does not do a very good job of detecting
-    // and acting on cross-compilation, so we'll let the `cc` crate do it.
-    let c_compiler = build.get_compiler();
-    let cc = c_compiler.path().to_string_lossy();
-    let c_flags = c_compiler.cflags_env();
-
-    let cxx_compiler = build.cpp(true).get_compiler();
-    let cxx = cxx_compiler.path().to_string_lossy();
-    let cxx_flags = cxx_compiler.cflags_env();
-
-    make_flags.push(format!("CC={}", cc));
-    make_flags.push(format!("CXX={}", cxx));
-    make_flags.push(format!("XCFLAGS={}", c_flags.to_string_lossy()));
-    make_flags.push(format!("XCXXFLAGS={}", cxx_flags.to_string_lossy(),));
-
-    // println!("cargo::warning=using make_flags {make_flags:?}");
-
-    // Enable parallel compilation
-    if let Ok(n) = std::thread::available_parallelism() {
-        make_flags.push(format!("-j{}", n));
-    }
-
-    let make = if cfg!(any(
-        target_os = "freebsd",
-        target_os = "openbsd",
-        target_os = "netbsd"
-    )) {
-        "gmake"
-    } else {
-        "make"
-    };
-    let output = Command::new(make)
-        .args(&make_flags)
-        .current_dir(&build_dir_str)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .output()
-        .expect("make failed");
-    if !output.status.success() {
-        panic!("Build error, exit code {}", output.status.code().unwrap());
-    }
-    println!("cargo:rustc-link-search=native={}", &build_dir_str);
-    println!("cargo:rustc-link-lib=static=mupdf");
-    // println!("cargo:rustc-link-lib=static=mupdf-pkcs7");
-    println!("cargo:rustc-link-lib=static=mupdf-third");
-    // println!("cargo:rustc-link-lib=static=mupdf-threads");
-}
-
-#[cfg(target_env = "msvc")]
-fn build_libmupdf() {
-    use cc::windows_registry::find_vs_version;
-
-    // Patch geometry.c to compile on vs 2022
-    let file_path = "mupdf/source/fitz/geometry.c";
-    let content = fs::read_to_string(file_path).expect("Failed to read geometry.c file");
-    let patched_content = content.replace("NAN", "(0.0/0.0)");
-    fs::write(file_path, patched_content).expect("Failed to write patched geometry.c file");
-
-    let target = env::var("TARGET").expect("TARGET not found in environment");
-    let msvc_platform = if target.contains("x86_64") {
-        "x64"
-    } else {
-        "Win32"
-    };
-    let profile = match &*env::var("PROFILE").unwrap_or("debug".to_owned()) {
-        "bench" | "release" => "Release",
-        _ => "Debug",
-    };
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let build_dir = out_dir.join("build");
-    t!(fs::create_dir_all(&build_dir));
-
-    let current_dir = env::current_dir().unwrap();
-    let mupdf_src_dir = current_dir.join("mupdf");
-    cp_r(&mupdf_src_dir, &build_dir, &[".git"]);
-
-    let msbuild = cc::windows_registry::find(target.as_str(), "msbuild.exe");
-    if let Some(mut msbuild) = msbuild {
-        let mut cl_env = Vec::new();
-        if !cfg!(feature = "all-fonts") {
-            for font in &SKIP_FONTS {
-                cl_env.push(format!("/D{}", font));
-            }
-        }
-        if cfg!(not(feature = "xps")) {
-            cl_env.push("/DFZ_ENABLE_XPS#0".to_string());
-        }
-        if cfg!(not(feature = "svg")) {
-            cl_env.push("/DFZ_ENABLE_SVG#0".to_string());
-        }
-        if cfg!(not(feature = "cbz")) {
-            cl_env.push("/DFZ_ENABLE_CBZ#0".to_string());
-        }
-        if cfg!(not(feature = "img")) {
-            cl_env.push("/DFZ_ENABLE_IMG#0".to_string());
-        }
-        if cfg!(not(feature = "html")) {
-            cl_env.push("/DFZ_ENABLE_HTML#0".to_string());
-        }
-        if cfg!(not(feature = "epub")) {
-            cl_env.push("/DFZ_ENABLE_EPUB#0".to_string());
-        }
-        if cfg!(not(feature = "js")) {
-            cl_env.push("/DFZ_ENABLE_JS#0".to_string());
+        for font in &FONTS {
+            self.define_bool(font, cfg!(feature = "all-fonts"));
         }
 
-        // Enable parallel compilation
-        cl_env.push("/MP".to_string());
-        let platform_toolset = env::var("MUPDF_MSVC_PLATFORM_TOOLSET").unwrap_or(
-            (match find_vs_version() {
-                Ok(cc::windows_registry::VsVers::Vs17) => "v143",
-                _ => "v142",
-            })
-            .to_string(),
-        );
-        let d = msbuild
-            .args(&[
-                "platform\\win32\\mupdf.sln",
-                "/target:libmupdf",
-                &format!("/p:Configuration={}", profile),
-                &format!("/p:Platform={}", msvc_platform),
-                &format!("/p:PlatformToolset={}", platform_toolset),
-            ])
-            .current_dir(&build_dir)
-            .env("CL", cl_env.join(" "))
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .output()
-            .expect("failed to run msbuild. Do you have it installed?");
-        if !d.status.success() {
-            let err = String::from_utf8_lossy(&d.stderr);
-            let out = String::from_utf8_lossy(&d.stdout);
-            panic!("Build error:\nSTDERR:{}\nSTDOUT:{}", err, out);
-        }
-        if msvc_platform == "x64" {
-            println!(
-                "cargo:rustc-link-search=native={}/platform/win32/{}/{}",
-                build_dir.display(),
-                msvc_platform,
-                profile
-            );
-        } else {
-            println!(
-                "cargo:rustc-link-search=native={}/platform/win32/{}",
-                build_dir.display(),
-                profile
-            );
-        }
-
-        if profile == "Debug" {
-            println!("cargo:rustc-link-lib=dylib=ucrtd");
-            println!("cargo:rustc-link-lib=dylib=vcruntimed");
-            println!("cargo:rustc-link-lib=dylib=msvcrtd");
-        }
-
-        println!("cargo:rustc-link-lib=dylib=libmupdf");
-        println!("cargo:rustc-link-lib=dylib=libthirdparty");
-    } else {
-        panic!("failed to find msbuild. Do you have it installed?");
+        self.tool.build(target, src_dir, build_dir)
     }
 }
 
+#[allow(dead_code)]
+struct Target {
+    debug: bool,
+    opt_level: String,
+    arch: String,
+    os: String,
+    features: Vec<String>,
+}
+
+impl Target {
+    fn from_cargo() -> Result<Self> {
+        Ok(Self {
+            debug: env::var_os("DEBUG").is_some_and(|s| s != "0" && s != "false"),
+            opt_level: env::var("OPT_LEVEL")?,
+            arch: env::var("CARGO_CFG_TARGET_ARCH")?,
+            os: env::var("CARGO_CFG_TARGET_OS")?,
+            features: env::var("CARGO_CFG_TARGET_FEATURE")?
+                .split(',')
+                .map(str::to_owned)
+                .collect(),
+        })
+    }
+
+    fn build_profile(&self) -> BuildProfile {
+        match &*self.opt_level {
+            _ if self.debug => BuildProfile::Debug,
+            "2" | "3" => BuildProfile::Release,
+            "s" | "z" => BuildProfile::Small,
+            _ => BuildProfile::Debug,
+        }
+    }
+}
+
+enum BuildProfile {
+    Debug,
+    Release,
+    Small,
+}
+
+#[cfg(feature = "zerocopy")]
 #[derive(Debug)]
-struct Callback {
-    types: regex::Regex,
-    full_names: std::cell::RefCell<std::collections::HashMap<String, String>>,
-}
+struct ZerocopyDeriveCallbacks;
 
-impl Default for Callback {
-    fn default() -> Self {
-        Self {
-            types: regex::RegexBuilder::new("fz_[a-z_*]+")
-                .case_insensitive(true)
-                .build()
-                .unwrap(),
-            full_names: std::cell::RefCell::default(),
-        }
-    }
-}
-
-impl bindgen::callbacks::ParseCallbacks for Callback {
-    fn item_name(&self, original_item_name: &str) -> Option<String> {
-        self.full_names
-            .borrow_mut()
-            .insert(original_item_name.to_owned(), original_item_name.to_owned());
-        None
-    }
-
-    fn enum_variant_name(
-        &self,
-        enum_name: Option<&str>,
-        original_variant_name: &str,
-        _variant_value: bindgen::callbacks::EnumVariantValue,
-    ) -> Option<String> {
-        let enum_name = enum_name?;
-        if enum_name.contains("unnamed at ") {
-            return None;
-        }
-
-        let name = format!("{}_{}", enum_name, original_variant_name);
-        self.full_names
-            .borrow_mut()
-            .insert(original_variant_name.to_owned(), name);
-        None
-    }
-
-    fn process_comment(&self, comment: &str) -> Option<String> {
-        let mut output = String::new();
-        let mut newlines = 0;
-        let mut arguments = false;
-
-        for line in comment.split('\n') {
-            let mut line = line.trim();
-            if line.is_empty() {
-                newlines += 1;
-                continue;
-            }
-
-            let mut argument = false;
-            if let Some(pline) = line.strip_prefix("@param") {
-                line = pline;
-                argument = true;
-            }
-
-            match newlines {
-                _ if argument => output.push('\n'),
-                0 => {}
-                1 => output.push_str("<br>"),
-                _ => output.push_str("\n\n"),
-            };
-            newlines = 0;
-
-            if argument {
-                if !arguments {
-                    output.push_str("# Arguments\n");
-                    arguments = true;
-                }
-                output.push_str("* ");
-            }
-
-            let line = line
-                .replace('[', "\\[")
-                .replace(']', "\\]")
-                .replace('<', "\\<")
-                .replace('>', "\\>")
-                .replace("NULL", "`NULL`");
-            let mut line = self.types.replace_all(&line, |c: &regex::Captures| {
-                let name = &c[0];
-                if name.contains('*') {
-                    return format!("`{}`", name);
-                }
-
-                let full_names = self.full_names.borrow();
-                if let Some(full_name) = full_names.get(name) {
-                    return format!("[`{}`]({})", name, full_name);
-                }
-
-                if let Some(short_name) = name.strip_suffix("s") {
-                    if let Some(full_name) = full_names.get(short_name) {
-                        return format!("[`{}`]({})s", short_name, full_name);
-                    }
-                }
-
-                format!("[`{}`]", name)
-            });
-
-            if let Some((first, rest)) = line.split_once(": ") {
-                let mut new_line = String::new();
-
-                for arg in first.split(", ") {
-                    if arg.contains(|c: char| c.is_whitespace() || c == '`') {
-                        new_line.clear();
-                        break;
-                    }
-
-                    if !new_line.is_empty() {
-                        new_line.push_str(", ");
-                    }
-                    new_line.push('`');
-                    new_line.push_str(arg);
-                    new_line.push('`');
-                }
-
-                if !new_line.is_empty() {
-                    new_line.push_str(": ");
-                    new_line.push_str(rest);
-                    line = new_line.into();
-                }
-            }
-
-            output.push_str(&line);
-
-            newlines += 1;
-        }
-        Some(output)
-    }
-
+#[cfg(feature = "zerocopy")]
+impl bindgen::callbacks::ParseCallbacks for ZerocopyDeriveCallbacks {
     fn add_derives(&self, info: &bindgen::callbacks::DeriveInfo<'_>) -> Vec<String> {
-        static ZEROCOPY_TYPES: [&str; 2] = ["fz_point", "fz_quad"];
+        const TYPES: [&str; 2] = ["fz_point", "fz_quad"];
 
-        if ZEROCOPY_TYPES.contains(&info.name) {
-            [
-                "zerocopy::FromBytes",
-                "zerocopy::IntoBytes",
-                "zerocopy::Immutable",
+        if TYPES.contains(&info.name) {
+            vec![
+                "zerocopy::FromBytes".to_owned(),
+                "zerocopy::IntoBytes".to_owned(),
+                "zerocopy::Immutable".to_owned(),
             ]
-            .into_iter()
-            .map(ToString::to_string)
-            .collect()
         } else {
             vec![]
         }
     }
-}
-
-fn main() {
-    if fs::read_dir("mupdf").map_or(true, |d| d.count() == 0) {
-        println!("The `mupdf` directory is empty, did you forget to pull the submodules?");
-        println!("Try `git submodule update --init --recursive`");
-        panic!();
-    }
-
-    println!("cargo:rerun-if-changed=wrapper.h");
-    println!("cargo:rerun-if-changed=wrapper.c");
-
-    build_libmupdf();
-
-    let mut build = cc::Build::new();
-    build.file("wrapper.c").include("./mupdf/include");
-    if cfg!(target_os = "android") {
-        build.flag("-DHAVE_ANDROID").flag_if_supported("-std=c99");
-    }
-    #[cfg(target_arch = "x86_64")]
-    {
-        build.flag("-DARCH_HAS_SSE=1");
-    }
-    build.compile("libmupdf-wrapper.a");
-
-    let bindings = bindgen::Builder::default()
-        .clang_arg("-I./mupdf/include")
-        .header("wrapper.h")
-        .header("wrapper.c")
-        .allowlist_function("fz_.*")
-        .allowlist_function("pdf_.*")
-        .allowlist_function("ucdn_.*")
-        .allowlist_function("Memento_.*")
-        .allowlist_function("mupdf_.*")
-        .allowlist_type("fz_.*")
-        .allowlist_type("pdf_.*")
-        .allowlist_var("fz_.*")
-        .allowlist_var("FZ_.*")
-        .allowlist_var("pdf_.*")
-        .allowlist_var("PDF_.*")
-        .allowlist_var("UCDN_.*")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        .parse_callbacks(Box::new(Callback::default()))
-        .size_t_is_usize(true)
-        .generate()
-        .expect("Unable to generate bindings");
-
-    // Write the bindings to the $OUT_DIR/bindings.rs file.
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
 }

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -62,9 +62,6 @@ fn run() -> Result<()> {
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-changed=wrapper.c");
 
-    #[cfg(feature = "tesseract")]
-    println!("cargo:rustc-flags=-l dylib=c++");
-
     Build::new(&target).run(&target, build_dir)?;
     build_wrapper(&target).map_err(|e| format!("Unable to compile mupdf wrapper:\n  {e}"))?;
 

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -138,7 +138,7 @@ fn find_clang_sysroot(target: &Target) -> Result<Option<String>> {
                 "Using emscripten requires the EMSDK environment variable to be set".to_owned()
             }
             _ => {
-                format!("Invalid EMSDK environment variable: {}", e)
+                format!("Invalid EMSDK environment variable: {e}")
             }
         })?;
 

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -1,6 +1,7 @@
 use std::env::{self, current_dir};
 use std::error::Error;
 use std::fs::remove_dir_all;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::{fs, result};
@@ -48,10 +49,9 @@ fn run() -> Result<()> {
     })?;
 
     if let Err(e) = remove_dir_all(build_dir) {
-        println!(
-            "cargo:warning=Unable to clear {:?}. This may lead to flaky builds that might not incorporate configurations changes: {e}",
-            build_dir
-        );
+        if e.kind() != ErrorKind::NotFound {
+            println!("cargo:warning=Unable to clear {build_dir:?}. This may lead to flaky builds that might not incorporate configurations changes: {e}");
+        }
     }
 
     println!("cargo:rerun-if-changed=wrapper.h");

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -52,9 +52,9 @@ fn copy_recursive(src: &Path, dst: &Path, ignore: &[&OsStr]) -> Result<()> {
             let err = std::os::unix::fs::symlink(&link, &dst_path);
             #[cfg(windows)]
             let err = if file_type.is_dir() {
-                std::os::windows::fs::symlink_dir(&link, &dst_path);
+                std::os::windows::fs::symlink_dir(&link, &dst_path)
             } else {
-                std::os::windows::fs::symlink_file(&link, &dst_path);
+                std::os::windows::fs::symlink_file(&link, &dst_path)
             };
 
             match err {
@@ -69,7 +69,7 @@ fn copy_recursive(src: &Path, dst: &Path, ignore: &[&OsStr]) -> Result<()> {
             fs::copy(&src_path, &dst_path)
                 .map_err(|e| format!("Couldn't copy {src_path:?} to {dst_path:?}: {e}"))?;
         } else {
-            copy_recursive(&*src_path, &*dst_path, ignore)?;
+            copy_recursive(&src_path, &dst_path, ignore)?;
         }
     }
     Ok(())
@@ -105,7 +105,7 @@ fn run() -> Result<()> {
         }
     }
 
-    copy_recursive(&*src_dir, build_dir.as_ref(), &[".git".as_ref()])?;
+    copy_recursive(&src_dir, build_dir.as_ref(), &[".git".as_ref()])?;
 
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-changed=wrapper.c");

--- a/mupdf-sys/docs.rs
+++ b/mupdf-sys/docs.rs
@@ -40,7 +40,7 @@ impl ParseCallbacks for DocsCallbacks {
             return None;
         }
 
-        let name = format!("{}_{}", enum_name, original_variant_name);
+        let name = format!("{enum_name}_{original_variant_name}");
         self.full_names
             .borrow_mut()
             .insert(original_variant_name.to_owned(), name);
@@ -90,21 +90,21 @@ impl ParseCallbacks for DocsCallbacks {
             let mut line = self.types.replace_all(&line, |c: &regex::Captures| {
                 let name = &c[0];
                 if name.contains('*') {
-                    return format!("`{}`", name);
+                    return format!("`{name}`");
                 }
 
                 let full_names = self.full_names.borrow();
                 if let Some(full_name) = full_names.get(name) {
-                    return format!("[`{}`]({})", name, full_name);
+                    return format!("[`{name}`]({full_name})");
                 }
 
                 if let Some(short_name) = name.strip_suffix("s") {
                     if let Some(full_name) = full_names.get(short_name) {
-                        return format!("[`{}`]({})s", short_name, full_name);
+                        return format!("[`{short_name}`]({full_name})s");
                     }
                 }
 
-                format!("[`{}`]", name)
+                format!("[`{name}`]")
             });
 
             if let Some((first, rest)) = line.split_once(": ") {

--- a/mupdf-sys/docs.rs
+++ b/mupdf-sys/docs.rs
@@ -1,0 +1,140 @@
+use std::{cell::RefCell, collections::HashMap};
+
+use bindgen::callbacks::{EnumVariantValue, ParseCallbacks};
+use regex::{Regex, RegexBuilder};
+
+#[derive(Debug)]
+pub struct DocsCallbacks {
+    types: Regex,
+    full_names: RefCell<HashMap<String, String>>,
+}
+
+impl Default for DocsCallbacks {
+    fn default() -> Self {
+        Self {
+            types: RegexBuilder::new("fz_[a-z_*]+")
+                .case_insensitive(true)
+                .build()
+                .unwrap(),
+            full_names: RefCell::default(),
+        }
+    }
+}
+
+impl ParseCallbacks for DocsCallbacks {
+    fn item_name(&self, original_item_name: &str) -> Option<String> {
+        self.full_names
+            .borrow_mut()
+            .insert(original_item_name.to_owned(), original_item_name.to_owned());
+        None
+    }
+
+    fn enum_variant_name(
+        &self,
+        enum_name: Option<&str>,
+        original_variant_name: &str,
+        _variant_value: EnumVariantValue,
+    ) -> Option<String> {
+        let enum_name = enum_name?;
+        if enum_name.contains("unnamed at ") {
+            return None;
+        }
+
+        let name = format!("{}_{}", enum_name, original_variant_name);
+        self.full_names
+            .borrow_mut()
+            .insert(original_variant_name.to_owned(), name);
+        None
+    }
+
+    fn process_comment(&self, comment: &str) -> Option<String> {
+        let mut output = String::new();
+        let mut newlines = 0;
+        let mut arguments = false;
+
+        for line in comment.split('\n') {
+            let mut line = line.trim();
+            if line.is_empty() {
+                newlines += 1;
+                continue;
+            }
+
+            let mut argument = false;
+            if let Some(pline) = line.strip_prefix("@param") {
+                line = pline;
+                argument = true;
+            }
+
+            match newlines {
+                _ if argument => output.push('\n'),
+                0 => {}
+                1 => output.push_str("<br>"),
+                _ => output.push_str("\n\n"),
+            };
+            newlines = 0;
+
+            if argument {
+                if !arguments {
+                    output.push_str("# Arguments\n");
+                    arguments = true;
+                }
+                output.push_str("* ");
+            }
+
+            let line = line
+                .replace('[', "\\[")
+                .replace(']', "\\]")
+                .replace('<', "\\<")
+                .replace('>', "\\>")
+                .replace("NULL", "`NULL`");
+            let mut line = self.types.replace_all(&line, |c: &regex::Captures| {
+                let name = &c[0];
+                if name.contains('*') {
+                    return format!("`{}`", name);
+                }
+
+                let full_names = self.full_names.borrow();
+                if let Some(full_name) = full_names.get(name) {
+                    return format!("[`{}`]({})", name, full_name);
+                }
+
+                if let Some(short_name) = name.strip_suffix("s") {
+                    if let Some(full_name) = full_names.get(short_name) {
+                        return format!("[`{}`]({})s", short_name, full_name);
+                    }
+                }
+
+                format!("[`{}`]", name)
+            });
+
+            if let Some((first, rest)) = line.split_once(": ") {
+                let mut new_line = String::new();
+
+                for arg in first.split(", ") {
+                    if arg.contains(|c: char| c.is_whitespace() || c == '`') {
+                        new_line.clear();
+                        break;
+                    }
+
+                    if !new_line.is_empty() {
+                        new_line.push_str(", ");
+                    }
+                    new_line.push('`');
+                    new_line.push_str(arg);
+                    new_line.push('`');
+                }
+
+                if !new_line.is_empty() {
+                    new_line.push_str(": ");
+                    new_line.push_str(rest);
+                    line = new_line.into();
+                }
+            }
+
+            output.push_str(&line);
+
+            newlines += 1;
+        }
+        Some(output)
+    }
+}

--- a/mupdf-sys/make.rs
+++ b/mupdf-sys/make.rs
@@ -242,6 +242,13 @@ impl Make {
             })?;
         }
 
+        #[cfg(feature = "tesseract")]
+        if target.os == "macos" {
+            println!("cargo:rustc-link-lib=c++");
+        } else {
+            println!("cargo:rustc-link-lib=stdc++");
+        }
+
         println!("cargo:rustc-link-search=native={build_dir}");
         println!("cargo:rustc-link-lib=static=mupdf");
         println!("cargo:rustc-link-lib=static=mupdf-third");

--- a/mupdf-sys/make.rs
+++ b/mupdf-sys/make.rs
@@ -1,0 +1,241 @@
+use std::{
+    env,
+    ffi::{OsStr, OsString},
+    path::Path,
+    process::Command,
+    thread::available_parallelism,
+};
+
+use crate::{BuildProfile, Result, Target};
+
+#[derive(Default)]
+pub struct Make {
+    build: cc::Build,
+    make_flags: Vec<OsString>,
+}
+
+#[derive(PartialEq)]
+enum SystemLib {
+    Always,
+    Libs,
+    Explicit,
+}
+
+impl Make {
+    pub fn define(&mut self, var: &str, val: &str) {
+        self.build.define(var, val);
+    }
+
+    fn make_var(&mut self, var: &str, val: impl AsRef<OsStr>) {
+        let mut flag = OsString::from(var);
+        flag.push("=");
+        flag.push(val);
+        self.make_flags.push(flag);
+    }
+
+    fn make_bool(&mut self, var: &str, val: bool) {
+        self.make_var(var, if val { "yes" } else { "no" });
+    }
+
+    fn system_lib(
+        &mut self,
+        feature: &str,
+        feature_reason: SystemLib,
+        name: &str,
+        pkg_config_names: &[&str],
+    ) -> Result<()> {
+        self.make_bool(&format!("USE_SYSTEM_{name}"), true);
+
+        let libs_enabled = feature_reason == SystemLib::Libs && cfg!(feature = "sys-lib");
+        let feature_enabled = env::var_os(format!(
+            "CARGO_FEATURE_SYS_LIB_{}",
+            feature.to_ascii_uppercase()
+        ))
+        .is_some();
+        let enabled = feature_reason == SystemLib::Always || libs_enabled || feature_enabled;
+        if !enabled {
+            return Ok(());
+        }
+
+        for pkg_config_name in pkg_config_names {
+            let library = pkg_config::probe_library(pkg_config_name).map_err(|e| {
+                let first_solution = "Install the package in your distribution. If you already have it installed you might be missing the headers included in a `*-dev` or `*-devel` package.";
+
+                let solutions = if feature_reason == SystemLib::Always {
+                    first_solution.to_owned()
+                } else {
+                    format!(
+"You have two ways of solving this problem:
+  1. {first_solution}
+  2. Disable the `sys-lib-{feature}` {}. This might be not what you what though, as it will statically link {pkg_config_name}.",
+                        if libs_enabled { "and `sys-lib` features" } else { "feature" },
+                    )
+                };
+
+                format!("Unable to locate the library `{pkg_config_name}`\n{e}\n{solutions}")
+            })?;
+
+            let mut cflags = OsString::new();
+            for path in library.include_paths {
+                if !cflags.is_empty() {
+                    cflags.push(" ");
+                }
+
+                cflags.push("-I");
+                cflags.push(path);
+            }
+            self.make_var(&format!("SYS_{name}_CFLAGS"), &cflags);
+        }
+
+        Ok(())
+    }
+
+    fn libs(&mut self) -> Result<()> {
+        self.system_lib("freetype", SystemLib::Libs, "FREETYPE", &["freetype2"])?;
+        self.system_lib("gumbo", SystemLib::Libs, "GUMBO", &["gumbo"])?;
+        self.system_lib("harfbuzz", SystemLib::Libs, "HARFBUZZ", &["harfbuzz"])?;
+        self.system_lib("jbig2dec", SystemLib::Libs, "JBIG2DEC", &["jbig2dec"])?;
+        self.system_lib("jpegxr", SystemLib::Explicit, "JPEGXR", &["jpegxr"])?;
+        self.system_lib("lcms2", SystemLib::Explicit, "LCMS2", &["lcms2"])?;
+        self.system_lib("libjpeg", SystemLib::Libs, "LIBJPEG", &["libjpeg"])?;
+        self.system_lib("openjpeg", SystemLib::Libs, "OPENJPEG", &["libopenjp2"])?;
+        self.system_lib("zlib", SystemLib::Libs, "ZLIB", &["zlib"])?;
+
+        self.make_bool("USE_TESSERACT", cfg!(feature = "tesseract"));
+        #[cfg(feature = "tesseract")]
+        {
+            self.system_lib("tesseract", SystemLib::Libs, "LEPTONICA", &["lept"])?;
+            self.system_lib("tesseract", SystemLib::Libs, "TESSERACT", &["tesseract"])?;
+        }
+
+        self.make_bool("USE_ZXINGCPP", cfg!(feature = "zxingcpp"));
+        #[cfg(feature = "zxingcpp")]
+        // zint is required as well, but it (or distro for that matter,
+        // i checked debian, fedora and arch) don't distribute a pkg-config file
+        self.system_lib("zxingcpp", SystemLib::Libs, "ZXINGCPP", &["zxing"])?;
+
+        self.make_bool("USE_LIBARCHIVE", cfg!(feature = "libarchive"));
+        #[cfg(feature = "libarchive")]
+        self.system_lib(
+            "libarchive",
+            SystemLib::Always,
+            "LIBARCHIVE",
+            &["libarchive"],
+        )?;
+
+        self.system_lib(
+            "brotli",
+            SystemLib::Libs,
+            "BROTLI",
+            &["libbrotlidec", "libbrotlienc"],
+        )?;
+
+        Ok(())
+    }
+
+    fn cpu(
+        &mut self,
+        target: &Target,
+        feature: &str,
+        flag: &str,
+        make_flag: &str,
+        define: Option<&str>,
+    ) {
+        let contains = target.features.iter().any(|f| f == feature);
+        if contains {
+            self.build.flag(flag);
+            self.make_bool(make_flag, true);
+        }
+
+        if let Some(define) = define {
+            self.define(define, if contains { "1" } else { "0" });
+        }
+    }
+
+    fn cpus(&mut self, target: &Target) {
+        // x86
+        self.cpu(
+            target,
+            "sse4.1",
+            "-msse4.1",
+            "HAVE_SSE4_1",
+            Some("ARCH_HAS_SSE"),
+        );
+        self.cpu(target, "avx", "-mavx", "HAVE_AVX", None);
+        self.cpu(target, "avx2", "-mavx2", "HAVE_AVX2", None);
+        self.cpu(target, "fma", "-mfma", "HAVE_FMA", None);
+
+        // arm
+        self.cpu(
+            target,
+            "neon",
+            "-mfpu=neon",
+            "HAVE_NEON",
+            Some("ARCH_HAS_NEON"),
+        );
+    }
+
+    pub fn build(mut self, target: &Target, src_dir: &Path, build_dir: &str) -> Result<()> {
+        self.make_var(
+            "build",
+            match target.build_profile() {
+                BuildProfile::Debug => "debug",
+                BuildProfile::Release => "release",
+                BuildProfile::Small => "small",
+            },
+        );
+
+        self.make_var("OUT", build_dir);
+
+        self.make_bool("HAVE_X11", false);
+        self.make_bool("HAVE_GLUT", false);
+        self.make_bool("HAVE_CURL", false);
+
+        self.make_bool("verbose", true);
+
+        self.libs()?;
+        self.cpus(target);
+
+        if let Ok(n) = available_parallelism() {
+            self.make_flags.push(format!("-j{n}").into());
+        }
+
+        let c_compiler = self.build.get_compiler();
+        self.make_var("CC", c_compiler.path());
+        self.make_var("XCFLAGS", c_compiler.cflags_env());
+
+        self.build.cpp(true);
+        let cxx_compiler = self.build.get_compiler();
+        self.make_var("CXX", cxx_compiler.path());
+        self.make_var("XCXXFLAGS", c_compiler.cflags_env());
+
+        let make = if cfg!(any(
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd"
+        )) {
+            "gmake"
+        } else {
+            "make"
+        };
+
+        let status = Command::new(make)
+            .arg("libs")
+            .args(&self.make_flags)
+            .current_dir(src_dir)
+            .status()
+            .map_err(|e| format!("Failed to call {make}: {e}"))?;
+        if !status.success() {
+            Err(match status.code() {
+                Some(code) => format!("{make} invocation failed with status {code}"),
+                None => format!("{make} invocation failed"),
+            })?;
+        }
+
+        println!("cargo:rustc-link-search=native={build_dir}");
+        println!("cargo:rustc-link-lib=static=mupdf");
+        println!("cargo:rustc-link-lib=static=mupdf-third");
+
+        Ok(())
+    }
+}

--- a/mupdf-sys/make.rs
+++ b/mupdf-sys/make.rs
@@ -1,7 +1,6 @@
 use std::{
     env,
     ffi::{OsStr, OsString},
-    path::Path,
     process::Command,
     thread::available_parallelism,
 };
@@ -175,7 +174,7 @@ impl Make {
         );
     }
 
-    pub fn build(mut self, target: &Target, src_dir: &Path, build_dir: &str) -> Result<()> {
+    pub fn build(mut self, target: &Target, build_dir: &str) -> Result<()> {
         #[cfg(windows)]
         let build_dir = &build_dir.replace('\\', "/");
 
@@ -229,7 +228,7 @@ impl Make {
         let status = Command::new(make)
             .arg("libs")
             .args(&self.make_flags)
-            .current_dir(src_dir)
+            .current_dir(build_dir)
             .status()
             .map_err(|e| format!("Failed to call {make}: {e}"))?;
         if !status.success() {

--- a/mupdf-sys/make.rs
+++ b/mupdf-sys/make.rs
@@ -195,6 +195,10 @@ impl Make {
         self.make_bool("HAVE_GLUT", false);
         self.make_bool("HAVE_CURL", false);
 
+        if target.arch == "wasm32" {
+            self.make_bool("HAVE_OBJCOPY", false);
+        }
+
         self.make_bool("verbose", true);
 
         self.libs()?;

--- a/mupdf-sys/make.rs
+++ b/mupdf-sys/make.rs
@@ -6,11 +6,11 @@ use std::{
     thread::available_parallelism,
 };
 
-use crate::{BuildProfile, Result, Target};
+use crate::{Result, Target};
 
 #[derive(Default)]
 pub struct Make {
-    build: cc::Build,
+    build: Box<cc::Build>,
     make_flags: Vec<OsString>,
 }
 
@@ -181,10 +181,12 @@ impl Make {
 
         self.make_var(
             "build",
-            match target.build_profile() {
-                BuildProfile::Debug => "debug",
-                BuildProfile::Release => "release",
-                BuildProfile::Small => "small",
+            if target.small_profile() {
+                "small"
+            } else if target.debug_profile() {
+                "debug"
+            } else {
+                "release"
             },
         );
 

--- a/mupdf-sys/make.rs
+++ b/mupdf-sys/make.rs
@@ -207,14 +207,14 @@ impl Make {
 
         self.build.warnings(false);
 
-        let c_compiler = self.build.get_compiler();
-        self.make_var("CC", c_compiler.path());
-        self.make_var("XCFLAGS", c_compiler.cflags_env());
+        let compiler = self.build.get_compiler();
+        self.make_var("CC", compiler.path());
+        self.make_var("XCFLAGS", compiler.cflags_env());
 
         self.build.cpp(true);
-        let cxx_compiler = self.build.get_compiler();
-        self.make_var("CXX", cxx_compiler.path());
-        self.make_var("XCXXFLAGS", c_compiler.cflags_env());
+        let compiler = self.build.get_compiler();
+        self.make_var("CXX", compiler.path());
+        self.make_var("XCXXFLAGS", compiler.cflags_env());
 
         let make = if cfg!(any(
             target_os = "freebsd",

--- a/mupdf-sys/msbuild.rs
+++ b/mupdf-sys/msbuild.rs
@@ -39,7 +39,7 @@ impl Msbuild {
         };
 
         let Some(mut msbuild) = windows_registry::find(&target.arch, "msbuild.exe") else {
-            Err("Could not find msbuild.exe. Do you have it installed?")?;
+            Err("Could not find msbuild.exe. Do you have it installed?")?
         };
         let status = msbuild
             .args([

--- a/mupdf-sys/msbuild.rs
+++ b/mupdf-sys/msbuild.rs
@@ -49,7 +49,7 @@ impl Msbuild {
             .args([
                 r"platform\win32\mupdf.sln",
                 "/target:libmupdf",
-                &format!("/p:OutputPath={build_dir}"),
+                &format!("/p:OutDir={build_dir}\\"),
                 &format!("/p:Configuration={configuration}"),
                 &format!("/p:Platform={platform}"),
                 &format!("/p:PlatformToolset={platform_toolset}"),

--- a/mupdf-sys/msbuild.rs
+++ b/mupdf-sys/msbuild.rs
@@ -31,10 +31,10 @@ impl Msbuild {
         });
 
         let platform = match &*target.arch {
-            "i686" => "Win32",
+            "i386" | "i586" | "i686" => "Win32",
             "x86_64" => "x64",
             _ => Err("mupdf currently only supports Win32 and x64 with msvc\n\
-                Try compiling using mingw to try other architectures")?,
+                Try compiling using mingw for other architectures")?,
         };
 
         self.cl.push("/MP".to_owned());
@@ -61,15 +61,15 @@ impl Msbuild {
                 None => "msbuild invocation failed".to_owned(),
             })?;
         }
-        match &*target.arch {
-            "i686" => println!("cargo:rustc-link-search=native={build_dir}/platform/win32/{platform}/{configuration}"),
-            "x86_64" => println!(
+        match platform {
+            "Win32" => println!("cargo:rustc-link-search=native={build_dir}/platform/win32/{platform}/{configuration}"),
+            "x64" => println!(
                 "cargo:rustc-link-search=native={build_dir}/platform/win32/{configuration}"
             ),
             _ => {}
         };
 
-        if target.debug_profile() {
+        if configuration == "Debug" {
             println!("cargo:rustc-link-lib=dylib=ucrtd");
             println!("cargo:rustc-link-lib=dylib=vcruntimed");
             println!("cargo:rustc-link-lib=dylib=msvcrtd");

--- a/mupdf-sys/msbuild.rs
+++ b/mupdf-sys/msbuild.rs
@@ -61,10 +61,13 @@ impl Msbuild {
                 None => "msbuild invocation failed".to_owned(),
             })?;
         }
+
         match platform {
-            "Win32" => println!("cargo:rustc-link-search=native={build_dir}/platform/win32/{platform}/{configuration}"),
-            "x64" => println!(
+            "Win32" => println!(
                 "cargo:rustc-link-search=native={build_dir}/platform/win32/{configuration}"
+            ),
+            "x64" => println!(
+                "cargo:rustc-link-search=native={build_dir}/platform/win32/x64/{configuration}"
             ),
             _ => {}
         };

--- a/mupdf-sys/msbuild.rs
+++ b/mupdf-sys/msbuild.rs
@@ -1,4 +1,4 @@
-use std::{env, path::Path};
+use std::env;
 
 use cc::windows_registry::{self, find_vs_version};
 
@@ -14,7 +14,7 @@ impl Msbuild {
         self.cl.push(format!("/D{var}#{val}"));
     }
 
-    pub fn build(mut self, target: &Target, src_dir: &Path, build_dir: &str) -> Result<()> {
+    pub fn build(mut self, target: &Target, build_dir: &str) -> Result<()> {
         let configuration = if target.debug_profile() {
             "Debug"
         } else {
@@ -49,12 +49,11 @@ impl Msbuild {
             .args([
                 r"platform\win32\mupdf.sln",
                 "/target:libmupdf",
-                &format!("/p:OutDir={build_dir}\\"),
                 &format!("/p:Configuration={configuration}"),
                 &format!("/p:Platform={platform}"),
                 &format!("/p:PlatformToolset={platform_toolset}"),
             ])
-            .current_dir(src_dir)
+            .current_dir(build_dir)
             .env("CL", self.cl.join(" "))
             .status()
             .map_err(|e| format!("Failed to call msbuild: {e}"))?;

--- a/mupdf-sys/msbuild.rs
+++ b/mupdf-sys/msbuild.rs
@@ -1,0 +1,83 @@
+use std::{env, path::Path};
+
+use cc::windows_registry::{self, find_vs_version};
+
+use crate::{BuildProfile, Result, Target};
+
+#[derive(Default)]
+pub struct Msbuild {
+    cl: Vec<String>,
+}
+
+impl Msbuild {
+    pub fn define(&mut self, var: &str, val: &str) {
+        self.cl.push(format!("/D{var}#{val}"));
+    }
+
+    pub fn build(self, target: &Target, src_dir: &Path, build_dir: &str) -> Result<()> {
+        let profile = target.build_profile();
+        let configuration = match profile {
+            BuildProfile::Debug => "Debug",
+            BuildProfile::Release => "Release",
+            BuildProfile::Small => "Small",
+        };
+
+        let platform_toolset = env::var("MUPDF_MSVC_PLATFORM_TOOLSET").unwrap_or_else(|_| {
+            if find_vs_version() == Ok(cc::windows_registry::VsVers::Vs17) {
+                "v143"
+            } else {
+                "v142"
+            }
+            .to_owned()
+        });
+
+        let platform = match &*target.arch {
+            "i686" => "Win32",
+            "x86_64" => "x64",
+            _ => Err("mupdf currently only supports Win32 and x64 with msvc\n\
+                Try compiling using mingw to compile for other architectures")?,
+        };
+
+        let Some(mut msbuild) = windows_registry::find(&target.arch, "msbuild.exe") else {
+            Err("Could not find msbuild.exe. Do you have it installed?")?;
+        };
+        let status = msbuild
+            .args([
+                r"platform\win32\mupdf.sln",
+                "/target:libmupdf",
+                &format!("/p:OutputPath={build_dir}"),
+                &format!("/p:Configuration={configuration}"),
+                &format!("/p:Platform={platform}"),
+                &format!("/p:PlatformToolset={platform_toolset}"),
+                "/MP",
+            ])
+            .current_dir(src_dir)
+            .env("CL", self.cl.join(" "))
+            .status()
+            .map_err(|e| format!("Failed to call msbuild: {e}"))?;
+        if !status.success() {
+            Err(match status.code() {
+                Some(code) => format!("msbuild invocation failed with status {code}"),
+                None => "msbuild invocation failed".to_owned(),
+            })?;
+        }
+        match &*target.arch {
+            "i686" => println!("cargo:rustc-link-search=native={build_dir}/platform/win32/{platform}/{configuration}"),
+            "x86_64" => println!(
+                "cargo:rustc-link-search=native={build_dir}/platform/win32/{configuration}"
+            ),
+            _ => {}
+        };
+
+        if matches!(profile, BuildProfile::Debug) {
+            println!("cargo:rustc-link-lib=dylib=ucrtd");
+            println!("cargo:rustc-link-lib=dylib=vcruntimed");
+            println!("cargo:rustc-link-lib=dylib=msvcrtd");
+        }
+
+        println!("cargo:rustc-link-lib=dylib=libmupdf");
+        println!("cargo:rustc-link-lib=dylib=libthirdparty");
+
+        Ok(())
+    }
+}

--- a/mupdf-sys/msbuild.rs
+++ b/mupdf-sys/msbuild.rs
@@ -33,8 +33,11 @@ impl Msbuild {
         let platform = match &*target.arch {
             "i386" | "i586" | "i686" => "Win32",
             "x86_64" => "x64",
-            _ => Err("mupdf currently only supports Win32 and x64 with msvc\n\
-                Try compiling using mingw for other architectures")?,
+            _ => Err(format!(
+                "mupdf currently only supports Win32 and x64 with msvc\n\
+                Try compiling using mingw for potential {:?} support",
+                target.arch,
+            ))?,
         };
 
         self.cl.push("/MP".to_owned());
@@ -62,22 +65,13 @@ impl Msbuild {
             })?;
         }
 
-        match platform {
-            "Win32" => println!(
-                "cargo:rustc-link-search=native={build_dir}/platform/win32/{configuration}"
-            ),
-            "x64" => println!(
-                "cargo:rustc-link-search=native={build_dir}/platform/win32/x64/{configuration}"
-            ),
-            _ => {}
-        };
-
         if configuration == "Debug" {
             println!("cargo:rustc-link-lib=dylib=ucrtd");
             println!("cargo:rustc-link-lib=dylib=vcruntimed");
             println!("cargo:rustc-link-lib=dylib=msvcrtd");
         }
 
+        println!("cargo:rustc-link-search=native={build_dir}");
         println!("cargo:rustc-link-lib=dylib=libmupdf");
         println!("cargo:rustc-link-lib=dylib=libthirdparty");
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -221,6 +221,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::unbuffered_bytes)]
     fn test_buffer_as_bytes() {
         let mut buf = Buffer::new();
         let n = buf.write("abc".as_bytes()).unwrap();

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -99,15 +99,13 @@ impl Buffer {
 
 impl io::Read for Buffer {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.read_bytes(buf)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))
+        self.read_bytes(buf).map_err(io::Error::other)
     }
 }
 
 impl io::Write for Buffer {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.write_bytes(buf)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))
+        self.write_bytes(buf).map_err(io::Error::other)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,7 +11,11 @@ use crate::Error;
 static BASE_CONTEXT: Lazy<Mutex<BaseContext>> = Lazy::new(|| {
     let ctx = unsafe {
         let base_ctx = mupdf_new_base_context();
-        #[cfg(all(not(target_os = "android"), feature = "system-fonts"))]
+        #[cfg(all(
+            not(target_os = "android"),
+            not(target_arch = "wasm32"),
+            feature = "system-fonts"
+        ))]
         {
             use crate::system_font;
             // Android version is written in C

--- a/src/display_list.rs
+++ b/src/display_list.rs
@@ -124,13 +124,13 @@ unsafe impl Sync for DisplayList {}
 
 #[cfg(test)]
 mod test {
-    use crate::Document;
+    use crate::{document::test_document, Document};
 
     #[test]
     fn test_display_list_search() {
         use crate::{Point, Quad};
 
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let list = page0.to_display_list(false).unwrap();
         let hits = list.search("Dummy", 1).unwrap();
@@ -162,10 +162,11 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(target_arch = "wasm32"))]
     fn test_multi_threaded_display_list_search() {
         use crossbeam_utils::thread;
 
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let list = page0.to_display_list(false).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub mod size;
 pub mod stroke_state;
 
 /// System font loading
-#[cfg(feature = "system-fonts")]
+#[cfg(all(feature = "system-fonts", not(target_arch = "wasm32")))]
 pub mod system_font;
 /// Text objects
 pub mod text;

--- a/src/page.rs
+++ b/src/page.rs
@@ -408,7 +408,7 @@ pub struct StextPage {
 
 #[cfg(test)]
 mod test {
-    use crate::{Document, Matrix};
+    use crate::{document::test_document, Document, Matrix};
 
     #[test]
     #[cfg(feature = "serde")]
@@ -445,7 +445,7 @@ mod test {
 
     #[test]
     fn test_page_to_svg() {
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let svg = page0.to_svg(&Matrix::IDENTITY).unwrap();
         assert!(!svg.is_empty());
@@ -453,7 +453,7 @@ mod test {
 
     #[test]
     fn test_page_to_html() {
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let html = page0.to_html().unwrap();
         assert!(!html.is_empty());
@@ -461,7 +461,7 @@ mod test {
 
     #[test]
     fn test_page_to_xhtml() {
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let xhtml = page0.to_xhtml().unwrap();
         assert!(!xhtml.is_empty());
@@ -469,7 +469,7 @@ mod test {
 
     #[test]
     fn test_page_to_xml() {
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let xml = page0.to_xml().unwrap();
         assert!(!xml.is_empty());
@@ -477,7 +477,7 @@ mod test {
 
     #[test]
     fn test_page_to_text() {
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let text = page0.to_text().unwrap();
         assert!(!text.is_empty());
@@ -485,7 +485,7 @@ mod test {
 
     #[test]
     fn test_page_to_display_list() {
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let _dl = page0.to_display_list(true).unwrap();
         let _dl = page0.to_display_list(false).unwrap();
@@ -495,7 +495,7 @@ mod test {
     fn test_page_to_text_page() {
         use crate::TextPageOptions;
 
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let _tp = page0
             .to_text_page(TextPageOptions::PRESERVE_IMAGES)
@@ -506,7 +506,7 @@ mod test {
     fn test_page_links() {
         use crate::Link;
 
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let links_iter = page0.links().unwrap();
         let links: Vec<Link> = links_iter.collect();
@@ -515,7 +515,7 @@ mod test {
 
     #[test]
     fn test_page_separations() {
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let seps = page0.separations().unwrap();
         assert_eq!(seps.len(), 0);
@@ -525,7 +525,7 @@ mod test {
     fn test_page_search() {
         use crate::{Point, Quad};
 
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let hits = page0.search("Dummy", 1).unwrap();
         assert_eq!(hits.len(), 1);

--- a/src/page.rs
+++ b/src/page.rs
@@ -413,12 +413,7 @@ mod test {
     #[test]
     #[cfg(feature = "serde")]
     fn test_get_stext_page_as_json() {
-        let path_to_doc = std::env::current_dir()
-            .unwrap()
-            .join("tests")
-            .join("files")
-            .join("dummy.pdf");
-        let doc = Document::open(path_to_doc.to_str().unwrap()).unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page = doc.load_page(0).unwrap();
         match page.stext_page_as_json_from_page(1.0) {
             Ok(stext_json) => {

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -676,6 +676,8 @@ impl<'a> IntoIterator for &'a PdfDocument {
 
 #[cfg(test)]
 mod test {
+    use crate::document::test_document;
+
     use super::{PdfDocument, PdfWriteOptions, Permission};
 
     #[test]
@@ -695,7 +697,7 @@ mod test {
 
     #[test]
     fn test_open_pdf_document() {
-        let doc = PdfDocument::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("../..", "files/dummy.pdf" as PdfDocument).unwrap();
         assert!(!doc.has_unsaved_changes());
         assert!(!doc.has_acro_form().unwrap());
         assert!(!doc.has_xfa_form().unwrap());
@@ -720,13 +722,8 @@ mod test {
 
     #[test]
     fn test_open_pdf_document_from_bytes() {
-        use std::fs;
-        use std::io::Read;
-
-        let mut bytes = Vec::new();
-        let mut file = fs::File::open("tests/files/dummy.pdf").unwrap();
-        file.read_to_end(&mut bytes).unwrap();
-        let doc = PdfDocument::from_bytes(&bytes).unwrap();
+        let bytes = include_bytes!("../../tests/files/dummy.pdf");
+        let doc = PdfDocument::from_bytes(bytes).unwrap();
         assert!(!doc.needs_password().unwrap());
     }
 
@@ -838,7 +835,7 @@ mod test {
 
     #[test]
     fn test_pdf_document_find_page() {
-        let doc = PdfDocument::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("../..", "files/dummy.pdf" as PdfDocument).unwrap();
         let _page = doc.find_page(0).unwrap();
     }
 }

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -351,7 +351,7 @@ impl Write for PdfObject {
         let mut fz_buf = Buffer::with_capacity(len);
         fz_buf.write(buf)?;
         self.write_stream_buffer(&fz_buf)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+            .map_err(io::Error::other)?;
         Ok(len)
     }
 

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -195,12 +195,13 @@ impl TryFrom<Page> for PdfPage {
 
 #[cfg(test)]
 mod test {
+    use crate::document::test_document;
     use crate::pdf::{PdfAnnotation, PdfDocument, PdfPage};
     use crate::{Matrix, Rect};
 
     #[test]
     fn test_page_properties() {
-        let doc = PdfDocument::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("../..", "files/dummy.pdf" as PdfDocument).unwrap();
         let mut page0 = PdfPage::try_from(doc.load_page(0).unwrap()).unwrap();
 
         // CTM
@@ -232,7 +233,7 @@ mod test {
 
     #[test]
     fn test_page_annotations() {
-        let doc = PdfDocument::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("../..", "files/dummy.pdf" as PdfDocument).unwrap();
         let page0 = PdfPage::try_from(doc.load_page(0).unwrap()).unwrap();
         let annots: Vec<PdfAnnotation> = page0.annotations().collect();
         assert_eq!(annots.len(), 0);

--- a/src/text_page.rs
+++ b/src/text_page.rs
@@ -362,13 +362,13 @@ impl<'a> Iterator for TextCharIter<'a> {
 
 #[cfg(test)]
 mod test {
-    use crate::{text_page::SearchHitResponse, Document, TextPageOptions};
+    use crate::{document::test_document, text_page::SearchHitResponse, Document, TextPageOptions};
 
     #[test]
     fn test_text_page_search() {
         use crate::{Point, Quad};
 
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let text_page = page0.to_text_page(TextPageOptions::BLOCK_IMAGE).unwrap();
         let hits = text_page.search("Dummy").unwrap();
@@ -401,7 +401,7 @@ mod test {
 
     #[test]
     fn test_text_page_cb_search() {
-        let doc = Document::open("tests/files/dummy.pdf").unwrap();
+        let doc = test_document!("..", "files/dummy.pdf").unwrap();
         let page0 = doc.load_page(0).unwrap();
         let text_page = page0.to_text_page(TextPageOptions::BLOCK_IMAGE).unwrap();
         let mut sum_x = 0.0;

--- a/tests/test_issues.rs
+++ b/tests/test_issues.rs
@@ -1,25 +1,23 @@
 use mupdf::pdf::PdfDocument;
-use mupdf::{Colorspace, Error, ImageFormat, Matrix, TextPageOptions};
+use mupdf::{Error, TextPageOptions};
 
-#[cfg(feature = "serde")]
-use mupdf::page::StextPage;
-
+#[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn test_issue_16_pixmap_to_png() {
-    let document = PdfDocument::open("tests/files/dummy.pdf").unwrap();
+    let document = PdfDocument::from_bytes(include_bytes!("../tests/files/dummy.pdf")).unwrap();
     let page = document.load_page(0).unwrap();
-    let matrix = Matrix::new_scale(72f32 / 72f32, 72f32 / 72f32);
+    let matrix = mupdf::Matrix::new_scale(72f32 / 72f32, 72f32 / 72f32);
     let pixmap = page
-        .to_pixmap(&matrix, &Colorspace::device_rgb(), false, true)
+        .to_pixmap(&matrix, &mupdf::Colorspace::device_rgb(), false, true)
         .unwrap();
     pixmap
-        .save_as("tests/output/test.png", ImageFormat::PNG)
+        .save_as("tests/output/test.png", mupdf::ImageFormat::PNG)
         .unwrap();
 }
 
 #[test]
 fn test_issue_27_flatten() {
-    let doc = PdfDocument::open("tests/files/dummy.pdf").unwrap();
+    let doc = PdfDocument::from_bytes(include_bytes!("../tests/files/dummy.pdf")).unwrap();
     let pages = doc
         .pages()
         .unwrap()
@@ -35,6 +33,7 @@ fn test_issue_27_flatten() {
     assert!(!blocks.is_empty());
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn test_issue_43_malloc() {
     const IDENTITY: mupdf::Matrix = mupdf::Matrix {
@@ -50,13 +49,9 @@ fn test_issue_43_malloc() {
     let height = 1500;
     let options = format!("resolution={},height={}", density, height);
 
-    let mut writer = mupdf::document_writer::DocumentWriter::new(
-        "tests/output/issue_43.png",
-        "png",
-        options.as_str(),
-    )
-    .unwrap();
-    let doc = mupdf::document::Document::open("tests/files/dummy.pdf").unwrap();
+    let mut writer =
+        mupdf::DocumentWriter::new("tests/output/issue_43.png", "png", options.as_str()).unwrap();
+    let doc = mupdf::Document::from_bytes(include_bytes!("../tests/files/dummy.pdf"), "").unwrap();
 
     for _ in 0..2 {
         let page0 = doc.load_page(0).unwrap();
@@ -69,7 +64,7 @@ fn test_issue_43_malloc() {
 
 #[test]
 fn test_issue_60_display_list() {
-    let doc = PdfDocument::open("tests/files/p11.pdf").unwrap();
+    let doc = PdfDocument::from_bytes(include_bytes!("../tests/files/p11.pdf")).unwrap();
     let num_pages = doc.page_count().unwrap();
     println!("Document has {} page(s)", num_pages);
 
@@ -86,7 +81,8 @@ fn test_issue_60_display_list() {
 
 #[test]
 fn test_issue_86_invalid_utf8() {
-    let doc = PdfDocument::open("tests/files/utf8-error-on-this-file.pdf").unwrap();
+    let doc = PdfDocument::from_bytes(include_bytes!("../tests/files/utf8-error-on-this-file.pdf"))
+        .unwrap();
     for (idx, page) in doc.pages().unwrap().enumerate() {
         let page = page.unwrap();
         let text = page.to_text();
@@ -105,7 +101,7 @@ fn test_issue_86_invalid_utf8() {
 #[test]
 #[cfg(feature = "serde")]
 fn test_issue_i32_box() {
-    let doc = PdfDocument::open("tests/files/i32-box.pdf").unwrap();
+    let doc = PdfDocument::from_bytes(include_bytes!("../tests/files/i32-box.pdf")).unwrap();
     for (idx, page) in doc.pages().unwrap().enumerate() {
         let page = page.unwrap();
         let text = page.to_text();
@@ -115,14 +111,15 @@ fn test_issue_i32_box() {
         let json = page.stext_page_as_json_from_page(1.0);
         assert!(json.is_ok());
 
-        let stext_page: Result<StextPage, _> = serde_json::from_str(json.unwrap().as_str());
+        let stext_page: Result<mupdf::page::StextPage, _> =
+            serde_json::from_str(json.unwrap().as_str());
         assert!(stext_page.is_ok());
     }
 }
 
 #[test]
 fn test_issue_no_json() {
-    let doc = PdfDocument::open("tests/files/no-json.pdf").unwrap();
+    let doc = PdfDocument::from_bytes(include_bytes!("../tests/files/no-json.pdf")).unwrap();
     let page = doc.load_page(0).unwrap();
     let json = page.stext_page_as_json_from_page(1.0);
     assert!(json.is_err());


### PR DESCRIPTION
- [x] Split make and msbuild in two seperate files.
- [x] Remove uses of `to_string_lossy` for paths. Replaced with `.to_str` or `OsStr` directly instead.
- [x] Split bindgen docs and zerocopy callbacks.
- [x] Make `zerocopy` a optional feature for `mupdf-sys`.
- [x] Improved and more error messages
- [x] Check `target_env` from env vars as well
- [x] ~~Don't copy `src` into `build`. [Not possible yet](https://bugs.ghostscript.com/show_bug.cgi?id=708520), are symlinks a better idea than copying?~~
Maybe in the future, just improved copy for now
- [x] Integrate and complete wasm compilation support from #123
- [x] Add WASM CI
- [x] Link C++