### PR TITLE
Extend from_enum macro to keep all enums at smallest repr

### DIFF
--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -1,3 +1,5 @@
+use core::ffi::c_void;
+
 use mupdf_sys::*;
 
 use crate::{context, Error};
@@ -57,7 +59,7 @@ impl Drop for Cookie {
     fn drop(&mut self) {
         if !self.inner.is_null() {
             unsafe {
-                fz_free(context(), self.inner as _);
+                fz_free(context(), self.inner as *mut c_void);
             }
         }
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -522,7 +522,7 @@ impl Device {
                 cs.inner,
                 isolated,
                 knockout,
-                blend_mode as _,
+                blend_mode.into(),
                 alpha
             ))
         }
@@ -575,9 +575,9 @@ impl Device {
             ffi_try!(mupdf_begin_structure(
                 context(),
                 self.dev,
-                standard as _,
+                standard.into(),
                 c_raw.as_ptr(),
-                idx as _
+                idx
             ))
         }
     }
@@ -592,7 +592,7 @@ impl Device {
             ffi_try!(mupdf_begin_metatext(
                 context(),
                 self.dev,
-                meta as _,
+                meta.into(),
                 c_text.as_ptr()
             ))
         }

--- a/src/display_list.rs
+++ b/src/display_list.rs
@@ -133,7 +133,7 @@ impl DisplayList {
                 context(),
                 self.inner,
                 c_needle.as_ptr(),
-                hit_max as _,
+                hit_max as i32,
                 &mut hit_count
             ))
         }

--- a/src/document.rs
+++ b/src/document.rs
@@ -187,9 +187,9 @@ impl Document {
             ffi_try!(mupdf_convert_to_pdf(
                 context(),
                 self.inner,
-                start_page as _,
-                end_page as _,
-                rotate as _,
+                start_page,
+                end_page,
+                rotate as i32,
                 cookie_ptr
             ))
         }

--- a/src/image.rs
+++ b/src/image.rs
@@ -85,7 +85,7 @@ impl Image {
 
     pub fn set_interpolate(&mut self, interpolate: bool) {
         unsafe {
-            (*self.inner).set_interpolate(interpolate as _);
+            (*self.inner).set_interpolate(interpolate.into());
         }
     }
 
@@ -95,7 +95,7 @@ impl Image {
 
     pub fn set_scalable(&mut self, scalable: bool) {
         unsafe {
-            (*self.inner).set_scalable(scalable as _);
+            (*self.inner).set_scalable(scalable.into());
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ macro_rules! unsafe_impl_ffi_wrapper {
 
         impl Drop for $struct {
             fn drop(&mut self) {
-                let ptr = <Self as $crate::FFIWrapper>::as_ptr(&*self) as *mut _;
+                let ptr = <Self as $crate::FFIWrapper>::as_ptr(&*self).cast_mut();
                 // SAFETY: Guaranteed by caller
                 unsafe { $ffi_drop_fn($crate::context(), ptr) }
             }

--- a/src/page.rs
+++ b/src/page.rs
@@ -39,7 +39,7 @@ impl Page {
     }
 
     pub fn bounds(&self) -> Result<Rect, Error> {
-        unsafe { ffi_try!(mupdf_bound_page(context(), self.as_ptr() as *mut _)) }.map(Into::into)
+        unsafe { ffi_try!(mupdf_bound_page(context(), self.as_ptr().cast_mut())) }.map(Into::into)
     }
 
     pub fn to_pixmap(
@@ -52,7 +52,7 @@ impl Page {
         unsafe {
             ffi_try!(mupdf_page_to_pixmap(
                 context(),
-                self.as_ptr() as *mut _,
+                self.as_ptr().cast_mut(),
                 ctm.into(),
                 cs.inner,
                 alpha,
@@ -66,7 +66,7 @@ impl Page {
         let inner = unsafe {
             ffi_try!(mupdf_page_to_svg(
                 context(),
-                self.as_ptr() as *mut _,
+                self.as_ptr().cast_mut(),
                 ctm.into(),
                 ptr::null_mut()
             ))
@@ -81,7 +81,7 @@ impl Page {
         let inner = unsafe {
             ffi_try!(mupdf_page_to_svg(
                 context(),
-                self.as_ptr() as *mut _,
+                self.as_ptr().cast_mut(),
                 ctm.into(),
                 cookie.inner
             ))
@@ -94,7 +94,7 @@ impl Page {
 
     pub fn to_text_page(&self, flags: TextPageFlags) -> Result<TextPage, Error> {
         let opts = fz_stext_options {
-            flags: flags.bits() as _,
+            flags: i32::from_be_bytes(flags.bits().to_be_bytes()),
             scale: 0.0,
             clip: fz_rect {
                 x0: 0.0,
@@ -121,7 +121,7 @@ impl Page {
         unsafe {
             ffi_try!(mupdf_page_to_display_list(
                 context(),
-                self.as_ptr() as *mut _,
+                self.as_ptr().cast_mut(),
                 annotations
             ))
         }
@@ -132,7 +132,7 @@ impl Page {
         unsafe {
             ffi_try!(mupdf_run_page(
                 context(),
-                self.as_ptr() as *mut _,
+                self.as_ptr().cast_mut(),
                 device.dev,
                 ctm.into(),
                 ptr::null_mut()
@@ -149,7 +149,7 @@ impl Page {
         unsafe {
             ffi_try!(mupdf_run_page(
                 context(),
-                self.as_ptr() as *mut _,
+                self.as_ptr().cast_mut(),
                 device.dev,
                 ctm.into(),
                 cookie.inner
@@ -161,7 +161,7 @@ impl Page {
         unsafe {
             ffi_try!(mupdf_run_page_contents(
                 context(),
-                self.as_ptr() as *mut _,
+                self.as_ptr().cast_mut(),
                 device.dev,
                 ctm.into(),
                 ptr::null_mut()
@@ -178,7 +178,7 @@ impl Page {
         unsafe {
             ffi_try!(mupdf_run_page_contents(
                 context(),
-                self.as_ptr() as *mut _,
+                self.as_ptr().cast_mut(),
                 device.dev,
                 ctm.into(),
                 cookie.inner
@@ -190,7 +190,7 @@ impl Page {
         unsafe {
             ffi_try!(mupdf_run_page_annots(
                 context(),
-                self.as_ptr() as *mut _,
+                self.as_ptr().cast_mut(),
                 device.dev,
                 ctm.into(),
                 ptr::null_mut()
@@ -207,7 +207,7 @@ impl Page {
         unsafe {
             ffi_try!(mupdf_run_page_annots(
                 context(),
-                self.as_ptr() as *mut _,
+                self.as_ptr().cast_mut(),
                 device.dev,
                 ctm.into(),
                 cookie.inner
@@ -219,7 +219,7 @@ impl Page {
         unsafe {
             ffi_try!(mupdf_run_page_widgets(
                 context(),
-                self.as_ptr() as *mut _,
+                self.as_ptr().cast_mut(),
                 device.dev,
                 ctm.into(),
                 ptr::null_mut()
@@ -236,7 +236,7 @@ impl Page {
         unsafe {
             ffi_try!(mupdf_run_page_widgets(
                 context(),
-                self.as_ptr() as *mut _,
+                self.as_ptr().cast_mut(),
                 device.dev,
                 ctm.into(),
                 cookie.inner
@@ -254,7 +254,7 @@ impl Page {
     }
 
     pub fn separations(&self) -> Result<Separations, Error> {
-        unsafe { ffi_try!(mupdf_page_separations(context(), self.as_ptr() as *mut _)) }
+        unsafe { ffi_try!(mupdf_page_separations(context(), self.as_ptr().cast_mut())) }
             .map(|inner| unsafe { Separations::from_raw(inner) })
     }
 
@@ -265,7 +265,7 @@ impl Page {
         unsafe {
             ffi_try!(mupdf_search_page(
                 context(),
-                self.as_ptr() as *mut fz_page,
+                self.as_ptr().cast_mut(),
                 c_needle.as_ptr(),
                 hit_max as c_int,
                 &mut hit_count

--- a/src/pdf/annotation.rs
+++ b/src/pdf/annotation.rs
@@ -109,13 +109,13 @@ impl PdfAnnotation {
                     context(),
                     self.inner,
                     1,
-                    &[g] as *const _
+                    [g].as_ptr()
                 )),
                 AnnotationColor::Rgb { red, green, blue } => ffi_try!(mupdf_pdf_set_annot_color(
                     context(),
                     self.inner,
                     3,
-                    &[red, green, blue] as *const _
+                    [red, green, blue].as_ptr()
                 )),
                 AnnotationColor::Cmyk {
                     cyan,
@@ -126,7 +126,7 @@ impl PdfAnnotation {
                     context(),
                     self.inner,
                     4,
-                    &[cyan, magenta, yellow, key] as *const _
+                    [cyan, magenta, yellow, key].as_ptr()
                 )),
             }
         }
@@ -172,7 +172,7 @@ impl PdfAnnotation {
             ffi_try!(mupdf_pdf_filter_annot_contents(
                 context(),
                 self.inner,
-                &mut opt.inner as *mut _
+                &raw mut opt.inner
             ))
         }
     }

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -28,21 +28,16 @@ bitflags! {
 }
 
 from_enum! { c_int,
-    #[derive(Debug, Copy, Clone, PartialEq)]
+    #[derive(Debug, Copy, Clone, PartialEq, Default)]
     pub enum Encryption {
         Aes128 = PDF_ENCRYPT_AES_128,
         Aes256 = PDF_ENCRYPT_AES_256,
         Rc4_40 = PDF_ENCRYPT_RC4_40,
         Rc4_128 = PDF_ENCRYPT_RC4_128,
         Keep = PDF_ENCRYPT_KEEP,
+        #[default]
         None = PDF_ENCRYPT_NONE,
         Unknown = PDF_ENCRYPT_UNKNOWN,
-    }
-}
-
-impl Default for Encryption {
-    fn default() -> Encryption {
-        Self::None
     }
 }
 

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -179,7 +179,7 @@ impl PdfWriteOptions {
     }
 
     pub fn set_encryption(&mut self, value: Encryption) -> &mut Self {
-        self.inner.do_encrypt = value as _;
+        self.inner.do_encrypt = value.into();
         self
     }
 

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -1,3 +1,4 @@
+use core::ffi::c_void;
 use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
 use std::fmt;
@@ -326,7 +327,7 @@ impl PdfObject {
             unsafe { ffi_try!(mupdf_pdf_obj_to_string(context(), self.inner, tight, ascii)) }?;
         let c_str = unsafe { CStr::from_ptr(ptr) };
         let s = c_str.to_string_lossy().into_owned();
-        unsafe { fz_free(context(), ptr as _) };
+        unsafe { fz_free(context(), ptr as *mut c_void) };
         Ok(s)
     }
 

--- a/src/pixmap.rs
+++ b/src/pixmap.rs
@@ -162,7 +162,7 @@ impl Pixmap {
             // invalid stride
             return None;
         }
-        Some(unsafe { slice::from_raw_parts((*self.inner).samples as _, size) })
+        Some(unsafe { slice::from_raw_parts((*self.inner).samples as *mut u32, size) })
     }
 
     /// Initialize the samples area with 0x00

--- a/src/system_font.rs
+++ b/src/system_font.rs
@@ -53,7 +53,7 @@ pub(crate) unsafe extern "C" fn load_system_font(
             let font = match handle.load() {
                 Ok(f) => Font::from_bytes_with_index(
                     &f.family_name(),
-                    font_index as _,
+                    font_index as i32,
                     &f.copy_font_data().unwrap(),
                 ),
                 Err(_) => return ptr::null_mut(),

--- a/src/text.rs
+++ b/src/text.rs
@@ -91,7 +91,7 @@ impl TextSpan {
 
     pub fn set_wmode(&mut self, wmode: WriteMode) {
         unsafe {
-            (*self.inner).set_wmode(wmode as _);
+            (*self.inner).set_wmode(wmode.into());
         }
     }
 
@@ -109,7 +109,7 @@ impl TextSpan {
     }
 
     pub fn set_markup_dir(&mut self, dir: BidiDirection) {
-        unsafe { (*self.inner).set_markup_dir(dir as _) }
+        unsafe { (*self.inner).set_markup_dir(dir.into()) }
     }
 
     pub fn language(&self) -> Language {
@@ -118,7 +118,7 @@ impl TextSpan {
     }
 
     pub fn set_language(&mut self, language: Language) {
-        unsafe { (*self.inner).set_language(language as _) }
+        unsafe { (*self.inner).set_language(language.into()) }
     }
 
     pub fn items(&self) -> TextItemIter<'_> {

--- a/src/text.rs
+++ b/src/text.rs
@@ -53,7 +53,7 @@ from_enum! { fz_bidi_direction,
     }
 }
 
-from_enum! { fz_text_language,
+from_enum! { fz_text_language => u16,
     #[derive(Debug, Clone, Copy, PartialEq)]
     pub enum Language {
         Unset = FZ_LANG_UNSET,


### PR DESCRIPTION
The `from_enum` macro, before this PR, defined each macro to have variants of `isize` type. While this probably didn't really cause any issues in practice, this always made me a bit nervous. As far as I can tell, rust doesn't guarantee that enums with `repr(rust)` are automatically sized down to the smallest representation they could use (see the reference chapters on [type layout](https://doc.rust-lang.org/reference/type-layout.html) and [enums](https://doc.rust-lang.org/reference/types/enum.html), maybe I missed something), so we might be passing all enums around as `isize`s right now (as opposed to their most optimal representation, which is a u8 in most cases).

So this PR, to fix that, allows specifying a `repr` for all enums created with `from_enum` and ensures that every constant passed in to be the value of a variant in that enum will actually fit within the given repr.

This pr also cleans up a few other small things, like using a fully-qualified path for `$crate::error::Error` and providing a way to convert from an enum into its c representation (e.g. `c_int`) losslessly (to ensure that we don't accidentally lose information when we add a new enum without checking what its largest value actually is).