### PR TITLE
Expose NameTree loading to query named destinations

### DIFF
--- a/mupdf-sys/wrapper.c
+++ b/mupdf-sys/wrapper.c
@@ -1604,6 +1604,21 @@ pdf_obj *mupdf_pdf_trailer(fz_context *ctx, pdf_document *pdf, mupdf_error_t **e
     return obj;
 }
 
+pdf_obj *mupdf_pdf_load_name_tree(fz_context *ctx, pdf_document *pdf, pdf_obj* name, mupdf_error_t **errptr)
+{
+    pdf_obj *obj = NULL;
+    fz_try(ctx)
+    {
+        obj = pdf_load_name_tree(ctx, pdf, name);
+        pdf_keep_obj(ctx, obj);
+    }
+    fz_catch(ctx)
+    {
+        mupdf_save_error(ctx, errptr);
+    }
+    return obj;
+}
+
 pdf_obj *mupdf_pdf_catalog(fz_context *ctx, pdf_document *pdf, mupdf_error_t **errptr)
 {
     pdf_obj *obj = NULL;

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -432,6 +432,11 @@ impl PdfDocument {
             .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
+    pub fn load_name_tree(&self, d: PdfObject) -> Result<PdfObject, Error> {
+        unsafe { ffi_try!(mupdf_pdf_load_name_tree(context(), self.inner, d.inner)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
+    }
+
     pub fn catalog(&self) -> Result<PdfObject, Error> {
         unsafe { ffi_try!(mupdf_pdf_catalog(context(), self.inner)) }
             .map(|inner| unsafe { PdfObject::from_raw(inner) })


### PR DESCRIPTION
Hi! I need to query for named destinations (such as `pdfinfo -dests`) for some application and the entry point for name tree traversal was missing. This PR exposes the missing function.