### PR TITLE
Fix 1.88 clippy complaints

### DIFF
--- a/src/colorspace.rs
+++ b/src/colorspace.rs
@@ -214,9 +214,9 @@ mod test {
             )
             .unwrap();
         assert_eq!(n, 3);
-        assert!((0.59..0.61).contains(&gray[0]), "gray = {:?}", gray);
-        assert!((0.59..0.61).contains(&gray[1]), "gray = {:?}", gray);
-        assert!((0.59..0.61).contains(&gray[2]), "gray = {:?}", gray);
+        assert!((0.59..0.61).contains(&gray[0]), "gray = {gray:?}");
+        assert!((0.59..0.61).contains(&gray[1]), "gray = {gray:?}");
+        assert!((0.59..0.61).contains(&gray[2]), "gray = {gray:?}");
         assert_eq!(gray[3], 0.0);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,13 +80,13 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            Error::Io(ref err) => err.fmt(f),
-            Error::InvalidLanguage(ref lang) => write!(f, "invalid language {}", lang),
+        match self {
+            Error::Io(err) => err.fmt(f),
+            Error::InvalidLanguage(lang) => write!(f, "invalid language {lang}"),
             Error::InvalidPdfDocument => write!(f, "invalid pdf document"),
-            Error::MuPdf(ref err) => err.fmt(f),
-            Error::Nul(ref err) => err.fmt(f),
-            Error::IntConversion(ref err) => err.fmt(f),
+            Error::MuPdf(err) => err.fmt(f),
+            Error::Nul(err) => err.fmt(f),
+            Error::IntConversion(err) => err.fmt(f),
             Error::InvalidUtf8 => f.write_str("string contained invalid utf-8"),
             Error::UnexpectedNullPtr => write!(
                 f,

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -379,7 +379,7 @@ impl Clone for PdfObject {
 impl fmt::Display for PdfObject {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = self.print(true, false).unwrap();
-        write!(f, "{}", s)
+        f.write_str(&s)
     }
 }
 

--- a/tests/test_issues.rs
+++ b/tests/test_issues.rs
@@ -38,7 +38,7 @@ fn test_issue_27_flatten() {
 fn test_issue_43_malloc() {
     let density = 300;
     let height = 1500;
-    let options = format!("resolution={},height={}", density, height);
+    let options = format!("resolution={density},height={height}");
 
     let mut writer =
         mupdf::DocumentWriter::new("tests/output/issue_43.png", "png", options.as_str()).unwrap();
@@ -57,7 +57,7 @@ fn test_issue_43_malloc() {
 fn test_issue_60_display_list() {
     let doc = PdfDocument::from_bytes(include_bytes!("../tests/files/p11.pdf")).unwrap();
     let num_pages = doc.page_count().unwrap();
-    println!("Document has {} page(s)", num_pages);
+    println!("Document has {num_pages} page(s)");
 
     let _display_list: Vec<(usize, mupdf::DisplayList)> = doc
         .pages()


### PR DESCRIPTION
Applies the now warn-by-default [`uninlined_format_args`](https://rust-lang.github.io/rust-clippy/stable/index.html?groups=style#uninlined_format_args) clippy lint in some places were it was still missing.