### PR TITLE
Ensure alignment of native devices not to be above `max_align_t`

### DIFF
--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -174,7 +174,9 @@ fn generate_bindings(target: &Target, path: &Path, sysroot: Option<String>) -> R
         .allowlist_recursively(false)
         .allowlist_type("wchar_t")
         .allowlist_type("FILE")
-        .opaque_type("FILE");
+        .opaque_type("FILE")
+        .allowlist_item("max_align_t")
+        .opaque_type("max_align_t");
 
     builder = builder
         .allowlist_item("fz_.*")

--- a/mupdf-sys/src/lib.rs
+++ b/mupdf-sys/src/lib.rs
@@ -20,19 +20,24 @@ use core::ffi::{c_int, CStr};
 /// a new instance of `T`, but only the `fz_device` portion will be initialized. The rest is
 /// currently being zero-initialized, but this might change in the future.
 ///
+/// The `*mut T` pointer returned is only guaranteed to be well aligned up to the alignment
+/// of [`max_align_t`].
+///
 /// # Example
 ///
 /// This is how a compliant `T` might look like. The `repr(C)` is necessary as `repr(Rust)` does
 /// not guarantee stable field orderings.
 ///
 /// ```rust
-/// use mupdf_sys::fz_device;
+/// use mupdf_sys::{fz_device, max_align_t};
 ///
 /// #[repr(C)]
 /// struct MyDevice {
 ///     base: fz_device,
 ///     foo: u32,
 /// }
+///
+/// const { assert!(align_of::<MyDevice>() <= align_of::<max_align_t>()); }
 /// ```
 pub unsafe fn mupdf_new_derived_device<T>(
     ctx: *mut fz_context,

--- a/src/device/native.rs
+++ b/src/device/native.rs
@@ -584,7 +584,21 @@ impl<T: NativeDevice + ?Sized> NativeDevice for Rc<RefCell<T>> {
     }
 }
 
+/// ```compile_fail
+/// use mupdf::{Device, NativeDevice};
+///
+/// #[repr(align(32))]
+/// struct U256(#[allow(dead_code)] [u128; 2]);
+///
+/// impl NativeDevice for U256 {}
+///
+/// Device::from_native(U256([0, 0])).unwrap();
+/// ```
 pub(crate) fn create<D: NativeDevice>(device: D) -> Result<Device, Error> {
+    const {
+        assert!(align_of::<D>() <= align_of::<max_align_t>());
+    }
+
     let ret = unsafe {
         let c_device: *mut CDevice<D> =
             ffi_try!(mupdf_new_derived_device(context(), c"RustDevice"))?;


### PR DESCRIPTION
Fix #185 using the [first proposed solution](https://github.com/messense/mupdf-rs/issues/185#issuecomment-3703810729)