### PR TITLE
Use macro to simplify common wrapper operations

### DIFF
--- a/mupdf-sys/wrapper.c
+++ b/mupdf-sys/wrapper.c
@@ -44,6 +44,32 @@ static void unlock(void *user, int lock)
 #endif
 }
 
+#define TRY_CATCH(ty, init, call) \
+do { \
+    ty result = init; \
+    fz_try(ctx) \
+    { \
+        result = call; \
+    } \
+    fz_catch(ctx) \
+    { \
+        mupdf_save_error(ctx, errptr); \
+    } \
+    return result; \
+} while (0)
+
+#define TRY_CATCH_VOID(call) \
+do { \
+    fz_try(ctx) \
+    { \
+        call; \
+    } \
+    fz_catch(ctx) \
+    { \
+        mupdf_save_error(ctx, errptr); \
+    } \
+} while (0)
+
 static const fz_locks_context locks =
     {
         NULL, /* user */
@@ -153,16 +179,7 @@ fz_context *mupdf_new_base_context()
 /* Rect */
 fz_rect mupdf_adjust_rect_for_stroke(fz_context *ctx, fz_rect self, fz_stroke_state *stroke, fz_matrix ctm, mupdf_error_t **errptr)
 {
-    fz_rect rect;
-    fz_try(ctx)
-    {
-        rect = fz_adjust_rect_for_stroke(ctx, self, stroke, ctm);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return rect;
+    TRY_CATCH(fz_rect, {}, fz_adjust_rect_for_stroke(ctx, self, stroke, ctm));
 }
 
 /* Pixmap */
@@ -184,52 +201,22 @@ fz_pixmap *mupdf_new_pixmap(fz_context *ctx, fz_colorspace *cs, int x, int y, in
 
 fz_pixmap *mupdf_clone_pixmap(fz_context *ctx, fz_pixmap *self, mupdf_error_t **errptr)
 {
-    fz_pixmap *pixmap = NULL;
-    fz_try(ctx)
-    {
-        pixmap = fz_clone_pixmap(ctx, self);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return pixmap;
+    TRY_CATCH(fz_pixmap*, NULL, fz_clone_pixmap(ctx, self));
 }
 
 void mupdf_clear_pixmap(fz_context *ctx, fz_pixmap *pixmap, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_clear_pixmap(ctx, pixmap);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_clear_pixmap(ctx, pixmap));
 }
 
 void mupdf_clear_pixmap_with_value(fz_context *ctx, fz_pixmap *pixmap, int value, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_clear_pixmap_with_value(ctx, pixmap, value);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_clear_pixmap_with_value(ctx, pixmap, value));
 }
 
 void mupdf_invert_pixmap(fz_context *ctx, fz_pixmap *pixmap, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_invert_pixmap(ctx, pixmap);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_invert_pixmap(ctx, pixmap));
 }
 
 void mupdf_gamma_pixmap(fz_context *ctx, fz_pixmap *pixmap, float gamma, mupdf_error_t **errptr)
@@ -239,14 +226,8 @@ void mupdf_gamma_pixmap(fz_context *ctx, fz_pixmap *pixmap, float gamma, mupdf_e
         *errptr = mupdf_new_error_from_str("colorspace invalid for function");
         return;
     }
-    fz_try(ctx)
-    {
-        fz_gamma_pixmap(ctx, pixmap, gamma);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+
+    TRY_CATCH_VOID(fz_gamma_pixmap(ctx, pixmap, gamma));
 }
 
 void mupdf_tint_pixmap(fz_context *ctx, fz_pixmap *pixmap, int black, int white, mupdf_error_t **errptr)
@@ -257,14 +238,8 @@ void mupdf_tint_pixmap(fz_context *ctx, fz_pixmap *pixmap, int black, int white,
         *errptr = mupdf_new_error_from_str("colorspace invalid for function");
         return;
     }
-    fz_try(ctx)
-    {
-        fz_tint_pixmap(ctx, pixmap, black, white);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+
+    TRY_CATCH_VOID(fz_tint_pixmap(ctx, pixmap, black, white));
 }
 
 void mupdf_save_pixmap_as(fz_context *ctx, fz_pixmap *pixmap, const char *filename, int format, mupdf_error_t **errptr)
@@ -371,130 +346,49 @@ fz_font *mupdf_new_font(fz_context *ctx, const char *name, int index, mupdf_erro
 
 fz_font *mupdf_new_font_from_buffer(fz_context *ctx, const char *name, int index, fz_buffer *buffer, mupdf_error_t **errptr)
 {
-    fz_font *font = NULL;
-    fz_try(ctx)
-    {
-        font = fz_new_font_from_buffer(ctx, name, buffer, index, 0);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return font;
+    TRY_CATCH(fz_font*, NULL, fz_new_font_from_buffer(ctx, name, buffer, index, 0));
 }
 
 int mupdf_encode_character(fz_context *ctx, fz_font *font, int unicode, mupdf_error_t **errptr)
 {
-    int glyph = 0;
-    fz_try(ctx)
-    {
-        glyph = fz_encode_character(ctx, font, unicode);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return glyph;
+    TRY_CATCH(int, 0, fz_encode_character(ctx, font, unicode));
 }
 
 float mupdf_advance_glyph(fz_context *ctx, fz_font *font, int glyph, bool wmode, mupdf_error_t **errptr)
 {
-    float advance = 0;
-    fz_try(ctx)
-    {
-        advance = fz_advance_glyph(ctx, font, glyph, wmode);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return advance;
+    TRY_CATCH(float, 0.0, fz_advance_glyph(ctx, font, glyph, wmode));
 }
 
 fz_path *mupdf_outline_glyph(fz_context *ctx, fz_font *font, int glyph, fz_matrix ctm, mupdf_error_t **errptr)
 {
-    fz_path *path = NULL;
-    fz_try(ctx)
-    {
-        path = fz_outline_glyph(ctx, font, glyph, ctm);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return path;
+    TRY_CATCH(fz_path*, NULL, fz_outline_glyph(ctx, font, glyph, ctm));
 }
 
 /* Image */
 fz_image *mupdf_new_image_from_pixmap(fz_context *ctx, fz_pixmap *pixmap, mupdf_error_t **errptr)
 {
-    fz_image *image = NULL;
-    fz_try(ctx)
-    {
-        image = fz_new_image_from_pixmap(ctx, pixmap, NULL);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return image;
+    TRY_CATCH(fz_image*, NULL, fz_new_image_from_pixmap(ctx, pixmap, NULL));
 }
 
 fz_image *mupdf_new_image_from_file(fz_context *ctx, const char *filename, mupdf_error_t **errptr)
 {
-    fz_image *image = NULL;
-    fz_try(ctx)
-    {
-        image = fz_new_image_from_file(ctx, filename);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return image;
+    TRY_CATCH(fz_image*, NULL, fz_new_image_from_file(ctx, filename));
 }
 
 fz_image *mupdf_new_image_from_display_list(fz_context *ctx, fz_display_list *list, float w, float h, mupdf_error_t **errptr)
 {
-    fz_image *image = NULL;
-    fz_try(ctx)
-    {
-        image = fz_new_image_from_display_list(ctx, w, h, list);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return image;
+    TRY_CATCH(fz_image*, NULL, fz_new_image_from_display_list(ctx, w, h, list));
 }
 
 fz_pixmap *mupdf_get_pixmap_from_image(fz_context *ctx, fz_image *image, mupdf_error_t **errptr)
 {
-    fz_pixmap *pixmap = NULL;
-    fz_try(ctx)
-    {
-        pixmap = fz_get_pixmap_from_image(ctx, image, NULL, NULL, NULL, NULL);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return pixmap;
+    TRY_CATCH(fz_pixmap*, NULL, fz_get_pixmap_from_image(ctx, image, NULL, NULL, NULL, NULL));
 }
 
 /* Text */
 fz_text *mupdf_new_text(fz_context *ctx, mupdf_error_t **errptr)
 {
-    fz_text *text = NULL;
-    fz_try(ctx)
-    {
-        text = fz_new_text(ctx);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return text;
+    TRY_CATCH(fz_text*, NULL, fz_new_text(ctx));
 }
 
 /* StrokeState */
@@ -532,215 +426,91 @@ fz_stroke_state *mupdf_new_stroke_state(
 
 fz_rect mupdf_bound_text(fz_context *ctx, fz_text *text, fz_stroke_state *stroke, fz_matrix ctm, mupdf_error_t **errptr)
 {
-    fz_rect rect;
-    fz_try(ctx)
-    {
-        rect = fz_bound_text(ctx, text, stroke, ctm);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return rect;
+    TRY_CATCH(fz_rect, {}, fz_bound_text(ctx, text, stroke, ctm));
 }
 
 /* Path */
 fz_path *mupdf_new_path(fz_context *ctx, mupdf_error_t **errptr)
 {
-    fz_path *path = NULL;
-    fz_try(ctx)
-    {
-        path = fz_new_path(ctx);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return path;
+    TRY_CATCH(fz_path*, NULL, fz_new_path(ctx));
 }
 
 fz_path *mupdf_clone_path(fz_context *ctx, fz_path *old_path, mupdf_error_t **errptr)
 {
-    fz_path *path = NULL;
-    fz_try(ctx)
-    {
-        path = fz_clone_path(ctx, old_path);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return path;
+    TRY_CATCH(fz_path*, NULL, fz_clone_path(ctx, old_path));
 }
 
 void mupdf_trim_path(fz_context *ctx, fz_path *path, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_trim_path(ctx, path);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_trim_path(ctx, path));
 }
 
 void mupdf_moveto(fz_context *ctx, fz_path *path, float x, float y, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_moveto(ctx, path, x, y);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_moveto(ctx, path, x, y));
 }
 
 void mupdf_lineto(fz_context *ctx, fz_path *path, float x, float y, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_lineto(ctx, path, x, y);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_lineto(ctx, path, x, y));
 }
 
 void mupdf_closepath(fz_context *ctx, fz_path *path, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_closepath(ctx, path);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_closepath(ctx, path));
 }
 
 void mupdf_rectto(fz_context *ctx, fz_path *path, float x1, float y1, float x2, float y2, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_rectto(ctx, path, x1, y1, x2, y2);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_rectto(ctx, path, x1, y1, x2, y2));
 }
 
 void mupdf_curveto(fz_context *ctx, fz_path *path, float cx1, float cy1, float cx2, float cy2, float ex, float ey, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_curveto(ctx, path, cx1, cy1, cx2, cy2, ex, ey);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_curveto(ctx, path, cx1, cy1, cx2, cy2, ex, ey));
 }
 
 void mupdf_curvetov(fz_context *ctx, fz_path *path, float cx, float cy, float ex, float ey, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_curvetov(ctx, path, cx, cy, ex, ey);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_curvetov(ctx, path, cx, cy, ex, ey));
 }
 
 void mupdf_curvetoy(fz_context *ctx, fz_path *path, float cx, float cy, float ex, float ey, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_curvetoy(ctx, path, cx, cy, ex, ey);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_curvetoy(ctx, path, cx, cy, ex, ey));
 }
 
 void mupdf_transform_path(fz_context *ctx, fz_path *path, fz_matrix ctm, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_transform_path(ctx, path, ctm);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_transform_path(ctx, path, ctm));
 }
 
 fz_rect mupdf_bound_path(fz_context *ctx, fz_path *path, fz_stroke_state *stroke, fz_matrix ctm, mupdf_error_t **errptr)
 {
-    fz_rect rect;
-    fz_try(ctx)
-    {
-        rect = fz_bound_path(ctx, path, stroke, ctm);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return rect;
+    TRY_CATCH(fz_rect, {}, fz_bound_path(ctx, path, stroke, ctm));
 }
 
 void mupdf_walk_path(fz_context *ctx, const fz_path *path, const fz_path_walker *walker, void *arg, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_walk_path(ctx, path, walker, arg);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_walk_path(ctx, path, walker, arg));
 }
 
 /* Page */
 fz_rect mupdf_bound_page(fz_context *ctx, fz_page *page, mupdf_error_t **errptr)
 {
-    fz_rect rect;
-    fz_try(ctx)
-    {
-        rect = fz_bound_page(ctx, page);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return rect;
+    TRY_CATCH(fz_rect, {}, fz_bound_page(ctx, page));
 }
 
 fz_pixmap *mupdf_page_to_pixmap(fz_context *ctx, fz_page *page, fz_matrix ctm, fz_colorspace *cs, bool alpha, bool show_extras, mupdf_error_t **errptr)
 {
-    fz_pixmap *pixmap = NULL;
-    fz_try(ctx)
+    if (show_extras)
     {
-        if (show_extras)
-        {
-            pixmap = fz_new_pixmap_from_page(ctx, page, ctm, cs, alpha);
-        }
-        else
-        {
-            pixmap = fz_new_pixmap_from_page_contents(ctx, page, ctm, cs, alpha);
-        }
+        TRY_CATCH(fz_pixmap*, NULL, fz_new_pixmap_from_page(ctx, page, ctm, cs, alpha));
     }
-    fz_catch(ctx)
+    else
     {
-        mupdf_save_error(ctx, errptr);
+        TRY_CATCH(fz_pixmap*, NULL, fz_new_pixmap_from_page_contents(ctx, page, ctm, cs, alpha));
     }
-    return pixmap;
 }
 
 fz_buffer *mupdf_page_to_svg(fz_context *ctx, fz_page *page, fz_matrix ctm, fz_cookie *cookie, mupdf_error_t **errptr)
@@ -776,234 +546,98 @@ fz_buffer *mupdf_page_to_svg(fz_context *ctx, fz_page *page, fz_matrix ctm, fz_c
 
 fz_stext_page *mupdf_new_stext_page_from_page(fz_context *ctx, fz_page *page, const fz_stext_options *options, mupdf_error_t **errptr)
 {
-    fz_stext_page *text_page = NULL;
-    fz_try(ctx)
-    {
-        text_page = fz_new_stext_page_from_page(ctx, page, options);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return text_page;
+    TRY_CATCH(fz_stext_page*, NULL, fz_new_stext_page_from_page(ctx, page, options));
 }
 
 fz_display_list *mupdf_page_to_display_list(fz_context *ctx, fz_page *page, bool annots, mupdf_error_t **errptr)
 {
-    fz_display_list *list = NULL;
-    fz_try(ctx)
+    if (annots)
     {
-        if (annots)
-        {
-            list = fz_new_display_list_from_page(ctx, page);
-        }
-        else
-        {
-            list = fz_new_display_list_from_page_contents(ctx, page);
-        }
+        TRY_CATCH(fz_display_list*, NULL, fz_new_display_list_from_page(ctx, page));
     }
-    fz_catch(ctx)
+    else
     {
-        mupdf_save_error(ctx, errptr);
+        TRY_CATCH(fz_display_list*, NULL, fz_new_display_list_from_page_contents(ctx, page));
     }
-    return list;
 }
 
 void mupdf_run_page(fz_context *ctx, fz_page *page, fz_device *device, fz_matrix ctm, fz_cookie *cookie, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_run_page(ctx, page, device, ctm, cookie);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_run_page(ctx, page, device, ctm, cookie));
 }
 
 void mupdf_run_page_contents(fz_context *ctx, fz_page *page, fz_device *device, fz_matrix ctm, fz_cookie *cookie, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_run_page_contents(ctx, page, device, ctm, cookie);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_run_page_contents(ctx, page, device, ctm, cookie));
 }
 
 void mupdf_run_page_annots(fz_context *ctx, fz_page *page, fz_device *device, fz_matrix ctm, fz_cookie *cookie, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_run_page_annots(ctx, page, device, ctm, cookie);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_run_page_annots(ctx, page, device, ctm, cookie));
 }
 
 void mupdf_run_page_widgets(fz_context *ctx, fz_page *page, fz_device *device, fz_matrix ctm, fz_cookie *cookie, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_run_page_widgets(ctx, page, device, ctm, cookie);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_run_page_widgets(ctx, page, device, ctm, cookie));
 }
 
 fz_output *mupdf_new_output_with_buffer(fz_context *ctx, fz_buffer *buf, mupdf_error_t **errptr) {
-    fz_output* output;
-    fz_try(ctx)
-    {
-        output = fz_new_output_with_buffer(ctx, buf);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return output;
+    TRY_CATCH(fz_output*, NULL, fz_new_output_with_buffer(ctx, buf));
 }
 
 void mupdf_print_stext_page_as_html(fz_context *ctx, fz_output *out, fz_stext_page *page, int id, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_print_stext_page_as_html(ctx, out, page, id);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_print_stext_page_as_html(ctx, out, page, id));
 }
 
 void mupdf_print_stext_header_as_html(fz_context *ctx, fz_output *out, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_print_stext_header_as_html(ctx, out);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_print_stext_header_as_html(ctx, out));
 }
 
 void mupdf_print_stext_trailer_as_html(fz_context *ctx, fz_output *out, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_print_stext_trailer_as_html(ctx, out);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_print_stext_trailer_as_html(ctx, out));
 }
 
 void mupdf_print_stext_page_as_xhtml(fz_context *ctx, fz_output *out, fz_stext_page *page, int id, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_print_stext_page_as_xhtml(ctx, out, page, id);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_print_stext_page_as_xhtml(ctx, out, page, id));
 }
 
 void mupdf_print_stext_header_as_xhtml(fz_context *ctx, fz_output *out, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_print_stext_header_as_xhtml(ctx, out);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_print_stext_header_as_xhtml(ctx, out));
 }
 
 void mupdf_print_stext_trailer_as_xhtml(fz_context *ctx, fz_output *out, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_print_stext_trailer_as_xhtml(ctx, out);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_print_stext_trailer_as_xhtml(ctx, out));
 }
 
 void mupdf_print_stext_page_as_xml(fz_context *ctx, fz_output *out, fz_stext_page *page, int id, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_print_stext_page_as_xml(ctx, out, page, id);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_print_stext_page_as_xml(ctx, out, page, id));
 }
 
 void mupdf_print_stext_page_as_text(fz_context *ctx, fz_output *out, fz_stext_page *page, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_print_stext_page_as_text(ctx, out, page);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_print_stext_page_as_text(ctx, out, page));
 }
 
 void mupdf_print_stext_page_as_json(fz_context *ctx, fz_output *out, fz_stext_page *page, float scale, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_print_stext_page_as_json(ctx, out, page, scale);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_print_stext_page_as_json(ctx, out, page, scale));
 }
 
 fz_link *mupdf_load_links(fz_context *ctx, fz_page *page, mupdf_error_t **errptr)
 {
-    fz_link *link = NULL;
-    fz_try(ctx)
-    {
-        link = fz_load_links(ctx, page);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return link;
+    TRY_CATCH(fz_link*, NULL, fz_load_links(ctx, page));
 }
 
 fz_separations *mupdf_page_separations(fz_context *ctx, fz_page *page, mupdf_error_t **errptr)
 {
-    fz_separations *seps = NULL;
-    fz_try(ctx)
-    {
-        seps = fz_page_separations(ctx, page);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return seps;
+    TRY_CATCH(fz_separations*, NULL, fz_page_separations(ctx, page));
 }
 
 fz_quad *mupdf_search_page(fz_context *ctx, fz_page *page, const char *needle, const int hit_max, int *hit_count, mupdf_error_t **errptr)
@@ -1063,58 +697,24 @@ fz_quad *mupdf_search_stext_page(fz_context *ctx, fz_stext_page *page, const cha
 /* Cookie */
 fz_cookie *mupdf_new_cookie(fz_context *ctx, mupdf_error_t **errptr)
 {
-    fz_cookie *cookie = NULL;
-    fz_try(ctx)
-    {
-        cookie = fz_malloc_struct(ctx, fz_cookie);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return cookie;
+    TRY_CATCH(fz_cookie*, NULL, fz_malloc_struct(ctx, fz_cookie));
 }
 
 /* Colorspace */
 void mupdf_convert_color(fz_context *ctx, fz_colorspace *ss, const float *sv, fz_colorspace *ds, float *dv, fz_colorspace *is, fz_color_params params, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_convert_color(ctx, ss, sv, ds, dv, is, params);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_convert_color(ctx, ss, sv, ds, dv, is, params));
 }
 
 /* DisplayList */
 fz_display_list *mupdf_new_display_list(fz_context *ctx, fz_rect mediabox, mupdf_error_t **errptr)
 {
-    fz_display_list *list = NULL;
-    fz_try(ctx)
-    {
-        list = fz_new_display_list(ctx, mediabox);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return list;
+    TRY_CATCH(fz_display_list*, NULL, fz_new_display_list(ctx, mediabox));
 }
 
 fz_pixmap *mupdf_display_list_to_pixmap(fz_context *ctx, fz_display_list *list, fz_matrix ctm, fz_colorspace *cs, bool alpha, mupdf_error_t **errptr)
 {
-    fz_pixmap *pixmap = NULL;
-    fz_try(ctx)
-    {
-        pixmap = fz_new_pixmap_from_display_list(ctx, list, ctm, cs, alpha);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return pixmap;
+    TRY_CATCH(fz_pixmap*, NULL, fz_new_pixmap_from_display_list(ctx, list, ctm, cs, alpha));
 }
 
 fz_stext_page *mupdf_display_list_to_text_page(fz_context *ctx, fz_display_list *list, int flags, mupdf_error_t **errptr)
@@ -1135,14 +735,7 @@ fz_stext_page *mupdf_display_list_to_text_page(fz_context *ctx, fz_display_list 
 
 void mupdf_display_list_run(fz_context *ctx, fz_display_list *list, fz_device *device, fz_matrix ctm, fz_rect area, fz_cookie *cookie, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_run_display_list(ctx, list, device, ctm, area, cookie);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_run_display_list(ctx, list, device, ctm, area, cookie));
 }
 
 fz_quad *mupdf_search_display_list(fz_context *ctx, fz_display_list *list, const char *needle, const int hit_max, int *hit_count, mupdf_error_t **errptr)
@@ -1175,16 +768,7 @@ fz_quad *mupdf_search_display_list(fz_context *ctx, fz_display_list *list, const
 /* PDFObject */
 pdf_obj *mupdf_pdf_clone_obj(fz_context *ctx, pdf_obj *self, mupdf_error_t **errptr)
 {
-    pdf_obj *obj = NULL;
-    fz_try(ctx)
-    {
-        obj = pdf_deep_copy_obj(ctx, self);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return obj;
+    TRY_CATCH(pdf_obj*, NULL, pdf_deep_copy_obj(ctx, self));
 }
 
 pdf_document *mupdf_pdf_get_bound_document(fz_context *ctx, pdf_obj *obj)
@@ -1367,100 +951,37 @@ pdf_obj *mupdf_pdf_new_bool(bool b)
 
 pdf_obj *mupdf_pdf_new_int(fz_context *ctx, int i, mupdf_error_t **errptr)
 {
-    pdf_obj *obj = NULL;
-    fz_try(ctx)
-    {
-        obj = pdf_new_int(ctx, i);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return obj;
+    TRY_CATCH(pdf_obj*, NULL, pdf_new_int(ctx, i));
 }
 
 pdf_obj *mupdf_pdf_new_real(fz_context *ctx, float f, mupdf_error_t **errptr)
 {
-    pdf_obj *obj = NULL;
-    fz_try(ctx)
-    {
-        obj = pdf_new_real(ctx, f);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return obj;
+        TRY_CATCH(pdf_obj*, NULL, pdf_new_real(ctx, f));
 }
 
 pdf_obj *mupdf_pdf_new_string(fz_context *ctx, const char *s, mupdf_error_t **errptr)
 {
-    pdf_obj *obj = NULL;
-    fz_try(ctx)
-    {
-        obj = pdf_new_text_string(ctx, s);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return obj;
+    TRY_CATCH(pdf_obj*, NULL, pdf_new_text_string(ctx, s));
 }
 
 pdf_obj *mupdf_pdf_new_name(fz_context *ctx, const char *name, mupdf_error_t **errptr)
 {
-    pdf_obj *obj = NULL;
-    fz_try(ctx)
-    {
-        obj = pdf_new_name(ctx, name);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return obj;
+    TRY_CATCH(pdf_obj*, NULL, pdf_new_name(ctx, name));
 }
 
 pdf_obj *mupdf_pdf_new_indirect(fz_context *ctx, pdf_document *pdf, int num, int gen, mupdf_error_t **errptr)
 {
-    pdf_obj *obj = NULL;
-    fz_try(ctx)
-    {
-        obj = pdf_new_indirect(ctx, pdf, num, gen);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return obj;
+    TRY_CATCH(pdf_obj*, NULL, pdf_new_indirect(ctx, pdf, num, gen));
 }
 
 pdf_obj *mupdf_pdf_new_array(fz_context *ctx, pdf_document *pdf, int capacity, mupdf_error_t **errptr)
 {
-    pdf_obj *obj = NULL;
-    fz_try(ctx)
-    {
-        obj = pdf_new_array(ctx, pdf, capacity);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return obj;
+    TRY_CATCH(pdf_obj*, NULL, pdf_new_array(ctx, pdf, capacity));
 }
 
 pdf_obj *mupdf_pdf_new_dict(fz_context *ctx, pdf_document *pdf, int capacity, mupdf_error_t **errptr)
 {
-    pdf_obj *obj = NULL;
-    fz_try(ctx)
-    {
-        obj = pdf_new_dict(ctx, pdf, capacity);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return obj;
+    TRY_CATCH(pdf_obj*, NULL, pdf_new_dict(ctx, pdf, capacity));
 }
 
 pdf_obj *mupdf_pdf_obj_from_str(fz_context *ctx, pdf_document *pdf, const char *src, mupdf_error_t **errptr)
@@ -1488,100 +1009,37 @@ pdf_obj *mupdf_pdf_obj_from_str(fz_context *ctx, pdf_document *pdf, const char *
 
 bool mupdf_pdf_to_bool(fz_context *ctx, pdf_obj *obj, mupdf_error_t **errptr)
 {
-    bool b = false;
-    fz_try(ctx)
-    {
-        b = pdf_to_bool(ctx, obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return b;
+    TRY_CATCH(bool, false, pdf_to_bool(ctx, obj));
 }
 
 int mupdf_pdf_to_int(fz_context *ctx, pdf_obj *obj, mupdf_error_t **errptr)
 {
-    int i = 0;
-    fz_try(ctx)
-    {
-        i = pdf_to_int(ctx, obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return i;
+    TRY_CATCH(int, 0, pdf_to_int(ctx, obj));
 }
 
 float mupdf_pdf_to_float(fz_context *ctx, pdf_obj *obj, mupdf_error_t **errptr)
 {
-    float f = 0.0;
-    fz_try(ctx)
-    {
-        f = pdf_to_real(ctx, obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return f;
+    TRY_CATCH(float, 0.0, pdf_to_real(ctx, obj));
 }
 
 int mupdf_pdf_to_indirect(fz_context *ctx, pdf_obj *obj, mupdf_error_t **errptr)
 {
-    int ind = 0;
-    fz_try(ctx)
-    {
-        ind = pdf_to_num(ctx, obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return ind;
+    TRY_CATCH(int, 0, pdf_to_num(ctx, obj));
 }
 
 const char *mupdf_pdf_to_string(fz_context *ctx, pdf_obj *obj, mupdf_error_t **errptr)
 {
-    const char *s = NULL;
-    fz_try(ctx)
-    {
-        s = pdf_to_text_string(ctx, obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return s;
+    TRY_CATCH(const char *, NULL, pdf_to_text_string(ctx, obj));
 }
 
 const char *mupdf_pdf_to_name(fz_context *ctx, pdf_obj *obj, mupdf_error_t **errptr)
 {
-    const char *s = NULL;
-    fz_try(ctx)
-    {
-        s = pdf_to_name(ctx, obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return s;
+    TRY_CATCH(const char*, NULL, pdf_to_name(ctx, obj));
 }
 
-const unsigned char *mupdf_pdf_to_bytes(fz_context *ctx, pdf_obj *obj, size_t *len, mupdf_error_t **errptr)
+const char *mupdf_pdf_to_bytes(fz_context *ctx, pdf_obj *obj, size_t *len, mupdf_error_t **errptr)
 {
-    const char *s = NULL;
-    fz_try(ctx)
-    {
-        s = pdf_to_string(ctx, obj, len);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return (unsigned char *)s;
+    TRY_CATCH(const char*, NULL, pdf_to_string(ctx, obj, len));
 }
 
 pdf_obj *mupdf_pdf_resolve_indirect(fz_context *ctx, pdf_obj *obj, mupdf_error_t **errptr)
@@ -1676,30 +1134,12 @@ pdf_obj *mupdf_pdf_dict_get_inheritable(fz_context *ctx, pdf_obj *obj, pdf_obj *
 
 fz_buffer *mupdf_pdf_read_stream(fz_context *ctx, pdf_obj *obj, mupdf_error_t **errptr)
 {
-    fz_buffer *buf = NULL;
-    fz_try(ctx)
-    {
-        buf = pdf_load_stream(ctx, obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return buf;
+    TRY_CATCH(fz_buffer*, NULL, pdf_load_stream(ctx, obj));
 }
 
 fz_buffer *mupdf_pdf_read_raw_stream(fz_context *ctx, pdf_obj *obj, mupdf_error_t **errptr)
 {
-    fz_buffer *buf = NULL;
-    fz_try(ctx)
-    {
-        buf = pdf_load_raw_stream(ctx, obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return buf;
+    TRY_CATCH(fz_buffer*, NULL, pdf_load_raw_stream(ctx, obj));
 }
 
 void mupdf_pdf_write_object(fz_context *ctx, pdf_obj *self, pdf_obj *obj, mupdf_error_t **errptr)
@@ -1710,14 +1150,8 @@ void mupdf_pdf_write_object(fz_context *ctx, pdf_obj *self, pdf_obj *obj, mupdf_
         *errptr = mupdf_new_error_from_str("object not bound to document");
         return;
     }
-    fz_try(ctx)
-    {
-        pdf_update_object(ctx, pdf, pdf_to_num(ctx, self), obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+
+    TRY_CATCH_VOID(pdf_update_object(ctx, pdf, pdf_to_num(ctx, self), obj));
 }
 
 void mupdf_pdf_write_stream_buffer(fz_context *ctx, pdf_obj *obj, fz_buffer *buf, int compressed, mupdf_error_t **errptr)
@@ -1728,102 +1162,43 @@ void mupdf_pdf_write_stream_buffer(fz_context *ctx, pdf_obj *obj, fz_buffer *buf
         *errptr = mupdf_new_error_from_str("object not bound to document");
         return;
     }
-    fz_try(ctx)
-    {
-        pdf_update_stream(ctx, pdf, obj, buf, compressed);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+
+    TRY_CATCH_VOID(pdf_update_stream(ctx, pdf, obj, buf, compressed));
 }
 
 int mupdf_pdf_array_len(fz_context *ctx, pdf_obj *obj, mupdf_error_t **errptr)
 {
-    int len = 0;
-    fz_try(ctx)
-    {
-        len = pdf_array_len(ctx, obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return len;
+    TRY_CATCH(int, 0, pdf_array_len(ctx, obj));
 }
 
 void mupdf_pdf_array_put(fz_context *ctx, pdf_obj *self, int i, pdf_obj *item, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        pdf_array_put(ctx, self, i, item);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_array_put(ctx, self, i, item));
 }
 
 void mupdf_pdf_array_push(fz_context *ctx, pdf_obj *self, pdf_obj *item, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        pdf_array_push(ctx, self, item);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_array_push(ctx, self, item));
 }
 
 void mupdf_pdf_array_delete(fz_context *ctx, pdf_obj *self, int i, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        pdf_array_delete(ctx, self, i);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_array_delete(ctx, self, i));
 }
 
 int mupdf_pdf_dict_len(fz_context *ctx, pdf_obj *obj, mupdf_error_t **errptr)
 {
-    int len = 0;
-    fz_try(ctx)
-    {
-        len = pdf_dict_len(ctx, obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return len;
+    TRY_CATCH(int, 0, pdf_dict_len(ctx, obj));
 }
 
 void mupdf_pdf_dict_put(fz_context *ctx, pdf_obj *self, pdf_obj *key, pdf_obj *value, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        pdf_dict_put(ctx, self, key, value);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_dict_put(ctx, self, key, value));
 }
 
 void mupdf_pdf_dict_delete(fz_context *ctx, pdf_obj *self, pdf_obj *key, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        pdf_dict_del(ctx, self, key);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_dict_del(ctx, self, key));
 }
 
 char *mupdf_pdf_obj_to_string(fz_context *ctx, pdf_obj *obj, bool tight, bool ascii, mupdf_error_t **errptr)
@@ -1866,57 +1241,23 @@ size_t mupdf_buffer_read_bytes(fz_context *ctx, fz_buffer *buf, size_t at, unsig
 
 void mupdf_buffer_write_bytes(fz_context *ctx, fz_buffer *buf, const unsigned char *bytes, size_t len, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_append_data(ctx, buf, bytes, len);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_append_data(ctx, buf, bytes, len));
 }
 
 fz_buffer *mupdf_buffer_from_str(fz_context *ctx, const char *s, mupdf_error_t **errptr)
 {
-    fz_buffer *buf = NULL;
-    fz_try(ctx)
-    {
-        buf = fz_new_buffer_from_copied_data(ctx, (const unsigned char *)s, strlen(s));
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return buf;
+    TRY_CATCH(fz_buffer*, NULL, fz_new_buffer_from_copied_data(ctx, (const unsigned char *)s, strlen(s)));
 }
 
 fz_buffer *mupdf_buffer_from_base64(fz_context *ctx, const char *s, mupdf_error_t **errptr)
 {
-    fz_buffer *buf = NULL;
-    fz_try(ctx)
-    {
-        buf = fz_new_buffer_from_base64(ctx, s, strlen(s));
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return buf;
+    TRY_CATCH(fz_buffer*, NULL, fz_new_buffer_from_base64(ctx, s, strlen(s)));
 }
 
 /* Document */
 fz_document *mupdf_open_document(fz_context *ctx, const char *filename, mupdf_error_t **errptr)
 {
-    fz_document *doc = NULL;
-    fz_try(ctx)
-    {
-        doc = fz_open_document(ctx, filename);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return doc;
+    TRY_CATCH(fz_document*, NULL, fz_open_document(ctx, filename));
 }
 
 fz_document *mupdf_open_document_from_bytes(fz_context *ctx, fz_buffer *bytes, const char *magic, mupdf_error_t **errptr)
@@ -1950,58 +1291,22 @@ bool mupdf_recognize_document(fz_context *ctx, const char *magic, mupdf_error_t 
     {
         return false;
     }
-    bool recognized = false;
-    fz_try(ctx)
-    {
-        recognized = fz_recognize_document(ctx, magic) != NULL;
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return recognized;
+    TRY_CATCH(bool, false, fz_recognize_document(ctx, magic) != NULL);
 }
 
 bool mupdf_needs_password(fz_context *ctx, fz_document *doc, mupdf_error_t **errptr)
 {
-    bool needs = false;
-    fz_try(ctx)
-    {
-        needs = fz_needs_password(ctx, doc);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return needs;
+    TRY_CATCH(bool, false, fz_needs_password(ctx, doc));
 }
 
 bool mupdf_authenticate_password(fz_context *ctx, fz_document *doc, const char *password, mupdf_error_t **errptr)
 {
-    bool ok = false;
-    fz_try(ctx)
-    {
-        ok = fz_authenticate_password(ctx, doc, password);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return ok;
+    TRY_CATCH(bool, false, fz_authenticate_password(ctx, doc, password));
 }
 
 int mupdf_document_page_count(fz_context *ctx, fz_document *doc, mupdf_error_t **errptr)
 {
-    int count = 0;
-    fz_try(ctx)
-    {
-        count = fz_count_pages(ctx, doc);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return count;
+    TRY_CATCH(int, 0, fz_count_pages(ctx, doc));
 }
 
 char *mupdf_lookup_metadata(fz_context *ctx, fz_document *doc, const char *key, mupdf_error_t **errptr)
@@ -2026,16 +1331,7 @@ char *mupdf_lookup_metadata(fz_context *ctx, fz_document *doc, const char *key, 
 
 bool mupdf_is_document_reflowable(fz_context *ctx, fz_document *doc, mupdf_error_t **errptr)
 {
-    bool is_reflowable = false;
-    fz_try(ctx)
-    {
-        is_reflowable = fz_is_document_reflowable(ctx, doc);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return is_reflowable;
+    TRY_CATCH(bool, false, fz_is_document_reflowable(ctx, doc));
 }
 
 void mupdf_layout_document(fz_context *ctx, fz_document *doc, float w, float h, float em, mupdf_error_t **errptr)
@@ -2061,16 +1357,7 @@ void mupdf_layout_document(fz_context *ctx, fz_document *doc, float w, float h, 
 
 fz_page *mupdf_load_page(fz_context *ctx, fz_document *doc, int page_no, mupdf_error_t **errptr)
 {
-    fz_page *page = NULL;
-    fz_try(ctx)
-    {
-        page = fz_load_page(ctx, doc, page_no);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return page;
+    TRY_CATCH(fz_page*, NULL, fz_load_page(ctx, doc, page_no));
 }
 
 static pdf_document *mupdf_convert_to_pdf_internal(fz_context *ctx, fz_document *doc, int fp, int tp, int rotate, fz_cookie *cookie)
@@ -2129,73 +1416,38 @@ pdf_document *mupdf_convert_to_pdf(fz_context *ctx, fz_document *doc, int fp, in
         *errptr = mupdf_new_error_from_str("rotation not multiple of 90");
         return NULL;
     }
-    pdf_document *pdf = NULL;
-    fz_try(ctx)
-    {
-        pdf = mupdf_convert_to_pdf_internal(ctx, doc, fp, tp, rotate, cookie);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return pdf;
+
+    TRY_CATCH(pdf_document*, NULL, mupdf_convert_to_pdf_internal(ctx, doc, fp, tp, rotate, cookie));
 }
 
 fz_location mupdf_resolve_link(fz_context *ctx, fz_document *doc, const char *uri, float *xp, float *yp, mupdf_error_t **errptr)
 {
-    fz_location loc = { -1, -1 };
+    fz_location ret = { -1, -1 };
     fz_try(ctx)
     {
-        loc = fz_resolve_link(ctx, doc, uri, xp, yp);
+        ret = fz_resolve_link(ctx, doc, uri, xp, yp);
     }
     fz_catch(ctx)
     {
         mupdf_save_error(ctx, errptr);
     }
-    return loc;
+    return ret;
 }
 
 
 fz_link_dest mupdf_resolve_link_dest(fz_context *ctx, fz_document *doc, const char *uri, mupdf_error_t **errptr)
 {
-    fz_link_dest dest;
-    fz_try(ctx)
-    {
-        dest = fz_resolve_link_dest(ctx, doc, uri);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return dest;
+    TRY_CATCH(fz_link_dest, {}, fz_resolve_link_dest(ctx, doc, uri));
 }
 
 fz_colorspace *mupdf_document_output_intent(fz_context *ctx, fz_document *doc, mupdf_error_t **errptr)
 {
-    fz_colorspace *cs = NULL;
-    fz_try(ctx)
-    {
-        cs = fz_document_output_intent(ctx, doc);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return cs;
+    TRY_CATCH(fz_colorspace*, NULL, fz_document_output_intent(ctx, doc));
 }
 
 fz_outline *mupdf_load_outline(fz_context *ctx, fz_document *doc, mupdf_error_t **errptr)
 {
-    fz_outline *outline = NULL;
-    fz_try(ctx)
-    {
-        outline = fz_load_outline(ctx, doc);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return outline;
+    TRY_CATCH(fz_outline*, NULL, fz_load_outline(ctx, doc));
 }
 
 /* PdfDocument */
@@ -2222,110 +1474,42 @@ pdf_document *mupdf_pdf_open_document_from_bytes(fz_context *ctx, fz_buffer *byt
 
 pdf_obj *mupdf_pdf_add_object(fz_context *ctx, pdf_document *pdf, pdf_obj *obj, mupdf_error_t **errptr)
 {
-    pdf_obj *ind = NULL;
-    fz_try(ctx)
-    {
-        ind = pdf_add_object(ctx, pdf, obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return ind;
+    TRY_CATCH(pdf_obj*, NULL, pdf_add_object(ctx, pdf, obj));
 }
 
 pdf_obj *mupdf_pdf_create_object(fz_context *ctx, pdf_document *pdf, mupdf_error_t **errptr)
 {
-    pdf_obj *ind = NULL;
-    fz_try(ctx)
-    {
-        ind = pdf_new_indirect(ctx, pdf, pdf_create_object(ctx, pdf), 0);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return ind;
+    TRY_CATCH(pdf_obj*, NULL, pdf_new_indirect(ctx, pdf, pdf_create_object(ctx, pdf), 0));
 }
 
 void mupdf_pdf_delete_object(fz_context *ctx, pdf_document *pdf, int num, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        pdf_delete_object(ctx, pdf, num);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_delete_object(ctx, pdf, num));
 }
 
 pdf_obj *mupdf_pdf_add_image(fz_context *ctx, pdf_document *pdf, fz_image *image, mupdf_error_t **errptr)
 {
-    pdf_obj *ind = NULL;
-    fz_try(ctx)
-    {
-        ind = pdf_add_image(ctx, pdf, image);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return ind;
+    TRY_CATCH(pdf_obj*, NULL, pdf_add_image(ctx, pdf, image));
 }
 
 pdf_obj *mupdf_pdf_add_font(fz_context *ctx, pdf_document *pdf, fz_font *font, mupdf_error_t **errptr)
 {
-    pdf_obj *ind = NULL;
-    fz_try(ctx)
-    {
-        ind = pdf_add_cid_font(ctx, pdf, font);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return ind;
+    TRY_CATCH(pdf_obj*, NULL, pdf_add_cid_font(ctx, pdf, font));
 }
 
 pdf_obj *mupdf_pdf_add_cjk_font(fz_context *ctx, pdf_document *pdf, fz_font *font, int ordering, int wmode, bool serif, mupdf_error_t **errptr)
 {
-    pdf_obj *ind = NULL;
-    fz_try(ctx)
-    {
-        ind = pdf_add_cjk_font(ctx, pdf, font, ordering, wmode, serif);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return ind;
+    TRY_CATCH(pdf_obj*, NULL, pdf_add_cjk_font(ctx, pdf, font, ordering, wmode, serif));
 }
 
 pdf_obj *mupdf_pdf_add_simple_font(fz_context *ctx, pdf_document *pdf, fz_font *font, int encoding, mupdf_error_t **errptr)
 {
-    pdf_obj *ind = NULL;
-    fz_try(ctx)
-    {
-        ind = pdf_add_simple_font(ctx, pdf, font, encoding);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return ind;
+    TRY_CATCH(pdf_obj*, NULL, pdf_add_simple_font(ctx, pdf, font, encoding));
 }
 
 void mupdf_pdf_save_document(fz_context *ctx, pdf_document *pdf, const char *filename, pdf_write_options pwo, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        pdf_save_document(ctx, pdf, filename, &pwo);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_save_document(ctx, pdf, filename, &pwo));
 }
 
 fz_buffer *mupdf_pdf_write_document(fz_context *ctx, pdf_document *pdf, pdf_write_options pwo, mupdf_error_t **errptr)
@@ -2354,55 +1538,24 @@ fz_buffer *mupdf_pdf_write_document(fz_context *ctx, pdf_document *pdf, pdf_writ
 
 void mupdf_pdf_enable_js(fz_context *ctx, pdf_document *pdf, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        pdf_enable_js(ctx, pdf);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_enable_js(ctx, pdf));
 }
 
 void mupdf_pdf_disable_js(fz_context *ctx, pdf_document *pdf, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        pdf_disable_js(ctx, pdf);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_disable_js(ctx, pdf));
 }
 
 bool mupdf_pdf_js_supported(fz_context *ctx, pdf_document *pdf, mupdf_error_t **errptr)
 {
-    bool supported = false;
-    fz_try(ctx)
-    {
-        supported = pdf_js_supported(ctx, pdf);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return supported;
+    TRY_CATCH(bool, false, pdf_js_supported(ctx, pdf));
 }
 
 void mupdf_pdf_calculate_form(fz_context *ctx, pdf_document *pdf, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        if (pdf->recalculate)
-        {
-            pdf_calculate_form(ctx, pdf);
-        }
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    if (!pdf->recalculate) return;
+
+    TRY_CATCH_VOID(pdf_calculate_form(ctx, pdf));
 }
 
 pdf_obj *mupdf_pdf_trailer(fz_context *ctx, pdf_document *pdf, mupdf_error_t **errptr)
@@ -2437,58 +1590,22 @@ pdf_obj *mupdf_pdf_catalog(fz_context *ctx, pdf_document *pdf, mupdf_error_t **e
 
 int mupdf_pdf_count_objects(fz_context *ctx, pdf_document *pdf, mupdf_error_t **errptr)
 {
-    int count = 0;
-    fz_try(ctx)
-    {
-        count = pdf_xref_len(ctx, pdf);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return count;
+    TRY_CATCH(int, 0, pdf_xref_len(ctx, pdf));
 }
 
 pdf_graft_map *mupdf_pdf_new_graft_map(fz_context *ctx, pdf_document *pdf, mupdf_error_t **errptr)
 {
-    pdf_graft_map *map = NULL;
-    fz_try(ctx)
-    {
-        map = pdf_new_graft_map(ctx, pdf);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return map;
+    TRY_CATCH(pdf_graft_map*, NULL, pdf_new_graft_map(ctx, pdf));
 }
 
 pdf_obj *mupdf_pdf_graft_object(fz_context *ctx, pdf_document *doc, pdf_obj *obj, mupdf_error_t **errptr)
 {
-    pdf_obj *graft_obj = NULL;
-    fz_try(ctx)
-    {
-        graft_obj = pdf_graft_object(ctx, doc, obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return graft_obj;
+    TRY_CATCH(pdf_obj*, NULL, pdf_graft_object(ctx, doc, obj));
 }
 
 pdf_obj *mupdf_pdf_graft_mapped_object(fz_context *ctx, pdf_graft_map *map, pdf_obj *obj, mupdf_error_t **errptr)
 {
-    pdf_obj *graft_obj = NULL;
-    fz_try(ctx)
-    {
-        graft_obj = pdf_graft_mapped_object(ctx, map, obj);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return graft_obj;
+    TRY_CATCH(pdf_obj*, NULL, pdf_graft_mapped_object(ctx, map, obj));
 }
 
 pdf_page *mupdf_pdf_new_page(fz_context *ctx, pdf_document *pdf, int page_no, float width, float height, mupdf_error_t **errptr)
@@ -2552,14 +1669,7 @@ void mupdf_pdf_insert_page(fz_context *ctx, pdf_document *pdf, int page_no, pdf_
         *errptr = mupdf_new_error_from_str("page_no is not a valid page");
         return;
     }
-    fz_try(ctx)
-    {
-        pdf_insert_page(ctx, pdf, page_no, page);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_insert_page(ctx, pdf, page_no, page));
 }
 
 void mupdf_pdf_delete_page(fz_context *ctx, pdf_document *pdf, int page_no, mupdf_error_t **errptr)
@@ -2607,16 +1717,7 @@ fz_device *mupdf_new_draw_device(fz_context *ctx, fz_pixmap *pixmap, fz_irect cl
 
 fz_device *mupdf_new_device_of_size(fz_context *ctx, int size, mupdf_error_t **errptr)
 {
-    fz_device *device = NULL;
-    fz_try(ctx)
-    {
-        device = fz_new_device_of_size(ctx, size);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return device;
+    TRY_CATCH(fz_device*, NULL, fz_new_device_of_size(ctx, size));
 }
 
 fz_device *mupdf_new_display_list_device(fz_context *ctx, fz_display_list *list, mupdf_error_t **errptr)
@@ -2636,399 +1737,165 @@ fz_device *mupdf_new_display_list_device(fz_context *ctx, fz_display_list *list,
 
 fz_device *mupdf_new_stext_device(fz_context *ctx, fz_stext_page *tp, int flags, mupdf_error_t **errptr)
 {
-    fz_device *device = NULL;
-    fz_try(ctx)
-    {
-        fz_stext_options opts = {0};
-        opts.flags = flags;
-        device = fz_new_stext_device(ctx, tp, &opts);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return device;
+    fz_stext_options opts = {0};
+    opts.flags = flags;
+    TRY_CATCH(fz_device*, NULL, fz_new_stext_device(ctx, tp, &opts));
 }
 
 void mupdf_fill_path(fz_context *ctx, fz_device *device, fz_path *path, bool even_odd, fz_matrix ctm, fz_colorspace *cs, const float *color, float alpha, fz_color_params cp, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_fill_path(ctx, device, path, even_odd, ctm, cs, color, alpha, cp);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_fill_path(ctx, device, path, even_odd, ctm, cs, color, alpha, cp));
 }
 
 void mupdf_stroke_path(fz_context *ctx, fz_device *device, fz_path *path, fz_stroke_state *stroke, fz_matrix ctm, fz_colorspace *cs, const float *color, float alpha, fz_color_params cp, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_stroke_path(ctx, device, path, stroke, ctm, cs, color, alpha, cp);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_stroke_path(ctx, device, path, stroke, ctm, cs, color, alpha, cp));
 }
 
 void mupdf_clip_path(fz_context *ctx, fz_device *device, fz_path *path, bool even_odd, fz_matrix ctm, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_clip_path(ctx, device, path, even_odd, ctm, fz_infinite_rect);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_clip_path(ctx, device, path, even_odd, ctm, fz_infinite_rect));
 }
 
 void mupdf_clip_stroke_path(fz_context *ctx, fz_device *device, fz_path *path, fz_stroke_state *stroke, fz_matrix ctm, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_clip_stroke_path(ctx, device, path, stroke, ctm, fz_infinite_rect);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_clip_stroke_path(ctx, device, path, stroke, ctm, fz_infinite_rect));
 }
 
 void mupdf_fill_text(fz_context *ctx, fz_device *device, fz_text *text, fz_matrix ctm, fz_colorspace *cs, const float *color, float alpha, fz_color_params cp, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_fill_text(ctx, device, text, ctm, cs, color, alpha, cp);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_fill_text(ctx, device, text, ctm, cs, color, alpha, cp));
 }
 
 void mupdf_stroke_text(fz_context *ctx, fz_device *device, fz_text *text, fz_stroke_state *stroke, fz_matrix ctm, fz_colorspace *cs, const float *color, float alpha, fz_color_params cp, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_stroke_text(ctx, device, text, stroke, ctm, cs, color, alpha, cp);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_stroke_text(ctx, device, text, stroke, ctm, cs, color, alpha, cp));
 }
 
 void mupdf_clip_text(fz_context *ctx, fz_device *device, fz_text *text, fz_matrix ctm, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_clip_text(ctx, device, text, ctm, fz_infinite_rect);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_clip_text(ctx, device, text, ctm, fz_infinite_rect));
 }
 
 void mupdf_clip_stroke_text(fz_context *ctx, fz_device *device, fz_text *text, fz_stroke_state *stroke, fz_matrix ctm, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_clip_stroke_text(ctx, device, text, stroke, ctm, fz_infinite_rect);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_clip_stroke_text(ctx, device, text, stroke, ctm, fz_infinite_rect));
 }
 
 void mupdf_ignore_text(fz_context *ctx, fz_device *device, fz_text *text, fz_matrix ctm, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_ignore_text(ctx, device, text, ctm);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_ignore_text(ctx, device, text, ctm));
 }
 
 void mupdf_fill_shade(fz_context *ctx, fz_device *device, fz_shade *shade, fz_matrix ctm, float alpha, fz_color_params cp, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_fill_shade(ctx, device, shade, ctm, alpha, cp);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_fill_shade(ctx, device, shade, ctm, alpha, cp));
 }
 
 void mupdf_fill_image(fz_context *ctx, fz_device *device, fz_image *image, fz_matrix ctm, float alpha, fz_color_params cp, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_fill_image(ctx, device, image, ctm, alpha, cp);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_fill_image(ctx, device, image, ctm, alpha, cp));
 }
 
 void mupdf_fill_image_mask(fz_context *ctx, fz_device *device, fz_image *image, fz_matrix ctm, fz_colorspace *cs, const float *color, float alpha, fz_color_params cp, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_fill_image_mask(ctx, device, image, ctm, cs, color, alpha, cp);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_fill_image_mask(ctx, device, image, ctm, cs, color, alpha, cp));
 }
 
 void mupdf_clip_image_mask(fz_context *ctx, fz_device *device, fz_image *image, fz_matrix ctm, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_clip_image_mask(ctx, device, image, ctm, fz_infinite_rect);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_clip_image_mask(ctx, device, image, ctm, fz_infinite_rect));
 }
 
 void mupdf_pop_clip(fz_context *ctx, fz_device *device, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_pop_clip(ctx, device);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_pop_clip(ctx, device));
 }
 
 void mupdf_begin_layer(fz_context *ctx, fz_device *device, const char *name, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_begin_layer(ctx, device, name);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_begin_layer(ctx, device, name));
 }
 
 void mupdf_end_layer(fz_context *ctx, fz_device *device, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_end_layer(ctx, device);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_end_layer(ctx, device));
 }
 
 void mupdf_begin_structure(fz_context *ctx, fz_device *device, fz_structure standard, const char *raw, int idx, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_begin_structure(ctx, device, standard, raw, idx);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_begin_structure(ctx, device, standard, raw, idx));
 }
 
 void mupdf_end_structure(fz_context *ctx, fz_device *device, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_end_structure(ctx, device);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_end_structure(ctx, device));
 }
 
 void mupdf_begin_metatext(fz_context *ctx, fz_device *device, fz_metatext meta, const char *text, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_begin_metatext(ctx, device, meta, text);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_begin_metatext(ctx, device, meta, text));
 }
 
 void mupdf_end_metatext(fz_context *ctx, fz_device *device, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_end_metatext(ctx, device);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_end_metatext(ctx, device));
 }
 
 void mupdf_begin_mask(fz_context *ctx, fz_device *device, fz_rect area, bool luminosity, fz_colorspace *cs, const float *color, fz_color_params cp, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_begin_mask(ctx, device, area, luminosity, cs, color, cp);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_begin_mask(ctx, device, area, luminosity, cs, color, cp));
 }
 
 void mupdf_end_mask(fz_context *ctx, fz_device *device, fz_function *fn, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_end_mask_tr(ctx, device, fn);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_end_mask_tr(ctx, device, fn));
 }
 
 void mupdf_begin_group(fz_context *ctx, fz_device *device, fz_rect area, fz_colorspace *cs, bool isolated, bool knockout, int blendmode, float alpha, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_begin_group(ctx, device, area, cs, isolated, knockout, blendmode, alpha);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_begin_group(ctx, device, area, cs, isolated, knockout, blendmode, alpha));
 }
 
 void mupdf_end_group(fz_context *ctx, fz_device *device, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_end_group(ctx, device);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_end_group(ctx, device));
 }
 
 int mupdf_begin_tile(fz_context *ctx, fz_device *device, fz_rect area, fz_rect view, float xstep, float ystep, fz_matrix ctm, int id, mupdf_error_t **errptr)
 {
-    int i = 0;
-    fz_try(ctx)
-    {
-        i = fz_begin_tile_id(ctx, device, area, view, xstep, ystep, ctm, id);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return i;
+    TRY_CATCH(int, 0, fz_begin_tile_id(ctx, device, area, view, xstep, ystep, ctm, id));
 }
 
 void mupdf_end_tile(fz_context *ctx, fz_device *device, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_end_tile(ctx, device);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_end_tile(ctx, device));
 }
 
 /* PdfPage */
 pdf_annot *mupdf_pdf_create_annot(fz_context *ctx, pdf_page *page, int subtype, mupdf_error_t **errptr)
 {
-    pdf_annot *annot = NULL;
-    fz_try(ctx)
-    {
-        annot = pdf_create_annot(ctx, page, subtype);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return annot;
+    TRY_CATCH(pdf_annot*, NULL, pdf_create_annot(ctx, page, subtype));
 }
 
 void mupdf_pdf_delete_annot(fz_context *ctx, pdf_page *page, pdf_annot *annot, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        pdf_delete_annot(ctx, page, annot);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_delete_annot(ctx, page, annot));
 }
 
 bool mupdf_pdf_update_page(fz_context *ctx, pdf_page *page, mupdf_error_t **errptr)
 {
-    bool updated = false;
-    fz_try(ctx)
-    {
-        updated = pdf_update_page(ctx, page);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return updated;
+    TRY_CATCH(bool, false, pdf_update_page(ctx, page));
 }
 
 bool mupdf_pdf_redact_page(fz_context *ctx, pdf_page *page, mupdf_error_t **errptr)
 {
-    bool redacted = false;
-    fz_try(ctx)
-    {
-        redacted = pdf_redact_page(ctx, page->doc, page, NULL);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return redacted;
+    TRY_CATCH(bool, false, pdf_redact_page(ctx, page->doc, page, NULL));
 }
 
 void mupdf_pdf_filter_page_contents(fz_context *ctx, pdf_page *page, pdf_filter_options *filter, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        pdf_filter_page_contents(ctx, page->doc, page, filter);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_filter_page_contents(ctx, page->doc, page, filter));
 }
 
 void mupdf_pdf_page_set_rotation(fz_context *ctx, pdf_page *page, int rotation, mupdf_error_t **errptr)
@@ -3038,14 +1905,7 @@ void mupdf_pdf_page_set_rotation(fz_context *ctx, pdf_page *page, int rotation, 
         *errptr = mupdf_new_error_from_str("rotation not multiple of 90");
         return;
     }
-    fz_try(ctx)
-    {
-        pdf_dict_put_int(ctx, page->obj, PDF_NAME(Rotate), (int64_t)rotation);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_dict_put_int(ctx, page->obj, PDF_NAME(Rotate), (int64_t)rotation));
 }
 
 void mupdf_pdf_page_set_crop_box(fz_context *ctx, pdf_page *page, fz_rect rect, mupdf_error_t **errptr)
@@ -3127,151 +1987,63 @@ fz_matrix mupdf_pdf_page_obj_transform(fz_context *ctx, pdf_obj *page, mupdf_err
 /* PDFAnnotation */
 int mupdf_pdf_annot_type(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
 {
-    int subtype = 0;
-    fz_try(ctx)
-    {
-        subtype = pdf_annot_type(ctx, annot);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return subtype;
+    TRY_CATCH(int, 0, pdf_annot_type(ctx, annot));
 }
 
 const char *mupdf_pdf_annot_author(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
 {
-    const char *author = NULL;
-    fz_try(ctx)
-    {
-        author = pdf_annot_author(ctx, annot);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return author;
+    TRY_CATCH(const char *, NULL, pdf_annot_author(ctx, annot));
 }
 
 void mupdf_pdf_set_annot_author(fz_context *ctx, pdf_annot *annot, const char *author, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        pdf_set_annot_author(ctx, annot, author);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_set_annot_author(ctx, annot, author));
+}
+
+void mupdf_pdf_set_annot_line(fz_context *ctx, pdf_annot *annot, fz_point a, fz_point b, mupdf_error_t **errptr)
+{
+    TRY_CATCH_VOID(pdf_set_annot_line(ctx, annot, a, b));
 }
 
 void mupdf_pdf_filter_annot_contents(fz_context *ctx, pdf_annot *annot, pdf_filter_options *filter, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        pdf_filter_annot_contents(ctx, pdf_annot_page(ctx, annot)->doc, annot, filter);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(pdf_filter_annot_contents(ctx, pdf_annot_page(ctx, annot)->doc, annot, filter));
 }
 
 /* DocumentWriter */
 fz_document_writer *mupdf_new_document_writer(fz_context *ctx, const char *filename, const char *format, const char *options, mupdf_error_t **errptr)
 {
-    fz_document_writer *writer = NULL;
-    fz_try(ctx)
-    {
-        writer = fz_new_document_writer(ctx, filename, format, options);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return writer;
+    TRY_CATCH(fz_document_writer*, NULL, fz_new_document_writer(ctx, filename, format, options));
 }
 
 fz_document_writer *mupdf_new_pdfocr_writer(fz_context *ctx, const char *path, const char *options, mupdf_error_t **errptr)
 {
-    fz_document_writer *writer = NULL;
-    fz_try(ctx)
-    {
-        writer = fz_new_pdfocr_writer(ctx, path, options);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return writer;
+    TRY_CATCH(fz_document_writer*, NULL, fz_new_pdfocr_writer(ctx, path, options));
 }
 
 fz_device *mupdf_document_writer_begin_page(fz_context *ctx, fz_document_writer *writer, fz_rect mediabox, mupdf_error_t **errptr)
 {
-    fz_device *device = NULL;
-    fz_try(ctx)
-    {
-        device = fz_begin_page(ctx, writer, mediabox);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return device;
+    TRY_CATCH(fz_device*, NULL, fz_begin_page(ctx, writer, mediabox));
 }
 
 void mupdf_document_writer_end_page(fz_context *ctx, fz_document_writer *writer, mupdf_error_t **errptr)
 {
-    fz_try(ctx)
-    {
-        fz_end_page(ctx, writer);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
+    TRY_CATCH_VOID(fz_end_page(ctx, writer));
 }
 
 /* Bitmap */
 fz_bitmap *mupdf_new_bitmap_from_pixmap(fz_context *ctx, fz_pixmap *pixmap, mupdf_error_t **errptr)
 {
-    fz_bitmap *bitmap = NULL;
-    fz_try(ctx)
-    {
-        bitmap = fz_new_bitmap_from_pixmap(ctx, pixmap, NULL);
-    }
-    fz_catch(ctx)
-    {
-        mupdf_save_error(ctx, errptr);
-    }
-    return bitmap;
+    TRY_CATCH(fz_bitmap*, NULL, fz_new_bitmap_from_pixmap(ctx, pixmap, NULL));
 }
 
 int32_t mupdf_highlight_selection(fz_context *ctx, fz_stext_page *page, fz_point a, fz_point b, fz_quad *quads, int max_quads, mupdf_error_t **errptr)
 {
-	int count = 0;
-	fz_try(ctx)
-	{
-		count = fz_highlight_selection(ctx, page, a, b, quads, max_quads);
-	}
-	fz_catch(ctx)
-	{
-		mupdf_save_error(ctx, errptr);
-	}
-	return count;
+    TRY_CATCH(int, 0, fz_highlight_selection(ctx, page, a, b, quads, max_quads));
 }
 
 int32_t mupdf_search_stext_page_cb(fz_context *ctx, fz_stext_page *page, const char *needle, fz_search_callback_fn *cb, void *opaque, mupdf_error_t **errptr) {
-	int32_t count = 0;
-	fz_try(ctx)
-	{
-		count = fz_search_stext_page_cb(ctx, page, needle, cb, opaque);
-	}
-	fz_catch(ctx)
-	{
-		mupdf_save_error(ctx, errptr);
-	}
-	return count;
+    TRY_CATCH(int32_t, 0, fz_search_stext_page_cb(ctx, page, needle, cb, opaque));
 }
 
 void mupdf_format_string(fz_context *ctx, void *user, void (*emit)(fz_context *ctx, void *user, int c), const char *fmt, ...) {


### PR DESCRIPTION
It's kinda annoying to have to keep writing the whole `try_catch(ctx) { } fz_catch(ctx) { }` thing whenever I add a new binding, so this just makes the process a bit easier.

There are some functions that don't fit neatly into this format, so I just left them as-is.