### PR TITLE
Fix some clippy and doc issues and add docs to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt-get -y install libfontconfig1-dev
       - run: cargo clippy --tests --features serde -- -D warnings
+      - run: cargo doc -p mupdf --no-deps --document-private-items
 
   test:
     name: Test Suite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ members = [
 version = "0.5.0"
 edition = "2021"
 
+[lints.rustdoc]
+broken_intra_doc_links = "deny"
+
 [dev-dependencies]
 crossbeam-utils = "0.8.1"
 serde_json = "1.0.117"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -25,6 +25,12 @@ impl FromStr for Buffer {
     }
 }
 
+impl Default for Buffer {
+    fn default() -> Self {
+        Self::with_capacity(0)
+    }
+}
+
 impl Buffer {
     pub(crate) unsafe fn from_raw(ptr: *mut fz_buffer) -> Self {
         Self {
@@ -34,7 +40,7 @@ impl Buffer {
     }
 
     pub fn new() -> Self {
-        Self::with_capacity(0)
+        Self::default()
     }
 
     pub fn from_base64(str: &str) -> Result<Self, Error> {

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct Color {
     pub alpha: u8,
     pub red: u8,
@@ -51,6 +51,8 @@ impl Color {
 /// The method used to set colors for [`PdfAnnotation::set_color`] - each float inside should
 /// contain a value between [0, 1.0], with 1.0 being the most intense. A 1.0 for Self::Gray
 /// indicates white.
+///
+/// [`PdfAnnotation::set_color`]: crate::pdf::annotation::PdfAnnotation::set_color
 pub enum AnnotationColor {
     Gray(f32),
     Rgb {

--- a/src/colorspace.rs
+++ b/src/colorspace.rs
@@ -87,6 +87,16 @@ impl Colorspace {
         name_cstr.to_str().unwrap()
     }
 
+    /// `color` should contain a number of elements euql to [`self.n()`]. Each element within
+    /// `color` should *probably* be a value between [0, 1.0] (at least, that is the case when
+    /// [`Self::is_rgb()`], [`Self::is_gray()`], or [`Self::is_cmyk()`] - other colorspaces may
+    /// work differently).
+    ///
+    /// The returned vector will have [`to.n()`] elements, and contain values that follow the same
+    /// rules as the input `color` (but with regard to `to`, not `self`)
+    ///
+    /// [`self.n()`]: Self::n
+    /// [`to.n()`]: Self::n
     pub fn convert_color(
         &self,
         color: &[f32],

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,7 +1,7 @@
-use std::ptr;
 use std::{
     ffi::{c_int, CString},
     num::NonZero,
+    ptr,
 };
 
 use bitflags::bitflags;
@@ -226,6 +226,8 @@ impl Device {
         })
     }
 
+    /// The colors in `color` must match the colorspace `cs`, as described in
+    /// [`Colorspace::convert_color`]
     #[allow(clippy::too_many_arguments)]
     pub fn fill_path(
         &self,
@@ -252,6 +254,8 @@ impl Device {
         }
     }
 
+    /// The colors in `color` must match the colorspace `cs`, as described in
+    /// [`Colorspace::convert_color`]
     #[allow(clippy::too_many_arguments)]
     pub fn stroke_path(
         &self,
@@ -307,6 +311,8 @@ impl Device {
         }
     }
 
+    /// The colors in `color` must match the colorspace `cs`, as described in
+    /// [`Colorspace::convert_color`]
     pub fn fill_text(
         &self,
         text: &Text,
@@ -330,6 +336,8 @@ impl Device {
         }
     }
 
+    /// The colors in `color` must match the colorspace `cs`, as described in
+    /// [`Colorspace::convert_color`]
     #[allow(clippy::too_many_arguments)]
     pub fn stroke_text(
         &self,
@@ -426,6 +434,8 @@ impl Device {
         }
     }
 
+    /// The colors in `color` must match the colorspace `cs`, as described in
+    /// [`Colorspace::convert_color`]
     pub fn fill_image_mask(
         &self,
         image: &Image,

--- a/src/device/native.rs
+++ b/src/device/native.rs
@@ -21,6 +21,8 @@ use super::{DefaultColorspaces, DeviceFlag, Metatext, Structure};
 pub trait NativeDevice: 'static {
     fn close_device(&mut self) {}
 
+    /// The colors in `color` must match the colorspace `cs`, as described in
+    /// [`Colorspace::convert_color`]
     fn fill_path(
         &mut self,
         path: &Path,
@@ -33,6 +35,8 @@ pub trait NativeDevice: 'static {
     ) {
     }
 
+    /// The colors in `color` must match the colorspace `cs`, as described in
+    /// [`Colorspace::convert_color`]
     fn stroke_path(
         &mut self,
         path: &Path,
@@ -56,6 +60,8 @@ pub trait NativeDevice: 'static {
     ) {
     }
 
+    /// The colors in `color` must match the colorspace `cs`, as described in
+    /// [`Colorspace::convert_color`]
     fn fill_text(
         &mut self,
         text: &Text,
@@ -67,6 +73,8 @@ pub trait NativeDevice: 'static {
     ) {
     }
 
+    /// The colors in `color` must match the colorspace `cs`, as described in
+    /// [`Colorspace::convert_color`]
     fn stroke_text(
         &mut self,
         text: &Text,
@@ -96,6 +104,8 @@ pub trait NativeDevice: 'static {
 
     fn fill_image(&mut self, img: &Image, cmt: Matrix, alpha: f32, cp: ColorParams) {}
 
+    /// The colors in `color` must match the colorspace `cs`, as described in
+    /// [`Colorspace::convert_color`]
     fn fill_image_mask(
         &mut self,
         img: &Image,
@@ -111,6 +121,8 @@ pub trait NativeDevice: 'static {
 
     fn pop_clip(&mut self) {}
 
+    /// The colors in `color` must match the colorspace `cs`, as described in
+    /// [`Colorspace::convert_color`]
     fn begin_mask(
         &mut self,
         area: Rect,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,9 +230,9 @@ struct AssertSizeEquals<A, B> {
 }
 
 impl<A, B> AssertSizeEquals<A, B> {
-    const _SIZE_OK: () = assert!(size_of::<A>() == size_of::<B>());
+    const _SIZE_OK: () = const { assert!(size_of::<A>() == size_of::<B>()) };
 
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             _phantom: PhantomData,
         }

--- a/src/pdf/annotation.rs
+++ b/src/pdf/annotation.rs
@@ -81,7 +81,7 @@ impl PdfAnnotation {
         unsafe { pdf_annot_hot(context(), self.inner) != 0 }
     }
 
-    /// Make this "hot" (see [`is_hot()`])
+    /// Make this "hot" (see [`Self::is_hot()`])
     pub fn set_hot(&mut self, hot: bool) {
         // Just kinda trusting it would be insane of them to throw here
         unsafe { pdf_set_annot_hot(context(), self.inner, i32::from(hot)) }

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -240,6 +240,14 @@ pub struct PdfDocument {
     doc: Document,
 }
 
+impl Default for PdfDocument {
+    fn default() -> Self {
+        let inner = unsafe { pdf_create_document(context()) };
+        let doc = unsafe { Document::from_raw(&mut (*inner).super_) };
+        Self { inner, doc }
+    }
+}
+
 impl PdfDocument {
     pub(crate) unsafe fn from_raw(ptr: *mut pdf_document) -> Self {
         let doc = Document::from_raw(&mut (*ptr).super_);
@@ -247,11 +255,7 @@ impl PdfDocument {
     }
 
     pub fn new() -> Self {
-        unsafe {
-            let inner = pdf_create_document(context());
-            let doc = Document::from_raw(&mut (*inner).super_);
-            Self { inner, doc }
-        }
+        Self::default()
     }
 
     pub fn open<P: AsRef<FilePath> + ?Sized>(p: &P) -> Result<Self, Error> {


### PR DESCRIPTION
Clippy was complaining about some missing `Default` impls, and I also noticed that some doc links were broken so I added a `cargo doc` call to CI