### PR TITLE
Set `CFLAGS` for `wasm32-unknown-emscripten` in `build.rs`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,7 +71,7 @@ jobs:
           targets: wasm32-unknown-emscripten
       - uses: mymindstorm/setup-emsdk@v14
 
-      - run: cargo test --target wasm32-unknown-emscripten --config "target.wasm32-unknown-emscripten.runner = 'node'" --features serde
+      - run: CFLAGS="-sSUPPORT_LONGJMP=wasm" cargo test --target wasm32-unknown-emscripten --config "target.wasm32-unknown-emscripten.runner = 'node'" --features serde
 
   test-msys:
     name: Test Suite (MSYS2)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,7 +71,7 @@ jobs:
           targets: wasm32-unknown-emscripten
       - uses: mymindstorm/setup-emsdk@v14
 
-      - run: CFLAGS="-sSUPPORT_LONGJMP=wasm" cargo test --target wasm32-unknown-emscripten --config "target.wasm32-unknown-emscripten.runner = 'node'" --features serde
+      - run: cargo test --target wasm32-unknown-emscripten --config "target.wasm32-unknown-emscripten.runner = 'node'" --features serde
 
   test-msys:
     name: Test Suite (MSYS2)

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -40,6 +40,8 @@ fn run() -> Result<()> {
         )
     })?;
 
+    std::env::set_var("CFLAGS_wasm32-unknown-emscripten", "-sSUPPORT_LONGJMP=wasm");
+
     let src_dir = current_dir().unwrap().join("mupdf");
     let out_dir =
         PathBuf::from(env::var_os("OUT_DIR").ok_or("Missing OUT_DIR environment variable")?);


### PR DESCRIPTION
Removes the workaround the ci build in #201
Sets the required flag in build file.