### PR TITLE
Add github action for trusted publishing to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish to crates.io
+on:
+  push:
+    tags: ['v*']  # Triggers when pushing tags starting with 'v'
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: publish
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v5
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+    - run: sudo apt-get -y install libfontconfig1-dev # required to compile mupdf
+    - run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
This github action should match the configuration outlined in #165 by @messense 

I've tested it on my own at https://github.com/vincent-uden/dummy-trusted which uses mupdf as a dependency to check that the compilation does indeed work.

The action would publish to crates.io on each tag starting with "v", as in "v0.6.0" which adheres to the current naming scheme of versions for release.