### PR TITLE
Fix emscripten build error under rust 1.93.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,7 +71,7 @@ jobs:
           targets: wasm32-unknown-emscripten
       - uses: mymindstorm/setup-emsdk@v14
 
-      - run: cargo test --target wasm32-unknown-emscripten --config "target.wasm32-unknown-emscripten.runner = 'node'" --features serde
+      - run: CFLAGS="-sSUPPORT_LONGJMP=wasm" cargo test --target wasm32-unknown-emscripten --config "target.wasm32-unknown-emscripten.runner = 'node'" --features serde
 
   test-msys:
     name: Test Suite (MSYS2)


### PR DESCRIPTION
The support for `emscripten_longjmp` should be enabled in the compiler.
I didn't find how to add the `CFLAGS="-sSUPPORT_LONGJMP=wasm"` for the correct build, so I just put it right before the `cargo test` call.

Fixes CI failure because of #196