### PR TITLE
Fix build on windows-2022 and windows-2025 (visual studio 2022)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-2019, windows-2022, windows-2025]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -246,7 +246,7 @@ fn build_libmupdf() {
 fn build_libmupdf() {
     use cc::windows_registry::find_vs_version;
 
-    // Patch geometry.c to compile on vs 2020
+    // Patch geometry.c to compile on vs 2022
     let file_path = "mupdf/source/fitz/geometry.c";
     let content = fs::read_to_string(file_path).expect("Failed to read geometry.c file");
     let patched_content = content.replace("NAN", "(0.0/0.0)");

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -246,6 +246,12 @@ fn build_libmupdf() {
 fn build_libmupdf() {
     use cc::windows_registry::find_vs_version;
 
+    // Patch geometry.c to compile on vs 2020
+    let file_path = "mupdf/source/fitz/geometry.c";
+    let content = fs::read_to_string(file_path).expect("Failed to read geometry.c file");
+    let patched_content = content.replace("NAN", "(0.0/0.0)");
+    fs::write(file_path, patched_content).expect("Failed to write patched geometry.c file");
+
     let target = env::var("TARGET").expect("TARGET not found in environment");
     let msvc_platform = if target.contains("x86_64") {
         "x64"


### PR DESCRIPTION
This PR fixes the problem (#138) of building mupdf with visual studio 2022 which is part of the windows-2022 and windows-2025 github runners.