### PR TITLE
Remove bindings to private or c std types

### DIFF
--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -44,26 +44,29 @@ fn run() -> Result<()> {
     let out_dir =
         PathBuf::from(env::var_os("OUT_DIR").ok_or("Missing OUT_DIR environment variable")?);
 
-    let build_dir = out_dir.join("build");
-    let build_dir = build_dir.to_str().ok_or_else(|| {
-        format!("Build dir path is required to be valid UTF-8, got {build_dir:?}")
-    })?;
-
-    if let Err(e) = remove_dir_all(build_dir) {
-        if e.kind() != ErrorKind::NotFound {
-            println!("cargo:warning=Unable to clear {build_dir:?}. This may lead to flaky builds that might not incorporate configurations changes: {e}");
-        }
-    }
-
     let sysroot = find_clang_sysroot(&target)?;
 
-    copy_recursive(&src_dir, build_dir.as_ref(), &[".git".as_ref()])?;
+    let docs = env::var("DOCS_RS").is_ok();
+    if !docs {
+        let build_dir = out_dir.join("build");
+        let build_dir = build_dir.to_str().ok_or_else(|| {
+            format!("Build dir path is required to be valid UTF-8, got {build_dir:?}")
+        })?;
 
-    println!("cargo:rerun-if-changed=wrapper.h");
-    println!("cargo:rerun-if-changed=wrapper.c");
+        if let Err(e) = remove_dir_all(build_dir) {
+            if e.kind() != ErrorKind::NotFound {
+                println!("cargo:warning=Unable to clear {build_dir:?}. This may lead to flaky builds that might not incorporate configurations changes: {e}");
+            }
+        }
 
-    Build::new(&target).run(&target, build_dir)?;
-    build_wrapper(&target).map_err(|e| format!("Unable to compile mupdf wrapper:\n  {e}"))?;
+        copy_recursive(&src_dir, build_dir.as_ref(), &[".git".as_ref()])?;
+
+        println!("cargo:rerun-if-changed=wrapper.h");
+        println!("cargo:rerun-if-changed=wrapper.c");
+
+        Build::new(&target).run(&target, build_dir)?;
+        build_wrapper(&target).map_err(|e| format!("Unable to compile mupdf wrapper:\n  {e}"))?;
+    }
 
     generate_bindings(&target, &out_dir.join("bindings.rs"), sysroot)
         .map_err(|e| format!("Unable to generate mupdf bindings using bindgen:\n  {e}"))?;
@@ -165,15 +168,51 @@ fn generate_bindings(target: &Target, path: &Path, sysroot: Option<String>) -> R
     builder = builder
         .clang_arg("-Imupdf/include")
         .header("wrapper.h")
-        .header("wrapper.c")
+        .header("wrapper.c");
+
+    builder = builder
+        .allowlist_recursively(false)
+        .allowlist_type("__va_list_tag")
+        .allowlist_type("wchar_t")
+        .allowlist_type("FILE")
+        .opaque_type("FILE");
+
+    builder = builder
         .allowlist_item("fz_.*")
         .allowlist_item("FZ_.*")
         .allowlist_item("pdf_.*")
         .allowlist_item("PDF_.*")
+        .allowlist_type("cmap_splay")
         .allowlist_item("ucdn_.*")
         .allowlist_item("UCDN_.*")
         .allowlist_item("Memento_.*")
-        .allowlist_item("mupdf_.*")
+        .allowlist_item("mupdf_.*");
+
+    // build config
+    builder = builder
+        .blocklist_var("FZ_VERSION.*")
+        .blocklist_var("FZ_ENABLE_.*")
+        .blocklist_var("FZ_PLOTTERS_.*");
+
+    // internal implementation details, considered private
+    builder = builder
+        .blocklist_item("fz_jmp_buf")
+        .blocklist_function("fz_var_imp")
+        .blocklist_function("fz_push_try")
+        .blocklist_function("fz_do_.*")
+        .blocklist_var("FZ_JMPBUF_ALIGN")
+        .blocklist_type("fz_error_stack_slot")
+        .blocklist_type("fz_error_context")
+        .blocklist_type("fz_warn_context")
+        .blocklist_type("fz_aa_context")
+        .blocklist_type("fz_activity_.*")
+        .blocklist_function("fz_register_activity_logger")
+        .opaque_type("fz_context")
+        .blocklist_type("fz_new_context_imp")
+        .blocklist_type("fz_lock")
+        .blocklist_type("fz_unlock");
+
+    builder = builder
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .parse_callbacks(Box::new(DocsCallbacks::default()));
 
@@ -182,10 +221,7 @@ fn generate_bindings(target: &Target, path: &Path, sysroot: Option<String>) -> R
         builder = builder.parse_callbacks(Box::new(ZerocopyDeriveCallbacks));
     }
 
-    builder
-        .size_t_is_usize(true)
-        .generate()?
-        .write_to_file(path)?;
+    builder.use_core().generate()?.write_to_file(path)?;
 
     Ok(())
 }

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -172,8 +172,6 @@ fn generate_bindings(target: &Target, path: &Path, sysroot: Option<String>) -> R
 
     builder = builder
         .allowlist_recursively(false)
-        .allowlist_type("va_list")
-        .allowlist_type("__va_list_tag")
         .allowlist_type("wchar_t")
         .allowlist_type("FILE")
         .opaque_type("FILE");
@@ -188,6 +186,17 @@ fn generate_bindings(target: &Target, path: &Path, sysroot: Option<String>) -> R
         .allowlist_item("UCDN_.*")
         .allowlist_item("Memento_.*")
         .allowlist_item("mupdf_.*");
+
+    // remove va_list functions as for all of these versions using ... exist
+    builder = builder
+        .blocklist_function("Memento_vasprintf") // Memento_asprintf
+        .blocklist_function("fz_vthrow") // fz_throw
+        .blocklist_function("fz_vwarn") // fz_warn
+        .blocklist_function("fz_vlog_error_printf") // fz_log_error_printf
+        .blocklist_function("fz_append_vprintf") // fz_append_printf
+        .blocklist_function("fz_write_vprintf") // fz_write_printf
+        .blocklist_function("fz_vsnprintf") // fz_snprintf
+        .blocklist_function("fz_format_string"); // mupdf_format_string
 
     // build config
     builder = builder

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -172,6 +172,7 @@ fn generate_bindings(target: &Target, path: &Path, sysroot: Option<String>) -> R
 
     builder = builder
         .allowlist_recursively(false)
+        .allowlist_type("va_list")
         .allowlist_type("__va_list_tag")
         .allowlist_type("wchar_t")
         .allowlist_type("FILE")

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -46,7 +46,7 @@ fn run() -> Result<()> {
 
     let sysroot = find_clang_sysroot(&target)?;
 
-    let docs = env::var("DOCS_RS").is_ok();
+    let docs = env::var_os("DOCS_RS").is_some();
     if !docs {
         let build_dir = out_dir.join("build");
         let build_dir = build_dir.to_str().ok_or_else(|| {

--- a/mupdf-sys/make.rs
+++ b/mupdf-sys/make.rs
@@ -201,6 +201,11 @@ impl Make {
 
         self.make_bool("verbose", true);
 
+        // harfbuzz sometimes requires this
+        if target.os == "windows" {
+            self.build.flag("-Wa,-mbig-obj");
+        }
+
         self.libs()?;
         self.cpus(target);
 

--- a/mupdf-sys/src/lib.rs
+++ b/mupdf-sys/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/mupdf-sys/wrapper.c
+++ b/mupdf-sys/wrapper.c
@@ -3273,3 +3273,10 @@ int32_t mupdf_search_stext_page_cb(fz_context *ctx, fz_stext_page *page, const c
 	}
 	return count;
 }
+
+void mupdf_format_string(fz_context *ctx, void *user, void (*emit)(fz_context *ctx, void *user, int c), const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+	fz_format_string(ctx, user, emit, fmt, ap);
+	va_end(ap);
+}


### PR DESCRIPTION
This makes functions and types specified as internal not show up in the bindings. On top it also only exports the needed C std types and makes them opaque.

Before
![rustdoc screenshot with more C std types](https://github.com/user-attachments/assets/7a730e73-c57e-456d-b9cf-6c1ffa342eb8)

After
![rustdoc screenshot with less C std types](https://github.com/user-attachments/assets/599504af-41e0-49ea-a281-c3540da656d2)

The harfbuzz cc flag fixes an error that occurs on my machine when cross compiling to windows (the harfbuzz-sys crate also has this flag set).