### PR TITLE
Get rid of num_enum dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ serde = ["dep:serde"]
 [dependencies]
 mupdf-sys = { version = "0.5.0", path = "mupdf-sys", features = ["zerocopy"] }
 once_cell = "1.3.1"
-num_enum = "0.7.0"
 bitflags = "2.0.2"
 serde = { version = "1.0.201", features = ["derive"], optional = true }
 zerocopy = { version = "0.8.17", features = ["derive"] }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,39 +1,43 @@
 use std::ptr;
-use std::{ffi::CString, num::NonZero};
+use std::{
+    ffi::{c_uint, CString},
+    num::NonZero,
+};
 
 use bitflags::bitflags;
+
 use mupdf_sys::*;
-use num_enum::TryFromPrimitive;
 
 use crate::{
-    context, ColorParams, Colorspace, DisplayList, Error, FFIWrapper, IRect, Image, Matrix, Path,
-    Pixmap, Rect, Shade, StrokeState, Text, TextPage, TextPageFlags,
+    context, from_enum, ColorParams, Colorspace, DisplayList, Error, FFIWrapper, IRect, Image,
+    Matrix, Path, Pixmap, Rect, Shade, StrokeState, Text, TextPage, TextPageFlags,
 };
 
 mod native;
 pub use native::NativeDevice;
 
-#[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
-#[repr(u32)]
-pub enum BlendMode {
-    /* PDF 1.4 -- standard separable */
-    Normal = FZ_BLEND_NORMAL as u32,
-    Multiply = FZ_BLEND_MULTIPLY as u32,
-    Screen = FZ_BLEND_SCREEN as u32,
-    Overlay = FZ_BLEND_OVERLAY as u32,
-    Darken = FZ_BLEND_DARKEN as u32,
-    Lighten = FZ_BLEND_LIGHTEN as u32,
-    ColorDodge = FZ_BLEND_COLOR_DODGE as u32,
-    ColorBurn = FZ_BLEND_COLOR_BURN as u32,
-    HardLight = FZ_BLEND_HARD_LIGHT as u32,
-    SoftLight = FZ_BLEND_SOFT_LIGHT as u32,
-    Difference = FZ_BLEND_DIFFERENCE as u32,
-    Exclusion = FZ_BLEND_EXCLUSION as u32,
-    /* PDF 1.4 -- standard non-separable */
-    Hue = FZ_BLEND_HUE as u32,
-    Saturation = FZ_BLEND_SATURATION as u32,
-    Color = FZ_BLEND_COLOR as u32,
-    Luminosity = FZ_BLEND_LUMINOSITY as u32,
+from_enum! { c_uint,
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    pub enum BlendMode {
+        /* PDF 1.4 -- standard separable */
+        Normal = FZ_BLEND_NORMAL,
+        Multiply = FZ_BLEND_MULTIPLY,
+        Screen = FZ_BLEND_SCREEN,
+        Overlay = FZ_BLEND_OVERLAY,
+        Darken = FZ_BLEND_DARKEN,
+        Lighten = FZ_BLEND_LIGHTEN,
+        ColorDodge = FZ_BLEND_COLOR_DODGE,
+        ColorBurn = FZ_BLEND_COLOR_BURN,
+        HardLight = FZ_BLEND_HARD_LIGHT,
+        SoftLight = FZ_BLEND_SOFT_LIGHT,
+        Difference = FZ_BLEND_DIFFERENCE,
+        Exclusion = FZ_BLEND_EXCLUSION,
+        /* PDF 1.4 -- standard non-separable */
+        Hue = FZ_BLEND_HUE,
+        Saturation = FZ_BLEND_SATURATION,
+        Color = FZ_BLEND_COLOR,
+        Luminosity = FZ_BLEND_LUMINOSITY,
+    }
 }
 
 bitflags! {
@@ -56,99 +60,101 @@ bitflags! {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
-#[repr(i32)]
-pub enum Structure {
-    Invalid = fz_structure_FZ_STRUCTURE_INVALID as _,
+from_enum! { fz_structure,
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    pub enum Structure {
+        Invalid = fz_structure_FZ_STRUCTURE_INVALID,
 
-    /* Grouping elements (PDF 1.7 - Table 10.20) */
-    Document = fz_structure_FZ_STRUCTURE_DOCUMENT as _,
-    Part = fz_structure_FZ_STRUCTURE_PART as _,
-    Art = fz_structure_FZ_STRUCTURE_ART as _,
-    Sect = fz_structure_FZ_STRUCTURE_SECT as _,
-    Div = fz_structure_FZ_STRUCTURE_DIV as _,
-    BlockQuote = fz_structure_FZ_STRUCTURE_BLOCKQUOTE as _,
-    Caption = fz_structure_FZ_STRUCTURE_CAPTION as _,
-    TOC = fz_structure_FZ_STRUCTURE_TOC as _,
-    TOCI = fz_structure_FZ_STRUCTURE_TOCI as _,
-    Index = fz_structure_FZ_STRUCTURE_INDEX as _,
-    NonStruct = fz_structure_FZ_STRUCTURE_NONSTRUCT as _,
-    Private = fz_structure_FZ_STRUCTURE_PRIVATE as _,
-    /* Grouping elements (PDF 2.0 - Table 364) */
-    DocumentFragment = fz_structure_FZ_STRUCTURE_DOCUMENTFRAGMENT as _,
-    /* Grouping elements (PDF 2.0 - Table 365) */
-    Aside = fz_structure_FZ_STRUCTURE_ASIDE as _,
-    /* Grouping elements (PDF 2.0 - Table 366) */
-    Title = fz_structure_FZ_STRUCTURE_TITLE as _,
-    FENote = fz_structure_FZ_STRUCTURE_FENOTE as _,
-    /* Grouping elements (PDF 2.0 - Table 367) */
-    Sub = fz_structure_FZ_STRUCTURE_SUB as _,
+        /* Grouping elements (PDF 1.7 - Table 10.20) */
+        Document = fz_structure_FZ_STRUCTURE_DOCUMENT,
+        Part = fz_structure_FZ_STRUCTURE_PART,
+        Art = fz_structure_FZ_STRUCTURE_ART,
+        Sect = fz_structure_FZ_STRUCTURE_SECT,
+        Div = fz_structure_FZ_STRUCTURE_DIV,
+        BlockQuote = fz_structure_FZ_STRUCTURE_BLOCKQUOTE,
+        Caption = fz_structure_FZ_STRUCTURE_CAPTION,
+        TOC = fz_structure_FZ_STRUCTURE_TOC,
+        TOCI = fz_structure_FZ_STRUCTURE_TOCI,
+        Index = fz_structure_FZ_STRUCTURE_INDEX,
+        NonStruct = fz_structure_FZ_STRUCTURE_NONSTRUCT,
+        Private = fz_structure_FZ_STRUCTURE_PRIVATE,
+        /* Grouping elements (PDF 2.0 - Table 364) */
+        DocumentFragment = fz_structure_FZ_STRUCTURE_DOCUMENTFRAGMENT,
+        /* Grouping elements (PDF 2.0 - Table 365) */
+        Aside = fz_structure_FZ_STRUCTURE_ASIDE,
+        /* Grouping elements (PDF 2.0 - Table 366) */
+        Title = fz_structure_FZ_STRUCTURE_TITLE,
+        FENote = fz_structure_FZ_STRUCTURE_FENOTE,
+        /* Grouping elements (PDF 2.0 - Table 367) */
+        Sub = fz_structure_FZ_STRUCTURE_SUB,
 
-    /* Paragraphlike elements (PDF 1.7 - Table 10.21) */
-    P = fz_structure_FZ_STRUCTURE_P as _,
-    H = fz_structure_FZ_STRUCTURE_H as _,
-    H1 = fz_structure_FZ_STRUCTURE_H1 as _,
-    H2 = fz_structure_FZ_STRUCTURE_H2 as _,
-    H3 = fz_structure_FZ_STRUCTURE_H3 as _,
-    H4 = fz_structure_FZ_STRUCTURE_H4 as _,
-    H5 = fz_structure_FZ_STRUCTURE_H5 as _,
-    H6 = fz_structure_FZ_STRUCTURE_H6 as _,
+        /* Paragraphlike elements (PDF 1.7 - Table 10.21) */
+        P = fz_structure_FZ_STRUCTURE_P,
+        H = fz_structure_FZ_STRUCTURE_H,
+        H1 = fz_structure_FZ_STRUCTURE_H1,
+        H2 = fz_structure_FZ_STRUCTURE_H2,
+        H3 = fz_structure_FZ_STRUCTURE_H3,
+        H4 = fz_structure_FZ_STRUCTURE_H4,
+        H5 = fz_structure_FZ_STRUCTURE_H5,
+        H6 = fz_structure_FZ_STRUCTURE_H6,
 
-    /* List elements (PDF 1.7 - Table 10.23) */
-    List = fz_structure_FZ_STRUCTURE_LIST as _,
-    ListItem = fz_structure_FZ_STRUCTURE_LISTITEM as _,
-    Label = fz_structure_FZ_STRUCTURE_LABEL as _,
-    ListBody = fz_structure_FZ_STRUCTURE_LISTBODY as _,
+        /* List elements (PDF 1.7 - Table 10.23) */
+        List = fz_structure_FZ_STRUCTURE_LIST,
+        ListItem = fz_structure_FZ_STRUCTURE_LISTITEM,
+        Label = fz_structure_FZ_STRUCTURE_LABEL,
+        ListBody = fz_structure_FZ_STRUCTURE_LISTBODY,
 
-    /* Table elements (PDF 1.7 - Table 10.24) */
-    Table = fz_structure_FZ_STRUCTURE_TABLE as _,
-    TR = fz_structure_FZ_STRUCTURE_TR as _,
-    TH = fz_structure_FZ_STRUCTURE_TH as _,
-    TD = fz_structure_FZ_STRUCTURE_TD as _,
-    THead = fz_structure_FZ_STRUCTURE_THEAD as _,
-    TBody = fz_structure_FZ_STRUCTURE_TBODY as _,
-    TFoot = fz_structure_FZ_STRUCTURE_TFOOT as _,
+        /* Table elements (PDF 1.7 - Table 10.24) */
+        Table = fz_structure_FZ_STRUCTURE_TABLE,
+        TR = fz_structure_FZ_STRUCTURE_TR,
+        TH = fz_structure_FZ_STRUCTURE_TH,
+        TD = fz_structure_FZ_STRUCTURE_TD,
+        THead = fz_structure_FZ_STRUCTURE_THEAD,
+        TBody = fz_structure_FZ_STRUCTURE_TBODY,
+        TFoot = fz_structure_FZ_STRUCTURE_TFOOT,
 
-    /* Inline elements (PDF 1.7 - Table 10.25) */
-    Span = fz_structure_FZ_STRUCTURE_SPAN as _,
-    Quote = fz_structure_FZ_STRUCTURE_QUOTE as _,
-    Note = fz_structure_FZ_STRUCTURE_NOTE as _,
-    Reference = fz_structure_FZ_STRUCTURE_REFERENCE as _,
-    BibEntry = fz_structure_FZ_STRUCTURE_BIBENTRY as _,
-    Code = fz_structure_FZ_STRUCTURE_CODE as _,
-    Link = fz_structure_FZ_STRUCTURE_LINK as _,
-    Annot = fz_structure_FZ_STRUCTURE_ANNOT as _,
-    /* Inline elements (PDF 2.0 - Table 368) */
-    Em = fz_structure_FZ_STRUCTURE_EM as _,
-    Strong = fz_structure_FZ_STRUCTURE_STRONG as _,
+        /* Inline elements (PDF 1.7 - Table 10.25) */
+        Span = fz_structure_FZ_STRUCTURE_SPAN,
+        Quote = fz_structure_FZ_STRUCTURE_QUOTE,
+        Note = fz_structure_FZ_STRUCTURE_NOTE,
+        Reference = fz_structure_FZ_STRUCTURE_REFERENCE,
+        BibEntry = fz_structure_FZ_STRUCTURE_BIBENTRY,
+        Code = fz_structure_FZ_STRUCTURE_CODE,
+        Link = fz_structure_FZ_STRUCTURE_LINK,
+        Annot = fz_structure_FZ_STRUCTURE_ANNOT,
+        /* Inline elements (PDF 2.0 - Table 368) */
+        Em = fz_structure_FZ_STRUCTURE_EM,
+        Strong = fz_structure_FZ_STRUCTURE_STRONG,
 
-    /* Ruby inline element (PDF 1.7 - Table 10.26) */
-    Ruby = fz_structure_FZ_STRUCTURE_RUBY as _,
-    RB = fz_structure_FZ_STRUCTURE_RB as _,
-    RT = fz_structure_FZ_STRUCTURE_RT as _,
-    RP = fz_structure_FZ_STRUCTURE_RP as _,
+        /* Ruby inline element (PDF 1.7 - Table 10.26) */
+        Ruby = fz_structure_FZ_STRUCTURE_RUBY,
+        RB = fz_structure_FZ_STRUCTURE_RB,
+        RT = fz_structure_FZ_STRUCTURE_RT,
+        RP = fz_structure_FZ_STRUCTURE_RP,
 
-    /* Warichu inline element (PDF 1.7 - Table 10.26) */
-    Warichu = fz_structure_FZ_STRUCTURE_WARICHU as _,
-    WT = fz_structure_FZ_STRUCTURE_WT as _,
-    WP = fz_structure_FZ_STRUCTURE_WP as _,
+        /* Warichu inline element (PDF 1.7 - Table 10.26) */
+        Warichu = fz_structure_FZ_STRUCTURE_WARICHU,
+        WT = fz_structure_FZ_STRUCTURE_WT,
+        WP = fz_structure_FZ_STRUCTURE_WP,
 
-    /* Illustration elements (PDF 1.7 - Table 10.27) */
-    Figure = fz_structure_FZ_STRUCTURE_FIGURE as _,
-    Formula = fz_structure_FZ_STRUCTURE_FORMULA as _,
-    Form = fz_structure_FZ_STRUCTURE_FORM as _,
+        /* Illustration elements (PDF 1.7 - Table 10.27) */
+        Figure = fz_structure_FZ_STRUCTURE_FIGURE,
+        Formula = fz_structure_FZ_STRUCTURE_FORMULA,
+        Form = fz_structure_FZ_STRUCTURE_FORM,
 
-    /* Artifact structure type (PDF 2.0 - Table 375) */
-    Artifact = fz_structure_FZ_STRUCTURE_ARTIFACT as _,
+        /* Artifact structure type (PDF 2.0 - Table 375) */
+        Artifact = fz_structure_FZ_STRUCTURE_ARTIFACT,
+    }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
-#[repr(u32)]
-pub enum Metatext {
-    ActualText = fz_metatext_FZ_METATEXT_ACTUALTEXT as _,
-    Alt = fz_metatext_FZ_METATEXT_ALT as _,
-    Abbreviation = fz_metatext_FZ_METATEXT_ABBREVIATION as _,
-    Title = fz_metatext_FZ_METATEXT_TITLE as _,
+from_enum! { fz_metatext,
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    pub enum Metatext {
+        ActualText = fz_metatext_FZ_METATEXT_ACTUALTEXT,
+        Alt = fz_metatext_FZ_METATEXT_ALT,
+        Abbreviation = fz_metatext_FZ_METATEXT_ABBREVIATION,
+        Title = fz_metatext_FZ_METATEXT_TITLE,
+    }
 }
 
 pub struct DefaultColorspaces {

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,6 +1,6 @@
 use std::ptr;
 use std::{
-    ffi::{c_uint, CString},
+    ffi::{c_int, CString},
     num::NonZero,
 };
 
@@ -16,7 +16,7 @@ use crate::{
 mod native;
 pub use native::NativeDevice;
 
-from_enum! { c_uint,
+from_enum! { c_int,
     #[derive(Debug, Clone, Copy, PartialEq)]
     pub enum BlendMode {
         /* PDF 1.4 -- standard separable */

--- a/src/device/native.rs
+++ b/src/device/native.rs
@@ -771,14 +771,12 @@ unsafe extern "C" fn begin_group<D: NativeDevice>(
     with_rust_device::<D, _>(dev, |dev| {
         let cs = ManuallyDrop::new(Colorspace::from_raw(color_space));
 
-        let blendmode = BlendMode::try_from(blendmode as u32).unwrap();
-
         dev.begin_group(
             area.into(),
             &cs,
             isolated != 0,
             knockout != 0,
-            blendmode,
+            blendmode.try_into().unwrap(),
             alpha,
         );
     });
@@ -891,7 +889,7 @@ unsafe extern "C" fn begin_metatext<D: NativeDevice>(
     text: *const c_char,
 ) {
     with_rust_device::<D, _>(dev, |dev| {
-        let meta = Metatext::try_from(meta as u32).unwrap();
+        let meta = Metatext::try_from(meta).unwrap();
         let text = unsafe { CStr::from_ptr(text) }.to_str().unwrap();
 
         dev.begin_metatext(meta, text);

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,7 @@ pub enum Error {
     IntConversion(TryFromIntError),
     InvalidUtf8,
     UnexpectedNullPtr,
+    UnknownEnumVariant,
 }
 
 impl fmt::Display for Error {
@@ -91,6 +92,7 @@ impl fmt::Display for Error {
                 f,
                 "An FFI function call returned a null ptr when we expected a non-null ptr"
             ),
+            Error::UnknownEnumVariant => write!(f, "unknown enum variant provided"),
         }
     }
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,34 +1,36 @@
-use std::ffi::{CStr, CString};
+use std::ffi::{c_uint, CStr, CString};
 use std::fmt;
 use std::str::FromStr;
 
 use mupdf_sys::*;
-use num_enum::TryFromPrimitive;
 
-use crate::{context, Buffer, Error, Matrix, Path};
+use crate::{context, from_enum, Buffer, Error, Matrix, Path};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-#[repr(C)]
-pub enum SimpleFontEncoding {
-    Latin,
-    Greek,
-    Cyrillic,
+from_enum! { c_uint,
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    pub enum SimpleFontEncoding {
+        Latin = PDF_SIMPLE_ENCODING_LATIN,
+        Greek = PDF_SIMPLE_ENCODING_GREEK,
+        Cyrillic = PDF_SIMPLE_ENCODING_CYRILLIC,
+    }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
-#[repr(u32)]
-pub enum WriteMode {
-    Horizontal = 0,
-    Vertical = 1,
+from_enum! { u32,
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    pub enum WriteMode {
+        Horizontal = 0,
+        Vertical = 1,
+    }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-#[repr(C)]
-pub enum CjkFontOrdering {
-    AdobeCns,
-    AdobeGb,
-    AdobeJapan,
-    AdobeKorea,
+from_enum! { c_uint,
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    pub enum CjkFontOrdering {
+        AdobeCns = FZ_ADOBE_CNS,
+        AdobeGb = FZ_ADOBE_GB,
+        AdobeJapan = FZ_ADOBE_JAPAN,
+        AdobeKorea = FZ_ADOBE_KOREA,
+    }
 }
 
 impl FromStr for CjkFontOrdering {

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_uint, CStr, CString};
+use std::ffi::{c_int, CStr, CString};
 use std::fmt;
 use std::str::FromStr;
 
@@ -6,7 +6,7 @@ use mupdf_sys::*;
 
 use crate::{context, from_enum, Buffer, Error, Matrix, Path};
 
-from_enum! { c_uint,
+from_enum! { c_int,
     #[derive(Debug, Clone, Copy, PartialEq)]
     pub enum SimpleFontEncoding {
         Latin = PDF_SIMPLE_ENCODING_LATIN,
@@ -23,7 +23,7 @@ from_enum! { u32,
     }
 }
 
-from_enum! { c_uint,
+from_enum! { c_int,
     #[derive(Debug, Clone, Copy, PartialEq)]
     pub enum CjkFontOrdering {
         AdobeCns = FZ_ADOBE_CNS,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,7 +261,7 @@ macro_rules! from_enum {
 
             #[allow(non_upper_case_globals)]
             fn try_from(value: $c_type) -> Result<Self, Self::Error> {
-                match value {
+                match value as _ {
                     $($value => Ok(Self::$field),)*
                     _ => Err(Error::UnknownEnumVariant)
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,13 +257,13 @@ macro_rules! from_enum {
         }
 
         impl TryFrom<$c_type> for $name {
-            type Error = ();
+            type Error = Error;
 
             #[allow(non_upper_case_globals)]
             fn try_from(value: $c_type) -> Result<Self, Self::Error> {
                 match value {
                     $($value => Ok(Self::$field),)*
-                    _ => Err(())
+                    _ => Err(Error::UnknownEnumVariant)
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,3 +236,37 @@ impl<A, B> AssertSizeEquals<A, B> {
         }
     }
 }
+
+macro_rules! from_enum {
+    (
+        $c_type:ty,
+        $(#[$($attr:tt)*])*
+        pub enum $name:ident {
+            $(
+                $(#[$($field_attr:tt)*])*
+                $field:ident = $value:tt,
+            )*
+        }
+    ) => {
+        $(#[$($attr)*])*
+        pub enum $name {
+            $(
+                $(#[$($field_attr)*])*
+                $field = ($value as isize),
+            )*
+        }
+
+        impl TryFrom<$c_type> for $name {
+            type Error = ();
+
+            #[allow(non_upper_case_globals)]
+            fn try_from(value: $c_type) -> Result<Self, Self::Error> {
+                match value {
+                    $($value => Ok(Self::$field),)*
+                    _ => Err(())
+                }
+            }
+        }
+    };
+}
+pub(crate) use from_enum;

--- a/src/pdf/annotation.rs
+++ b/src/pdf/annotation.rs
@@ -2,56 +2,59 @@ use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
 
 use mupdf_sys::*;
-use num_enum::TryFromPrimitive;
 
 use crate::pdf::PdfFilterOptions;
-use crate::{context, Error};
+use crate::{context, from_enum, Error};
 
-#[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
-#[repr(i32)]
-pub enum PdfAnnotationType {
-    Text = 0,
-    Link = 1,
-    FreeText = 2,
-    Line = 3,
-    Square = 4,
-    Circle = 5,
-    Polygon = 6,
-    PloyLine = 7,
-    Highlight = 8,
-    Underline = 9,
-    Squiggly = 10,
-    StrikeOut = 11,
-    Redact = 12,
-    Stamp = 13,
-    Caret = 14,
-    Ink = 15,
-    Popup = 16,
-    FileAttachment = 17,
-    Sound = 18,
-    Movie = 19,
-    Widget = 20,
-    Screen = 21,
-    PrinterMark = 22,
-    TrapNet = 23,
-    Watermark = 24,
-    ThreeD = 25,
-    Unknown = -1,
+from_enum! { pdf_annot_type,
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    pub enum PdfAnnotationType {
+        Text = pdf_annot_type_PDF_ANNOT_TEXT,
+        Link = pdf_annot_type_PDF_ANNOT_LINK,
+        FreeText = pdf_annot_type_PDF_ANNOT_FREE_TEXT,
+        Line = pdf_annot_type_PDF_ANNOT_LINE,
+        Square = pdf_annot_type_PDF_ANNOT_SQUARE,
+        Circle = pdf_annot_type_PDF_ANNOT_CIRCLE,
+        Polygon = pdf_annot_type_PDF_ANNOT_POLYGON,
+        PloyLine = pdf_annot_type_PDF_ANNOT_POLY_LINE,
+        Highlight = pdf_annot_type_PDF_ANNOT_HIGHLIGHT,
+        Underline = pdf_annot_type_PDF_ANNOT_UNDERLINE,
+        Squiggly = pdf_annot_type_PDF_ANNOT_SQUIGGLY,
+        StrikeOut = pdf_annot_type_PDF_ANNOT_STRIKE_OUT,
+        Redact = pdf_annot_type_PDF_ANNOT_REDACT,
+        Stamp = pdf_annot_type_PDF_ANNOT_STAMP,
+        Caret = pdf_annot_type_PDF_ANNOT_CARET,
+        Ink = pdf_annot_type_PDF_ANNOT_INK,
+        Popup = pdf_annot_type_PDF_ANNOT_POPUP,
+        FileAttachment = pdf_annot_type_PDF_ANNOT_FILE_ATTACHMENT,
+        Sound = pdf_annot_type_PDF_ANNOT_SOUND,
+        Movie = pdf_annot_type_PDF_ANNOT_MOVIE,
+        RichMedia = pdf_annot_type_PDF_ANNOT_RICH_MEDIA,
+        Widget = pdf_annot_type_PDF_ANNOT_WIDGET,
+        Screen = pdf_annot_type_PDF_ANNOT_SCREEN,
+        PrinterMark = pdf_annot_type_PDF_ANNOT_PRINTER_MARK,
+        TrapNet = pdf_annot_type_PDF_ANNOT_TRAP_NET,
+        Watermark = pdf_annot_type_PDF_ANNOT_WATERMARK,
+        ThreeD = pdf_annot_type_PDF_ANNOT_3D,
+        Projection = pdf_annot_type_PDF_ANNOT_PROJECTION,
+        Unknown = pdf_annot_type_PDF_ANNOT_UNKNOWN,
+    }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
-#[repr(i32)]
-pub enum LineEndingStyle {
-    None = 0,
-    Square = 1,
-    Circle = 2,
-    Diamond = 3,
-    OpenArrow = 4,
-    ClosedArrow = 5,
-    Butt = 6,
-    ROpenArrow = 7,
-    RClosedArrow = 8,
-    Slash = 9,
+from_enum! { pdf_line_ending,
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    pub enum LineEndingStyle {
+        None = pdf_line_ending_PDF_ANNOT_LE_NONE,
+        Square = pdf_line_ending_PDF_ANNOT_LE_SQUARE,
+        Circle = pdf_line_ending_PDF_ANNOT_LE_CIRCLE,
+        Diamond = pdf_line_ending_PDF_ANNOT_LE_DIAMOND,
+        OpenArrow = pdf_line_ending_PDF_ANNOT_LE_OPEN_ARROW,
+        ClosedArrow = pdf_line_ending_PDF_ANNOT_LE_CLOSED_ARROW,
+        Butt = pdf_line_ending_PDF_ANNOT_LE_BUTT,
+        ROpenArrow = pdf_line_ending_PDF_ANNOT_LE_R_OPEN_ARROW,
+        RClosedArrow = pdf_line_ending_PDF_ANNOT_LE_R_CLOSED_ARROW,
+        Slash = pdf_line_ending_PDF_ANNOT_LE_SLASH,
+    }
 }
 
 #[derive(Debug)]

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -1,17 +1,17 @@
 use std::convert::TryFrom;
-use std::ffi::{CStr, CString};
+use std::ffi::{c_uint, CStr, CString};
 use std::io::{self, Write};
 use std::ops::{Deref, DerefMut};
 use std::ptr::{self, NonNull};
 
 use bitflags::bitflags;
+
 use mupdf_sys::*;
-use num_enum::TryFromPrimitive;
 
 use crate::pdf::{PdfGraftMap, PdfObject, PdfPage};
 use crate::{
-    context, Buffer, CjkFontOrdering, Destination, Document, Error, FilePath, Font, Image, Outline,
-    SimpleFontEncoding, Size, WriteMode,
+    context, from_enum, Buffer, CjkFontOrdering, Destination, Document, Error, FilePath, Font,
+    Image, Outline, SimpleFontEncoding, Size, WriteMode,
 };
 
 bitflags! {
@@ -27,16 +27,17 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, TryFromPrimitive)]
-#[repr(u32)]
-pub enum Encryption {
-    Aes128 = PDF_ENCRYPT_AES_128 as u32,
-    Aes256 = PDF_ENCRYPT_AES_256 as u32,
-    Rc4_40 = PDF_ENCRYPT_RC4_40 as u32,
-    Rc4_128 = PDF_ENCRYPT_RC4_128 as u32,
-    Keep = PDF_ENCRYPT_KEEP as u32,
-    None = PDF_ENCRYPT_NONE as u32,
-    Unknown = PDF_ENCRYPT_UNKNOWN as u32,
+from_enum! { c_uint,
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub enum Encryption {
+        Aes128 = PDF_ENCRYPT_AES_128,
+        Aes256 = PDF_ENCRYPT_AES_256,
+        Rc4_40 = PDF_ENCRYPT_RC4_40,
+        Rc4_128 = PDF_ENCRYPT_RC4_128,
+        Keep = PDF_ENCRYPT_KEEP,
+        None = PDF_ENCRYPT_NONE,
+        Unknown = PDF_ENCRYPT_UNKNOWN,
+    }
 }
 
 impl Default for Encryption {

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -1,5 +1,5 @@
 use std::convert::TryFrom;
-use std::ffi::{c_uint, CStr, CString};
+use std::ffi::{c_int, CStr, CString};
 use std::io::{self, Write};
 use std::ops::{Deref, DerefMut};
 use std::ptr::{self, NonNull};
@@ -27,7 +27,7 @@ bitflags! {
     }
 }
 
-from_enum! { c_uint,
+from_enum! { c_int,
     #[derive(Debug, Copy, Clone, PartialEq)]
     pub enum Encryption {
         Aes128 = PDF_ENCRYPT_AES_128,
@@ -180,7 +180,7 @@ impl PdfWriteOptions {
     }
 
     pub fn encryption(&self) -> Encryption {
-        Encryption::try_from(self.inner.do_encrypt as u32).unwrap()
+        Encryption::try_from(self.inner.do_encrypt).unwrap()
     }
 
     pub fn set_encryption(&mut self, value: Encryption) -> &mut Self {

--- a/src/stroke_state.rs
+++ b/src/stroke_state.rs
@@ -83,19 +83,19 @@ impl StrokeState {
     }
 
     pub fn start_cap(&self) -> LineCap {
-        LineCap::try_from(unsafe { (*self.inner).start_cap as u32 }).unwrap()
+        LineCap::try_from(unsafe { (*self.inner).start_cap }).unwrap()
     }
 
     pub fn dash_cap(&self) -> LineCap {
-        LineCap::try_from(unsafe { (*self.inner).dash_cap as u32 }).unwrap()
+        LineCap::try_from(unsafe { (*self.inner).dash_cap }).unwrap()
     }
 
     pub fn end_cap(&self) -> LineCap {
-        LineCap::try_from(unsafe { (*self.inner).end_cap as u32 }).unwrap()
+        LineCap::try_from(unsafe { (*self.inner).end_cap }).unwrap()
     }
 
     pub fn line_join(&self) -> LineJoin {
-        LineJoin::try_from(unsafe { (*self.inner).linejoin as u32 }).unwrap()
+        LineJoin::try_from(unsafe { (*self.inner).linejoin }).unwrap()
     }
 
     pub fn line_width(&self) -> f32 {

--- a/src/stroke_state.rs
+++ b/src/stroke_state.rs
@@ -1,37 +1,28 @@
 use std::convert::TryFrom;
 
 use mupdf_sys::*;
-use num_enum::TryFromPrimitive;
 
-use crate::{context, Error};
+use crate::{context, from_enum, Error};
 
-#[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
-#[repr(u32)]
-pub enum LineCap {
-    Butt = 0,
-    Round = 1,
-    Square = 2,
-    Triangle = 3,
-}
-
-impl Default for LineCap {
-    fn default() -> Self {
-        Self::Butt
+from_enum! { fz_linecap,
+    #[derive(Debug, Default, Clone, Copy, PartialEq)]
+    pub enum LineCap {
+        #[default]
+        Butt = fz_linecap_FZ_LINECAP_BUTT,
+        Round = fz_linecap_FZ_LINECAP_ROUND,
+        Square = fz_linecap_FZ_LINECAP_SQUARE,
+        Triangle = fz_linecap_FZ_LINECAP_TRIANGLE,
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
-#[repr(u32)]
-pub enum LineJoin {
-    Miter = 0,
-    Round = 1,
-    Bevel = 2,
-    MiterXps = 3,
-}
-
-impl Default for LineJoin {
-    fn default() -> Self {
-        Self::Miter
+from_enum! { fz_linejoin,
+    #[derive(Debug, Default, Clone, Copy, PartialEq)]
+    pub enum LineJoin {
+        #[default]
+        Miter = fz_linejoin_FZ_LINEJOIN_MITER,
+        Round = fz_linejoin_FZ_LINEJOIN_ROUND,
+        Bevel = fz_linejoin_FZ_LINEJOIN_BEVEL,
+        MiterXps = fz_linejoin_FZ_LINEJOIN_MITER_XPS,
     }
 }
 

--- a/src/system_font.rs
+++ b/src/system_font.rs
@@ -6,9 +6,11 @@ use font_kit::family_name::FamilyName;
 use font_kit::handle::Handle;
 use font_kit::properties::{Properties, Style, Weight};
 use font_kit::source::SystemSource;
-use num_enum::TryFromPrimitive;
 
 use crate::font::Font;
+#[cfg(windows)]
+use crate::CjkFontOrdering;
+
 use mupdf_sys::*;
 
 pub(crate) unsafe extern "C" fn load_system_font(
@@ -70,16 +72,6 @@ pub(crate) unsafe extern "C" fn load_system_font(
     ptr::null_mut()
 }
 
-#[derive(TryFromPrimitive)]
-#[repr(u32)]
-#[allow(clippy::enum_variant_names)]
-enum Ordering {
-    AdobeCns = FZ_ADOBE_CNS as u32,
-    AdobeGb = FZ_ADOBE_GB as u32,
-    AdobeJapan = FZ_ADOBE_JAPAN as u32,
-    AdobeKorea = FZ_ADOBE_KOREA as u32,
-}
-
 #[cfg(windows)]
 unsafe fn load_font_by_names(ctx: *mut fz_context, names: &[&str]) -> *mut fz_font {
     use std::ffi::CString;
@@ -107,33 +99,33 @@ pub unsafe extern "C" fn load_system_cjk_font(
         return font;
     }
     if serif == 1 {
-        match Ordering::try_from(ordering as u32) {
-            Ok(Ordering::AdobeCns) => {
+        match CjkFontOrdering::try_from(ordering as u32) {
+            Ok(CjkFontOrdering::AdobeCns) => {
                 return load_font_by_names(ctx, &["MingLiU"]);
             }
-            Ok(Ordering::AdobeGb) => {
+            Ok(CjkFontOrdering::AdobeGb) => {
                 return load_font_by_names(ctx, &["SimSun"]);
             }
-            Ok(Ordering::AdobeJapan) => {
+            Ok(CjkFontOrdering::AdobeJapan) => {
                 return load_font_by_names(ctx, &["MS-Mincho"]);
             }
-            Ok(Ordering::AdobeKorea) => {
+            Ok(CjkFontOrdering::AdobeKorea) => {
                 return load_font_by_names(ctx, &["Batang"]);
             }
             Err(_) => {}
         }
     } else {
-        match Ordering::try_from(ordering as u32) {
-            Ok(Ordering::AdobeCns) => {
+        match CjkFontOrdering::try_from(ordering as u32) {
+            Ok(CjkFontOrdering::AdobeCns) => {
                 return load_font_by_names(ctx, &["DFKaiShu-SB-Estd-BF"]);
             }
-            Ok(Ordering::AdobeGb) => {
+            Ok(CjkFontOrdering::AdobeGb) => {
                 return load_font_by_names(ctx, &["KaiTi", "KaiTi_GB2312"]);
             }
-            Ok(Ordering::AdobeJapan) => {
+            Ok(CjkFontOrdering::AdobeJapan) => {
                 return load_font_by_names(ctx, &["MS-Gothic"]);
             }
-            Ok(Ordering::AdobeKorea) => {
+            Ok(CjkFontOrdering::AdobeKorea) => {
                 return load_font_by_names(ctx, &["Gulim"]);
             }
             Err(_) => {}

--- a/src/system_font.rs
+++ b/src/system_font.rs
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn load_system_cjk_font(
         return font;
     }
     if serif == 1 {
-        match CjkFontOrdering::try_from(ordering as u32) {
+        match CjkFontOrdering::try_from(ordering) {
             Ok(CjkFontOrdering::AdobeCns) => {
                 return load_font_by_names(ctx, &["MingLiU"]);
             }
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn load_system_cjk_font(
             Err(_) => {}
         }
     } else {
-        match CjkFontOrdering::try_from(ordering as u32) {
+        match CjkFontOrdering::try_from(ordering) {
             Ok(CjkFontOrdering::AdobeCns) => {
                 return load_font_by_names(ctx, &["DFKaiShu-SB-Estd-BF"]);
             }

--- a/src/text.rs
+++ b/src/text.rs
@@ -2,9 +2,8 @@ use std::convert::TryInto;
 use std::slice;
 
 use mupdf_sys::*;
-use num_enum::TryFromPrimitive;
 
-use crate::{context, Error, Font, Matrix, Rect, StrokeState, WriteMode};
+use crate::{context, from_enum, Error, Font, Matrix, Rect, StrokeState, WriteMode};
 
 #[derive(Debug)]
 pub struct Text {
@@ -45,25 +44,27 @@ impl Drop for Text {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
-#[repr(u32)]
-pub enum BidiDirection {
-    Ltr = fz_bidi_direction_FZ_BIDI_LTR as u32,
-    Neutral = fz_bidi_direction_FZ_BIDI_NEUTRAL as u32,
-    Rtl = fz_bidi_direction_FZ_BIDI_RTL as u32,
+from_enum! { fz_bidi_direction,
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    pub enum BidiDirection {
+        Ltr = fz_bidi_direction_FZ_BIDI_LTR,
+        Rtl = fz_bidi_direction_FZ_BIDI_RTL,
+        Neutral = fz_bidi_direction_FZ_BIDI_NEUTRAL,
+    }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
-#[repr(u32)]
-pub enum Language {
-    Unset = fz_text_language_FZ_LANG_UNSET as u32,
-    Ja = fz_text_language_FZ_LANG_ja as u32,
-    Ko = fz_text_language_FZ_LANG_ko as u32,
-    Ur = fz_text_language_FZ_LANG_ur as u32,
-    Urd = fz_text_language_FZ_LANG_urd as u32,
-    Zh = fz_text_language_FZ_LANG_zh as u32,
-    ZhHans = fz_text_language_FZ_LANG_zh_Hans as u32,
-    ZhHant = fz_text_language_FZ_LANG_zh_Hant as u32,
+from_enum! { fz_text_language,
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    pub enum Language {
+        Unset = fz_text_language_FZ_LANG_UNSET,
+        Ja = fz_text_language_FZ_LANG_ja,
+        Ko = fz_text_language_FZ_LANG_ko,
+        Ur = fz_text_language_FZ_LANG_ur,
+        Urd = fz_text_language_FZ_LANG_urd,
+        Zh = fz_text_language_FZ_LANG_zh,
+        ZhHans = fz_text_language_FZ_LANG_zh_Hans,
+        ZhHant = fz_text_language_FZ_LANG_zh_Hant,
+    }
 }
 
 #[derive(Debug)]

--- a/src/text.rs
+++ b/src/text.rs
@@ -104,7 +104,8 @@ impl TextSpan {
     }
 
     pub fn markup_dir(&self) -> BidiDirection {
-        unsafe { (*self.inner).markup_dir().try_into().unwrap() }
+        let markup_dir = unsafe { (*self.inner).markup_dir() };
+        (markup_dir as fz_bidi_direction).try_into().unwrap()
     }
 
     pub fn set_markup_dir(&mut self, dir: BidiDirection) {
@@ -112,7 +113,8 @@ impl TextSpan {
     }
 
     pub fn language(&self) -> Language {
-        unsafe { (*self.inner).language().try_into().unwrap() }
+        let lang = unsafe { (*self.inner).language() };
+        (lang as fz_text_language).try_into().unwrap()
     }
 
     pub fn set_language(&mut self, language: Language) {

--- a/src/text_page.rs
+++ b/src/text_page.rs
@@ -1,6 +1,6 @@
 use std::{
     convert::TryInto,
-    ffi::{c_int, c_uint, c_void, CString},
+    ffi::{c_int, c_void, CString},
     io::Read,
     marker::PhantomData,
     ptr::{self, NonNull},
@@ -309,7 +309,7 @@ pub enum SearchHitResponse {
     AbortSearch = 1,
 }
 
-from_enum! { c_uint,
+from_enum! { c_int,
     #[derive(Debug, Clone, Copy, PartialEq)]
     pub enum TextBlockType {
         Text = FZ_STEXT_BLOCK_TEXT,
@@ -327,7 +327,7 @@ pub struct TextBlock<'a> {
 
 impl TextBlock<'_> {
     pub fn r#type(&self) -> TextBlockType {
-        (self.inner.type_ as u32).try_into().unwrap()
+        self.inner.type_.try_into().unwrap()
     }
 
     pub fn bounds(&self) -> Rect {
@@ -336,7 +336,7 @@ impl TextBlock<'_> {
 
     pub fn lines(&self) -> TextLineIter {
         unsafe {
-            if self.inner.type_ == FZ_STEXT_BLOCK_TEXT as i32 {
+            if self.inner.type_ == FZ_STEXT_BLOCK_TEXT as c_int {
                 return TextLineIter {
                     next: self.inner.u.t.first_line,
                     _marker: PhantomData,

--- a/src/text_page.rs
+++ b/src/text_page.rs
@@ -1,6 +1,6 @@
 use std::{
     convert::TryInto,
-    ffi::{c_int, c_void, CString},
+    ffi::{c_int, c_uint, c_void, CString},
     io::Read,
     marker::PhantomData,
     ptr::{self, NonNull},
@@ -9,11 +9,10 @@ use std::{
 
 use bitflags::bitflags;
 use mupdf_sys::*;
-use num_enum::TryFromPrimitive;
 
 use crate::{
-    context, rust_slice_to_ffi_ptr, unsafe_impl_ffi_wrapper, Buffer, Error, FFIWrapper, Image,
-    Matrix, Point, Quad, Rect, WriteMode,
+    context, from_enum, rust_slice_to_ffi_ptr, unsafe_impl_ffi_wrapper, Buffer, Error, FFIWrapper,
+    Image, Matrix, Point, Quad, Rect, WriteMode,
 };
 use crate::{output::Output, FFIAnalogue};
 
@@ -310,11 +309,15 @@ pub enum SearchHitResponse {
     AbortSearch = 1,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
-#[repr(u32)]
-pub enum TextBlockType {
-    Text = FZ_STEXT_BLOCK_TEXT as u32,
-    Image = FZ_STEXT_BLOCK_IMAGE as u32,
+from_enum! { c_uint,
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    pub enum TextBlockType {
+        Text = FZ_STEXT_BLOCK_TEXT,
+        Image = FZ_STEXT_BLOCK_IMAGE,
+        Struct = FZ_STEXT_BLOCK_STRUCT,
+        Vector = FZ_STEXT_BLOCK_VECTOR,
+        Grid = FZ_STEXT_BLOCK_GRID,
+    }
 }
 
 /// A text block is a list of lines of text (typically a paragraph), or an image.


### PR DESCRIPTION
This replaces the `num_enum::TryFromPrimitive` macro with a small declarative macro, allowing to remove the dependency on `num_enum` (which depends on `toml-edit` for example).