### PR TITLE
Return more information for `outlines`

### DIFF
--- a/mupdf-sys/wrapper.c
+++ b/mupdf-sys/wrapper.c
@@ -2141,13 +2141,12 @@ pdf_document *mupdf_convert_to_pdf(fz_context *ctx, fz_document *doc, int fp, in
     return pdf;
 }
 
-fz_location mupdf_resolve_link(fz_context *ctx, fz_document *doc, const char *uri, mupdf_error_t **errptr)
+fz_location mupdf_resolve_link(fz_context *ctx, fz_document *doc, const char *uri, float *xp, float *yp, mupdf_error_t **errptr)
 {
     fz_location loc = { -1, -1 };
-    float xp = 0.0f, yp = 0.0f;
     fz_try(ctx)
     {
-        loc = fz_resolve_link(ctx, doc, uri, &xp, &yp);
+        loc = fz_resolve_link(ctx, doc, uri, xp, yp);
     }
     fz_catch(ctx)
     {

--- a/mupdf-sys/wrapper.c
+++ b/mupdf-sys/wrapper.c
@@ -2155,6 +2155,21 @@ fz_location mupdf_resolve_link(fz_context *ctx, fz_document *doc, const char *ur
     return loc;
 }
 
+
+fz_link_dest mupdf_resolve_link_dest(fz_context *ctx, fz_document *doc, const char *uri, mupdf_error_t **errptr)
+{
+    fz_link_dest dest;
+    fz_try(ctx)
+    {
+        dest = fz_resolve_link_dest(ctx, doc, uri);
+    }
+    fz_catch(ctx)
+    {
+        mupdf_save_error(ctx, errptr);
+    }
+    return dest;
+}
+
 fz_colorspace *mupdf_document_output_intent(fz_context *ctx, fz_document *doc, mupdf_error_t **errptr)
 {
     fz_colorspace *cs = NULL;

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -97,7 +97,7 @@ impl DestinationKind {
                 Self::XYZ {
                     left: Some(p.x),
                     top: Some(p.y),
-                    zoom: zoom,
+                    zoom,
                 }
             }
             Self::FitR {

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -10,120 +10,6 @@ pub struct Destination {
     kind: DestinationKind,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum DestinationKind {
-    /// Display the page at a scale which just fits the whole page
-    /// in the window both horizontally and vertically.
-    Fit,
-    /// Display the page with the vertical coordinate `top` at the top edge of the window,
-    /// and the magnification set to fit the document horizontally.
-    FitH { top: f32 },
-    /// Display the page with the horizontal coordinate `left` at the left edge of the window,
-    /// and the magnification set to fit the document vertically.
-    FitV { left: f32 },
-    /// Display the page with (`left`, `top`) at the upper-left corner
-    /// of the window and the page magnified by factor `zoom`.
-    XYZ {
-        left: Option<f32>,
-        top: Option<f32>,
-        zoom: Option<f32>,
-    },
-    /// Display the page zoomed to show the rectangle specified by `left`, `bottom`, `right`, and `top`.
-    FitR {
-        left: f32,
-        bottom: f32,
-        right: f32,
-        top: f32,
-    },
-    /// Display the page like `/Fit`, but use the bounding box of the page’s contents,
-    /// rather than the crop box.
-    FitB,
-    /// Display the page like `/FitH`, but use the bounding box of the page’s contents,
-    /// rather than the crop box.
-    FitBH { top: f32 },
-    /// Display the page like `/FitV`, but use the bounding box of the page’s contents,
-    /// rather than the crop box.
-    FitBV { left: f32 },
-}
-
-impl DestinationKind {
-    #[allow(non_upper_case_globals)]
-    pub(crate) fn from_link_dest(dst: fz_link_dest) -> Self {
-        match dst.type_ {
-            fz_link_dest_type_FZ_LINK_DEST_FIT => Self::Fit,
-            fz_link_dest_type_FZ_LINK_DEST_FIT_B => Self::FitB,
-            fz_link_dest_type_FZ_LINK_DEST_FIT_H => Self::FitH { top: dst.y },
-            fz_link_dest_type_FZ_LINK_DEST_FIT_BH => Self::FitBH { top: dst.y },
-            fz_link_dest_type_FZ_LINK_DEST_FIT_V => Self::FitV { left: dst.x },
-            fz_link_dest_type_FZ_LINK_DEST_FIT_BV => Self::FitBV { left: dst.x },
-            fz_link_dest_type_FZ_LINK_DEST_XYZ => Self::XYZ {
-                left: Some(dst.x),
-                top: Some(dst.y),
-                zoom: Some(dst.zoom),
-            },
-            fz_link_dest_type_FZ_LINK_DEST_FIT_R => Self::FitR {
-                left: dst.x,
-                bottom: dst.y,
-                right: dst.x + dst.w,
-                top: dst.y + dst.h,
-            },
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn transform(self, matrix: &Matrix) -> Self {
-        match self {
-            Self::Fit => Self::Fit,
-            Self::FitB => Self::FitB,
-            Self::FitH { top } => {
-                let p = Point::new(0.0, top).transform(matrix);
-                Self::FitH { top: p.y }
-            }
-            Self::FitBH { top } => {
-                let p = Point::new(0.0, top).transform(matrix);
-                Self::FitBH { top: p.y }
-            }
-            Self::FitV { left } => {
-                let p = Point::new(left, 0.0).transform(matrix);
-                Self::FitV { left: p.x }
-            }
-            Self::FitBV { left } => {
-                let p = Point::new(left, 0.0).transform(matrix);
-                Self::FitBV { left: p.x }
-            }
-            Self::XYZ { left, top, zoom } => {
-                let p =
-                    Point::new(left.unwrap_or_default(), top.unwrap_or_default()).transform(matrix);
-                Self::XYZ {
-                    left: Some(p.x),
-                    top: Some(p.y),
-                    zoom,
-                }
-            }
-            Self::FitR {
-                left,
-                bottom,
-                right,
-                top,
-            } => {
-                let r = Rect {
-                    x0: left,
-                    y0: bottom,
-                    x1: right,
-                    y1: top,
-                };
-                let tr = r.transform(matrix);
-                Self::FitR {
-                    left: tr.x0,
-                    bottom: tr.y0,
-                    right: tr.x1,
-                    top: tr.y1,
-                }
-            }
-        }
-    }
-}
-
 impl Destination {
     pub(crate) fn new(page: PdfObject, kind: DestinationKind) -> Self {
         Self { page, kind }
@@ -186,5 +72,121 @@ impl Destination {
         }
 
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DestinationKind {
+    /// Display the page at a scale which just fits the whole page
+    /// in the window both horizontally and vertically.
+    Fit,
+    /// Display the page with the vertical coordinate `top` at the top edge of the window,
+    /// and the magnification set to fit the document horizontally.
+    FitH { top: f32 },
+    /// Display the page with the horizontal coordinate `left` at the left edge of the window,
+    /// and the magnification set to fit the document vertically.
+    FitV { left: f32 },
+    /// Display the page with (`left`, `top`) at the upper-left corner
+    /// of the window and the page magnified by factor `zoom`.
+    XYZ {
+        left: Option<f32>,
+        top: Option<f32>,
+        zoom: Option<f32>,
+    },
+    /// Display the page zoomed to show the rectangle specified by `left`, `bottom`, `right`, and `top`.
+    FitR {
+        left: f32,
+        bottom: f32,
+        right: f32,
+        top: f32,
+    },
+    /// Display the page like `/Fit`, but use the bounding box of the page’s contents,
+    /// rather than the crop box.
+    FitB,
+    /// Display the page like `/FitH`, but use the bounding box of the page’s contents,
+    /// rather than the crop box.
+    FitBH { top: f32 },
+    /// Display the page like `/FitV`, but use the bounding box of the page’s contents,
+    /// rather than the crop box.
+    FitBV { left: f32 },
+}
+
+impl DestinationKind {
+    pub fn transform(self, matrix: &Matrix) -> Self {
+        match self {
+            Self::Fit => Self::Fit,
+            Self::FitB => Self::FitB,
+            Self::FitH { top } => {
+                let p = Point::new(0.0, top).transform(matrix);
+                Self::FitH { top: p.y }
+            }
+            Self::FitBH { top } => {
+                let p = Point::new(0.0, top).transform(matrix);
+                Self::FitBH { top: p.y }
+            }
+            Self::FitV { left } => {
+                let p = Point::new(left, 0.0).transform(matrix);
+                Self::FitV { left: p.x }
+            }
+            Self::FitBV { left } => {
+                let p = Point::new(left, 0.0).transform(matrix);
+                Self::FitBV { left: p.x }
+            }
+            Self::XYZ { left, top, zoom } => {
+                let p =
+                    Point::new(left.unwrap_or_default(), top.unwrap_or_default()).transform(matrix);
+                Self::XYZ {
+                    left: Some(p.x),
+                    top: Some(p.y),
+                    zoom,
+                }
+            }
+            Self::FitR {
+                left,
+                bottom,
+                right,
+                top,
+            } => {
+                let r = Rect {
+                    x0: left,
+                    y0: bottom,
+                    x1: right,
+                    y1: top,
+                };
+                let tr = r.transform(matrix);
+                Self::FitR {
+                    left: tr.x0,
+                    bottom: tr.y0,
+                    right: tr.x1,
+                    top: tr.y1,
+                }
+            }
+        }
+    }
+}
+
+impl From<fz_link_dest> for DestinationKind {
+    #[allow(non_upper_case_globals)]
+    fn from(value: fz_link_dest) -> Self {
+        match value.type_ {
+            fz_link_dest_type_FZ_LINK_DEST_FIT => Self::Fit,
+            fz_link_dest_type_FZ_LINK_DEST_FIT_B => Self::FitB,
+            fz_link_dest_type_FZ_LINK_DEST_FIT_H => Self::FitH { top: value.y },
+            fz_link_dest_type_FZ_LINK_DEST_FIT_BH => Self::FitBH { top: value.y },
+            fz_link_dest_type_FZ_LINK_DEST_FIT_V => Self::FitV { left: value.x },
+            fz_link_dest_type_FZ_LINK_DEST_FIT_BV => Self::FitBV { left: value.x },
+            fz_link_dest_type_FZ_LINK_DEST_XYZ => Self::XYZ {
+                left: Some(value.x),
+                top: Some(value.y),
+                zoom: Some(value.zoom),
+            },
+            fz_link_dest_type_FZ_LINK_DEST_FIT_R => Self::FitR {
+                left: value.x,
+                bottom: value.y,
+                right: value.x + value.w,
+                top: value.y + value.h,
+            },
+            _ => unreachable!(),
+        }
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -44,13 +44,13 @@ impl MetadataName {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Location {
     pub chapter: u32,
-    /// Index of the page inside the inside the [`chapter`](Location::chapter).
+    /// Index of the page inside the [`chapter`](Location::chapter).
     ///
     /// See [`page_number`](Location::page_number) for the absolute page number.
-    pub page: u32,
+    pub page_in_chapter: u32,
     /// Page number absolute to the start of the document.
     ///
-    /// See [`page`](Location::page) for the page index relative to the [`chapter`](Location::chapter).
+    /// See [`page_in_chapter`](Location::page_in_chapter) for the page index relative to the [`chapter`](Location::chapter).
     pub page_number: u32,
 }
 
@@ -461,7 +461,7 @@ mod test {
             Some(LinkDestination {
                 loc: Location {
                     chapter: 0,
-                    page: 0,
+                    page_in_chapter: 0,
                     page_number: 0,
                 },
                 kind: DestinationKind::XYZ {

--- a/src/link.rs
+++ b/src/link.rs
@@ -36,10 +36,10 @@ impl LinkDestination {
         Ok(Some(Self {
             loc: Location {
                 chapter: dest.loc.chapter as u32,
-                page: dest.loc.page as u32,
+                page_in_chapter: dest.loc.page as u32,
                 page_number: page_number as u32,
             },
-            kind: DestinationKind::from_link_dest(dest),
+            kind: dest.into(),
         }))
     }
 }

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,21 +1,9 @@
-use std::fmt;
-
-use crate::Rect;
+use crate::{document::Location, Rect};
 
 /// A list of interactive links on a page.
 #[derive(Debug, Clone)]
 pub struct Link {
     pub bounds: Rect,
-    pub page: u32,
+    pub location: Option<Location>,
     pub uri: String,
-}
-
-impl fmt::Display for Link {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Link(b={},page={},uri={})",
-            self.bounds, self.page, self.uri
-        )
-    }
 }

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,9 +1,45 @@
-use crate::{document::Location, Rect};
+use std::ffi::CStr;
+
+use crate::{context, document::Location, DestinationKind, Document, Error, Rect};
+
+use mupdf_sys::*;
 
 /// A list of interactive links on a page.
 #[derive(Debug, Clone)]
 pub struct Link {
     pub bounds: Rect,
-    pub location: Option<Location>,
+    pub dest: Option<LinkDestination>,
     pub uri: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LinkDestination {
+    pub loc: Location,
+    pub kind: DestinationKind,
+}
+
+impl LinkDestination {
+    pub(crate) fn from_uri(doc: &Document, uri: &CStr) -> Result<Option<Self>, Error> {
+        let external = unsafe { fz_is_external_link(context(), uri.as_ptr()) } != 0;
+        if external {
+            return Ok(None);
+        }
+
+        let dest =
+            unsafe { ffi_try!(mupdf_resolve_link_dest(context(), doc.inner, uri.as_ptr())) }?;
+        if dest.loc.page < 0 {
+            return Ok(None);
+        }
+
+        let page_number = unsafe { fz_page_number_from_location(context(), doc.inner, dest.loc) };
+
+        Ok(Some(Self {
+            loc: Location {
+                chapter: dest.loc.chapter as u32,
+                page: dest.loc.page as u32,
+                page_number: page_number as u32,
+            },
+            kind: DestinationKind::from_link_dest(dest),
+        }))
+    }
 }

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -1,10 +1,10 @@
-use crate::document::Location;
+use crate::link::LinkDestination;
 
 /// a tree of the outline of a document (also known as table of contents).
 #[derive(Debug)]
 pub struct Outline {
     pub title: String,
     pub uri: Option<String>,
-    pub location: Option<Location>,
+    pub dest: Option<LinkDestination>,
     pub down: Vec<Outline>,
 }

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -1,10 +1,10 @@
+use crate::document::Location;
+
 /// a tree of the outline of a document (also known as table of contents).
 #[derive(Debug)]
 pub struct Outline {
     pub title: String,
     pub uri: Option<String>,
-    pub page: Option<u32>,
+    pub location: Option<Location>,
     pub down: Vec<Outline>,
-    pub x: f32,
-    pub y: f32,
 }

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -568,13 +568,12 @@ impl PdfDocument {
             item.dict_put("Title", PdfObject::new_string(&outline.title)?)?;
             item.dict_put("Parent", parent.clone())?;
             if let Some(dest) = outline
-                .page
-                .map(|page| {
-                    let page = self.find_page(page as i32)?;
+                .location
+                .map(|loc| {
+                    let page = self.find_page(loc.page as i32)?;
 
                     let matrix = page.page_ctm()?;
-                    let fz_point = Point::new(outline.x, outline.y);
-                    let Point { x, y } = fz_point.transform(&matrix);
+                    let Point { x, y } = loc.coord.transform(&matrix);
                     let dest_kind = DestinationKind::XYZ {
                         left: Some(x),
                         top: Some(y),

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -10,8 +10,8 @@ use num_enum::TryFromPrimitive;
 
 use crate::pdf::{PdfGraftMap, PdfObject, PdfPage};
 use crate::{
-    context, Buffer, CjkFontOrdering, Destination, DestinationKind, Document, Error, FilePath,
-    Font, Image, Outline, Point, SimpleFontEncoding, Size, WriteMode,
+    context, Buffer, CjkFontOrdering, Destination, Document, Error, FilePath, Font, Image, Outline,
+    SimpleFontEncoding, Size, WriteMode,
 };
 
 bitflags! {
@@ -568,17 +568,12 @@ impl PdfDocument {
             item.dict_put("Title", PdfObject::new_string(&outline.title)?)?;
             item.dict_put("Parent", parent.clone())?;
             if let Some(dest) = outline
-                .location
-                .map(|loc| {
-                    let page = self.find_page(loc.page as i32)?;
+                .dest
+                .map(|dest| {
+                    let page = self.find_page(dest.loc.page_number as i32)?;
 
                     let matrix = page.page_ctm()?;
-                    let Point { x, y } = loc.coord.transform(&matrix);
-                    let dest_kind = DestinationKind::XYZ {
-                        left: Some(x),
-                        top: Some(y),
-                        zoom: None,
-                    };
+                    let dest_kind = dest.kind.transform(&matrix);
                     let dest = Destination::new(page, dest_kind);
 
                     let mut array = self.new_array()?;

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -184,6 +184,10 @@ impl Rect {
         }
         .map(fz_rect::into)
     }
+
+    pub fn transform(self, matrix: &Matrix) -> Self {
+        unsafe { fz_transform_rect(self.into(), matrix.into()) }.into()
+    }
 }
 
 impl fmt::Display for Rect {


### PR DESCRIPTION
Fix #68 by providing more information inside `Outline` by using the new `LinkDestination` struct and adding `page_number` to `Location` (which is what #68 is looking for).

The naming isn't great as there is `page` and `page_number` but i couldn't come up with anything better and that is what mupdf calls them themselves. I added a doc comment to clarify things. If somebody has a better idea for a name I would be more than welcome to change it.

This changes the output of `.outlines()` on a from, for example
```rust
Outline {
    title: "Copyright",
    uri: None,
    page: Some(
        0,
    ),
    down: [],
    x: 0.0,
    y: 0.0,
}
```

to

```rust
Outline {
    title: "Copyright",
    uri: Some(
        "OEBPS/Text/copyright.xhtml",
    ),
    dest: Some(
        LinkDestination {
            loc: Location {
                chapter: 23,
                page: 0,
                page_number: 186,
            },
            kind: XYZ {
                left: Some(
                    0.0,
                ),
                top: Some(
                    0.0,
                ),
                zoom: Some(
                    0.0,
                ),
            },
        },
    ),
    down: [],
}
```