### PR TITLE
Impliment pdf link parsing and updating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ serde = ["dep:serde"]
 mupdf-sys = { version = "0.6.0", path = "mupdf-sys", features = ["zerocopy"] }
 once_cell = "1.3.1"
 bitflags = "2.0.2"
+percent-encoding = "2.3.1"
 serde = { version = "1.0.201", features = ["derive"], optional = true }
 zerocopy = { version = "0.8.17", features = ["derive"] }
 

--- a/mupdf-sys/wrapper/pdf_annot.c
+++ b/mupdf-sys/wrapper/pdf_annot.c
@@ -59,3 +59,8 @@ void mupdf_pdf_filter_annot_contents(fz_context *ctx, pdf_annot *annot, pdf_filt
 {
     TRY_CATCH_VOID(pdf_filter_annot_contents(ctx, pdf_annot_page(ctx, annot)->doc, annot, filter));
 }
+
+int mupdf_pdf_lookup_page_number(fz_context *ctx, pdf_document *doc, pdf_obj *page_obj, mupdf_error_t **errptr)
+{
+    TRY_CATCH(int, -1, pdf_lookup_page_number(ctx, doc, page_obj));
+}

--- a/mupdf-sys/wrapper/pdf_document.c
+++ b/mupdf-sys/wrapper/pdf_document.c
@@ -257,3 +257,18 @@ void mupdf_pdf_delete_page(fz_context *ctx, pdf_document *pdf, int page_no, mupd
         mupdf_save_error(ctx, errptr);
     }
 }
+
+void mupdf_pdf_begin_operation(fz_context *ctx, pdf_document *doc, const char *operation, mupdf_error_t **errptr)
+{
+    TRY_CATCH_VOID(pdf_begin_operation(ctx, doc, operation));
+}
+
+void mupdf_pdf_end_operation(fz_context *ctx, pdf_document *doc, mupdf_error_t **errptr)
+{
+    TRY_CATCH_VOID(pdf_end_operation(ctx, doc));
+}
+
+void mupdf_pdf_abandon_operation(fz_context *ctx, pdf_document *doc, mupdf_error_t **errptr)
+{
+    TRY_CATCH_VOID(pdf_abandon_operation(ctx, doc));
+}

--- a/mupdf-sys/wrapper/pdf_object.c
+++ b/mupdf-sys/wrapper/pdf_object.c
@@ -401,6 +401,11 @@ void mupdf_pdf_write_stream_buffer(fz_context *ctx, pdf_obj *obj, fz_buffer *buf
     TRY_CATCH_VOID(pdf_update_stream(ctx, pdf, obj, buf, compressed));
 }
 
+pdf_obj *mupdf_pdf_copy_array(fz_context *ctx, pdf_obj *obj, mupdf_error_t **errptr)
+{
+    TRY_CATCH(pdf_obj*, NULL, pdf_copy_array(ctx, obj));
+}
+
 int mupdf_pdf_array_len(fz_context *ctx, pdf_obj *obj, mupdf_error_t **errptr)
 {
     TRY_CATCH(int, 0, pdf_array_len(ctx, obj));

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::pdf::PdfObject;
 use crate::{Error, Matrix, Rect};
 
@@ -16,113 +18,11 @@ impl Destination {
     }
 
     /// Encode this destination into a PDF "Dest" array.
-    ///
-    /// # MuPDF parity / Source
-    /// Ported from MuPDF [`pdf_new_dest_from_link`] (pdf/pdf-link.c).
-    ///
-    /// In MuPDF logic:
-    ///
-    /// - optional parameters are represented internally by `NaN` (missing).
-    /// - when serializing into a PDF destination array, MuPDF writes `null`
-    ///   for `NaN` (missing) values.
-    ///
-    /// In this Rust crate:
-    ///
-    /// - **`Option::None`** represents a missing parameter.
-    /// - **`Option::None`** is serialized as the PDF `null` object.
-    ///
-    /// Additionally for `/XYZ`:
-    ///
-    /// - MuPDF stores zoom internally as a percentage (100 == 100% zoom).
-    /// - PDF `/XYZ` expects a scale factor (1.0 == 100%), so we write `zoom/100`.
-    ///
-    /// # Coordinate space
-    ///
-    /// This method does **not** apply any coordinate transforms.
-    /// It expects `self.kind` coordinates to already be in PDF user space for the *target page*.
+    /// See [DestinationKind::encode_into] documentation for more information
     pub(crate) fn encode_into(self, array: &mut PdfObject) -> Result<(), Error> {
         debug_assert_eq!(array.len()?, 0);
-
-        #[cold]
-        fn push_null(array: &mut PdfObject) -> Result<(), Error> {
-            array.array_push(PdfObject::new_null())
-        }
-
-        #[inline]
-        fn push_real_or_null(array: &mut PdfObject, v: Option<f32>) -> Result<(), Error> {
-            match v {
-                Some(v) => {
-                    if !v.is_nan() {
-                        array.array_push(PdfObject::new_real(v)?)
-                    } else {
-                        push_null(array) // move out from hot path
-                    }
-                }
-                None => array.array_push(PdfObject::new_null()),
-            }
-        }
-
-        // 1) Page reference (local destination)
         array.array_push(self.page)?;
-
-        // 2) Kind
-        match self.kind {
-            DestinationKind::Fit => array.array_push(PdfObject::new_name("Fit")?),
-
-            DestinationKind::FitH { top } => {
-                array.array_push(PdfObject::new_name("FitH")?)?;
-                // MuPDF: if isnan(p.y) push NULL else real
-                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1340
-                push_real_or_null(array, top)
-            }
-
-            DestinationKind::FitV { left } => {
-                array.array_push(PdfObject::new_name("FitV")?)?;
-                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1356
-                push_real_or_null(array, left)
-            }
-
-            DestinationKind::XYZ { left, top, zoom } => {
-                array.array_push(PdfObject::new_name("XYZ")?)?;
-                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1391
-                push_real_or_null(array, left)?;
-                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1395
-                push_real_or_null(array, top)?;
-
-                // MuPDF: stores zoom as percent (100 == 100%), but PDF wants scale (1.0 == 100%)
-                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1399
-                push_real_or_null(array, zoom.map(|z| z / 100.0))
-            }
-
-            DestinationKind::FitR {
-                left,
-                bottom,
-                right,
-                top,
-            } => {
-                array.array_push(PdfObject::new_name("FitR")?)?;
-                // In PDF all 4 coordinates are required -> always real.
-                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1411
-                array.array_push(PdfObject::new_real(left)?)?;
-                array.array_push(PdfObject::new_real(bottom)?)?;
-                array.array_push(PdfObject::new_real(right)?)?;
-                array.array_push(PdfObject::new_real(top)?)
-            }
-
-            DestinationKind::FitB => array.array_push(PdfObject::new_name("FitB")?),
-
-            DestinationKind::FitBH { top } => {
-                array.array_push(PdfObject::new_name("FitBH")?)?;
-                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1348
-                push_real_or_null(array, top)
-            }
-
-            DestinationKind::FitBV { left } => {
-                array.array_push(PdfObject::new_name("FitBV")?)?;
-                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1364
-                push_real_or_null(array, left)
-            }
-        }
+        self.kind.encode_into(array)
     }
 }
 
@@ -275,13 +175,6 @@ impl DestinationKind {
     ///
     /// Ported from [`pdf_new_dest_from_link`] in MuPDF (`pdf/pdf-link.c`).
     pub fn transform(self, matrix: &Matrix) -> Self {
-        // Helper function, similar to `fz_transform_point_xy` from C. Performs bare math without checking for NaN.
-        // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/fitz/geometry.c#L344
-        #[inline(always)]
-        fn transform_xy(m: &Matrix, x: f32, y: f32) -> (f32, f32) {
-            (x * m.a + y * m.c + m.e, x * m.b + y * m.d + m.f)
-        }
-
         match self {
             Self::Fit => Self::Fit,
             Self::FitB => Self::FitB,
@@ -291,25 +184,25 @@ impl DestinationKind {
             // write NULL if isnan(p.y). Here we only do the transform, `null`
             // emission should be done in encode step.
             Self::FitH { top } => {
-                let top = top.map(|t| transform_xy(matrix, 0.0, t).1);
+                let top = top.map(|t| matrix.transform_xy(0.0, t).1);
                 Self::FitH { top }
             }
 
             // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1345
             Self::FitBH { top } => {
-                let top = top.map(|t| transform_xy(matrix, 0.0, t).1);
+                let top = top.map(|t| matrix.transform_xy(0.0, t).1);
                 Self::FitBH { top }
             }
 
             // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1353
             Self::FitV { left } => {
-                let left = left.map(|l| transform_xy(matrix, l, 0.0).0);
+                let left = left.map(|l| matrix.transform_xy(l, 0.0).0);
                 Self::FitV { left }
             }
 
             // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1361
             Self::FitBV { left } => {
-                let left = left.map(|l| transform_xy(matrix, l, 0.0).0);
+                let left = left.map(|l| matrix.transform_xy(l, 0.0).0);
                 Self::FitBV { left }
             }
 
@@ -319,19 +212,19 @@ impl DestinationKind {
             Self::XYZ { left, top, zoom } => {
                 let (left, top) = if matrix.a == 0.0 && matrix.d == 0.0 {
                     // Rotating by 90 or 270 degrees
-                    let (tx, ty) = transform_xy(matrix, left.unwrap_or(0.0), top.unwrap_or(0.0));
+                    let (tx, ty) = matrix.transform_xy(left.unwrap_or(0.0), top.unwrap_or(0.0));
 
                     // MuPDF: if isnan(val.x) p.y = val.x / if isnan(val.y) p.x = val.y;
                     (top.and(Some(tx)), left.and(Some(ty)))
                 } else if matrix.b == 0.0 && matrix.c == 0.0 {
                     // No rotation, or 180 degrees
-                    let (tx, ty) = transform_xy(matrix, left.unwrap_or(0.0), top.unwrap_or(0.0));
+                    let (tx, ty) = matrix.transform_xy(left.unwrap_or(0.0), top.unwrap_or(0.0));
 
                     // MuPDF: if isnan(val.x) p.x = val.x / if isnan(val.y) p.y = val.y;
                     (left.and(Some(tx)), top.and(Some(ty)))
                 } else {
                     let (tx, ty) =
-                        transform_xy(matrix, left.unwrap_or(f32::NAN), top.unwrap_or(f32::NAN));
+                        matrix.transform_xy(left.unwrap_or(f32::NAN), top.unwrap_or(f32::NAN));
                     (not_nan(tx), not_nan(ty))
                 };
 
@@ -359,6 +252,289 @@ impl DestinationKind {
                 }
             }
         }
+    }
+
+    /// Encode this destination into a PDF "Dest" array.
+    ///
+    /// # MuPDF parity / Source
+    ///
+    /// Ported from MuPDF [`pdf_new_dest_from_link`] (pdf/pdf-link.c).
+    ///
+    /// In MuPDF logic:
+    ///
+    /// - optional parameters are represented internally by `NaN` (missing).
+    /// - when serializing into a PDF destination array, MuPDF writes `null`
+    ///   for `NaN` (missing) values.
+    ///
+    /// In this Rust crate:
+    ///
+    /// - **`Option::None`** represents a missing parameter.
+    /// - **`Option::None`** is serialized as the PDF `null` object.
+    ///
+    /// Additionally for `/XYZ`:
+    ///
+    /// - MuPDF stores zoom internally as a percentage (100 == 100% zoom).
+    /// - PDF `/XYZ` expects a scale factor (1.0 == 100%), so we write `zoom/100`.
+    ///
+    /// # Coordinate space
+    ///
+    /// This method does **not** apply any coordinate transforms.
+    /// It expects `self` coordinates to already be in PDF user space for the *target page*.
+    pub fn encode_into(self, array: &mut PdfObject) -> Result<(), Error> {
+        #[cold]
+        fn push_null(array: &mut PdfObject) -> Result<(), Error> {
+            array.array_push(PdfObject::new_null())
+        }
+
+        #[inline]
+        fn push_real_or_null(array: &mut PdfObject, v: Option<f32>) -> Result<(), Error> {
+            match v {
+                Some(v) => {
+                    if !v.is_nan() {
+                        array.array_push(PdfObject::new_real(v)?)
+                    } else {
+                        push_null(array) // move out from hot path
+                    }
+                }
+                None => array.array_push(PdfObject::new_null()),
+            }
+        }
+
+        match self {
+            DestinationKind::Fit => array.array_push(PdfObject::new_name("Fit")?),
+
+            DestinationKind::FitH { top } => {
+                array.array_push(PdfObject::new_name("FitH")?)?;
+                // MuPDF: if isnan(p.y) push NULL else real
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1340
+                push_real_or_null(array, top)
+            }
+
+            DestinationKind::FitV { left } => {
+                array.array_push(PdfObject::new_name("FitV")?)?;
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1356
+                push_real_or_null(array, left)
+            }
+
+            DestinationKind::XYZ { left, top, zoom } => {
+                array.array_push(PdfObject::new_name("XYZ")?)?;
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1391
+                push_real_or_null(array, left)?;
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1395
+                push_real_or_null(array, top)?;
+
+                // MuPDF: stores zoom as percent (100 == 100%), but PDF wants scale (1.0 == 100%)
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1399
+                push_real_or_null(array, zoom.map(|z| z / 100.0))
+            }
+
+            DestinationKind::FitR {
+                left,
+                bottom,
+                right,
+                top,
+            } => {
+                array.array_push(PdfObject::new_name("FitR")?)?;
+                // In PDF all 4 coordinates are required -> always real.
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1411
+                array.array_push(PdfObject::new_real(left)?)?;
+                array.array_push(PdfObject::new_real(bottom)?)?;
+                array.array_push(PdfObject::new_real(right)?)?;
+                array.array_push(PdfObject::new_real(top)?)
+            }
+
+            DestinationKind::FitB => array.array_push(PdfObject::new_name("FitB")?),
+
+            DestinationKind::FitBH { top } => {
+                array.array_push(PdfObject::new_name("FitBH")?)?;
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1348
+                push_real_or_null(array, top)
+            }
+
+            DestinationKind::FitBV { left } => {
+                array.array_push(PdfObject::new_name("FitBV")?)?;
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1364
+                push_real_or_null(array, left)
+            }
+        }
+    }
+
+    /// Decodes a PDF destination array into a `DestinationKind`.
+    ///
+    /// The `array` should be the full destination array `[page, /Name, params...]`.
+    /// This reads from index 1 onward (skipping the page reference at index 0).
+    /// Coordinates are returned as-is in PDF user space (no CTM applied).
+    ///
+    /// This is the inverse of [`encode_into`](Self::encode_into).
+    pub fn decode_from(array: &PdfObject) -> Result<DestinationKind, Error> {
+        let kind_obj = array
+            .get_array(1)?
+            .ok_or_else(|| Error::InvalidDestination("missing destination type name".into()))?;
+        let kind_name = kind_obj.as_name()?;
+
+        /// Read a float from an array index, returning None if the element is null/missing.
+        #[inline(always)]
+        fn read_optional_float(array: &PdfObject, idx: i32) -> Result<Option<f32>, Error> {
+            match array.get_array(idx)? {
+                Some(obj) => {
+                    if obj.is_null()? {
+                        Ok(None)
+                    } else {
+                        Ok(Some(obj.as_float()?))
+                    }
+                }
+                None => Ok(None),
+            }
+        }
+
+        #[inline(always)]
+        fn read_float(array: &PdfObject, idx: i32) -> Result<f32, Error> {
+            array
+                .get_array(idx)?
+                .ok_or_else(|| Error::InvalidDestination(format!("missing float at index {idx}")))?
+                .as_float()
+        }
+
+        let destination_kind = match kind_name {
+            b"Fit" => DestinationKind::Fit,
+            b"FitB" => DestinationKind::FitB,
+            b"FitH" => DestinationKind::FitH {
+                top: read_optional_float(array, 2)?,
+            },
+            b"FitBH" => DestinationKind::FitBH {
+                top: read_optional_float(array, 2)?,
+            },
+            b"FitV" => DestinationKind::FitV {
+                left: read_optional_float(array, 2)?,
+            },
+            b"FitBV" => DestinationKind::FitBV {
+                left: read_optional_float(array, 2)?,
+            },
+            b"FitR" => DestinationKind::FitR {
+                left: read_float(array, 2)?,
+                bottom: read_float(array, 3)?,
+                right: read_float(array, 4)?,
+                top: read_float(array, 5)?,
+            },
+            _ => DestinationKind::XYZ {
+                left: read_optional_float(array, 2)?,
+                top: read_optional_float(array, 3)?,
+                // PDF /XYZ stores zoom as a scale factor (1.0 = 100%).
+                // DestinationKind stores it as a percentage (100.0 = 100%).
+                zoom: read_optional_float(array, 4)?
+                    .map(|z| if z > 0.0 { z * 100.0 } else { 100.0 }),
+            },
+        };
+        Ok(destination_kind)
+    }
+}
+
+impl Default for DestinationKind {
+    fn default() -> Self {
+        // This analogue of MuPDF's `fz_make_link_dest_none` function
+        // (https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/fitz/link.c#L96)
+        DestinationKind::XYZ {
+            left: None,
+            top: None,
+            zoom: None,
+        }
+    }
+}
+
+impl fmt::Display for DestinationKind {
+    /// Formats this destination as a [MuPDF-compatible] URI fragment suffix based on the Adobe specification
+    /// ["Parameters for Opening PDF Files"] from the Adobe Acrobat SDK, version 8.1.
+    ///
+    /// This is only the parameter tail appended after `#page=...` in a link URI, so any emitted suffix starts
+    /// with `&`. The output may also be empty (e.g. for the default `XYZ` with all fields missing).
+    ///
+    /// Output shapes:
+    ///
+    /// - `Fit` / `FitB` -> `&view=Fit` / `&view=FitB`
+    /// - `FitH` / `FitV` / `FitBH` / `FitBV` -> `&view=Name` or `&view=Name,<coord>`
+    /// - `XYZ` -> `&zoom=<zoom>,<left>,<top>`
+    /// - `FitR` -> `&viewrect=<left>,<bottom>,<width>,<height>`
+    ///
+    /// Missing values:
+    ///
+    /// - `None` means “unspecified” (`null` as per [PDF 32000-1:2008, 12.3.2.2]). `Some(NaN)` is treated as `None`.
+    /// - For `Fit*`, a missing coordinate is omitted.
+    /// - For `XYZ`, the fragment is omitted when all fields are missing, otherwise missing fields are written as `nan`.
+    /// - For `XYZ`, `zoom == 0` is treated as missing.
+    ///
+    /// Values are written as-is (no transforms applied).
+    ///
+    /// [MuPDF-compatible]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/include/mupdf/pdf/annot.h#L317
+    /// [PDF 32000-1:2008, 12.3.2.2]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1696125
+    /// ["Parameters for Opening PDF Files"]: https://web.archive.org/web/20170921000830/http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cold]
+        #[inline(never)]
+        fn cold_nan_handler() {}
+
+        #[inline(always)]
+        fn filter_nan(v: Option<f32>) -> Option<f32> {
+            match v {
+                Some(val) => {
+                    if !val.is_nan() {
+                        Some(val)
+                    } else {
+                        cold_nan_handler(); // move out from hot path
+                        None
+                    }
+                }
+                None => None,
+            }
+        }
+
+        match *self {
+            Self::Fit => f.write_str("&view=Fit"),
+            Self::FitB => f.write_str("&view=FitB"),
+            Self::FitH { top } => write_fit_view(f, "FitH", filter_nan(top)),
+            Self::FitBH { top } => write_fit_view(f, "FitBH", filter_nan(top)),
+            Self::FitV { left } => write_fit_view(f, "FitV", filter_nan(left)),
+            Self::FitBV { left } => write_fit_view(f, "FitBV", filter_nan(left)),
+            Self::XYZ { left, top, zoom } => {
+                let x = filter_nan(left);
+                let y = filter_nan(top);
+                let z = filter_nan(zoom).filter(|&v| v != 0.0);
+
+                if x.is_some() || y.is_some() || z.is_some() {
+                    f.write_str("&zoom=")?;
+                    write_f32_or_nan(f, z)?;
+                    f.write_str(",")?;
+                    write_f32_or_nan(f, x)?;
+                    f.write_str(",")?;
+                    write_f32_or_nan(f, y)?;
+                }
+                Ok(())
+            }
+            Self::FitR {
+                left,
+                bottom,
+                right,
+                top,
+            } => {
+                let w = right - left;
+                let h = top - bottom;
+                write!(f, "&viewrect={left},{bottom},{w},{h}")
+            }
+        }
+    }
+}
+
+/// Writes `&view=Name,val` or `&view=Name` depending on whether `val` is present.
+fn write_fit_view(f: &mut fmt::Formatter<'_>, name: &str, val: Option<f32>) -> fmt::Result {
+    match val {
+        Some(v) => write!(f, "&view={name},{v}"),
+        None => write!(f, "&view={name}"),
+    }
+}
+
+fn write_f32_or_nan(f: &mut fmt::Formatter<'_>, v: Option<f32>) -> fmt::Result {
+    match v {
+        Some(v) => write!(f, "{v}"),
+        None => f.write_str("nan"),
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,6 +76,7 @@ pub enum Error {
     InvalidUtf8,
     UnexpectedNullPtr,
     UnknownEnumVariant,
+    InvalidDestination(String),
 }
 
 impl fmt::Display for Error {
@@ -93,6 +94,7 @@ impl fmt::Display for Error {
                 "An FFI function call returned a null ptr when we expected a non-null ptr"
             ),
             Error::UnknownEnumVariant => write!(f, "unknown enum variant provided"),
+            Error::InvalidDestination(msg) => write!(f, "invalid PDF destination: {msg}"),
         }
     }
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -182,6 +182,16 @@ impl Matrix {
 
         None // MuPDF returns zeros here
     }
+
+    // Helper function, similar to `fz_transform_point_xy` from C. Performs bare math without checking for NaN.
+    // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/fitz/geometry.c#L344
+    #[inline(always)]
+    pub fn transform_xy(&self, x: f32, y: f32) -> (f32, f32) {
+        (
+            x * self.a + y * self.c + self.e,
+            x * self.b + y * self.d + self.f,
+        )
+    }
 }
 
 impl Default for Matrix {

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -249,6 +249,10 @@ impl PdfDocument {
         Self { inner: ptr, doc }
     }
 
+    pub(crate) fn as_raw(&self) -> *mut pdf_document {
+        self.inner
+    }
+
     pub fn new() -> Self {
         Self::default()
     }
@@ -300,8 +304,18 @@ impl PdfDocument {
             .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
+    pub fn new_array_with_capacity(&self, capacity: i32) -> Result<PdfObject, Error> {
+        unsafe { ffi_try!(mupdf_pdf_new_array(context(), self.inner, capacity)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
+    }
+
     pub fn new_dict(&self) -> Result<PdfObject, Error> {
         unsafe { ffi_try!(mupdf_pdf_new_dict(context(), self.inner, 0)) }
+            .map(|inner| unsafe { PdfObject::from_raw(inner) })
+    }
+
+    pub fn new_dict_with_capacity(&self, capacity: i32) -> Result<PdfObject, Error> {
+        unsafe { ffi_try!(mupdf_pdf_new_dict(context(), self.inner, capacity)) }
             .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
@@ -509,6 +523,24 @@ impl PdfDocument {
             .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
+    /// Given a page object reference, returns its zero-based page number.
+    pub fn lookup_page_number(&self, page_obj: &PdfObject) -> Result<i32, Error> {
+        unsafe {
+            ffi_try!(mupdf_pdf_lookup_page_number(
+                context(),
+                self.inner,
+                page_obj.inner
+            ))
+        }
+    }
+
+    /// Loads a PdfPage from a page index.
+    /// Helper function to convert from Document page loading to PdfPage.
+    pub fn load_pdf_page(&self, page_no: i32) -> Result<PdfPage, Error> {
+        let page = self.doc.load_page(page_no)?;
+        PdfPage::try_from(page)
+    }
+
     pub fn new_page_at<T: Into<Size>>(&mut self, page_no: i32, size: T) -> Result<PdfPage, Error> {
         let size = size.into();
         let inner = unsafe {
@@ -541,6 +573,25 @@ impl PdfDocument {
 
     pub fn delete_page(&mut self, page_no: i32) -> Result<(), Error> {
         unsafe { ffi_try!(mupdf_pdf_delete_page(context(), self.inner, page_no)) }
+    }
+
+    pub fn begin_operation(&self, op: &str) -> Result<(), Error> {
+        let c_op = CString::new(op).map_err(|_| Error::InvalidUtf8)?;
+        unsafe {
+            ffi_try!(mupdf_pdf_begin_operation(
+                context(),
+                self.inner,
+                c_op.as_ptr()
+            ))
+        }
+    }
+
+    pub fn end_operation(&self) -> Result<(), Error> {
+        unsafe { ffi_try!(mupdf_pdf_end_operation(context(), self.inner)) }
+    }
+
+    pub fn abandon_operation(&self) -> Result<(), Error> {
+        unsafe { ffi_try!(mupdf_pdf_abandon_operation(context(), self.inner)) }
     }
 
     pub fn set_outlines(&mut self, toc: &[Outline]) -> Result<(), Error> {

--- a/src/pdf/links/build.rs
+++ b/src/pdf/links/build.rs
@@ -1,0 +1,204 @@
+use super::{DestPageResolver, LinkAction, PdfAction, PdfLink};
+use crate::pdf::{PdfDocument, PdfObject};
+use crate::{Error, Matrix};
+
+/// Builds a PDF link annotation dictionary from a [`PdfLink`]
+/// (see [PDF 32000-1:2008, 12.5.6.5] for link annotations, [12.6.4] for action types).
+///
+/// This is the Rust analogue of MuPDF's [`pdf_create_link`] (annotation-dict building portion).
+/// Like [`pdf_create_link`], it transforms the bounding rectangle from Fitz space to PDF user
+/// space and assembles the annotation dictionary. It differs from [`pdf_create_link`] in that it:
+///
+/// - supports writing either `/A` (action) or `/Dest` (direct destination) via
+///   [`set_link_action_on_annot_dict`], while MuPDF always writes `/A` via
+///   [`pdf_new_action_from_link`],
+/// - adds a `/P` back-reference to the parent page object (see below),
+/// - returns the dict without inserting it into `/Annots` or creating an indirect object
+///   (the caller handles those steps).
+///
+/// # Dictionary structure
+///
+/// | Entry      | Value                                                                |
+/// |------------|----------------------------------------------------------------------|
+/// | `Type`     | `/Annot`                                                             |
+/// | `Subtype`  | `/Link`                                                              |
+/// | `Rect`     | Link bounding box in PDF user space (transformed from Fitz)          |
+/// | `BS`       | Border style dict: `{S: /S, Type: /Border, W: 0}` — invisible border |
+/// | `A`/`Dest` | Action or destination (see [`set_link_action_on_annot_dict`])        |
+/// | `P`        | Indirect reference to the parent page object                         |
+///
+/// where:
+/// - `BS` is the Border Style dictionary ([PDF 32000-1:2008, 12.5.4], Table 166).
+/// - `S = /S` selects the solid border style, `Type = /Border` types the sub-dictionary,
+///   and `W = 0` sets zero width — producing an invisible border while the link region
+///   remains active.
+/// - `P` is the parent page back-reference ([PDF 32000-1:2008, 12.5.2], Table 164).
+///
+/// For action and destination entry shapes and per-variant MuPDF function mapping, see
+/// [`set_link_action_on_annot_dict`].
+///
+/// [PDF 32000-1:2008, 12.5.6.5]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1951136
+/// [12.6.4]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1697199
+/// [`pdf_create_link`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-annot.c#L717
+/// [`pdf_new_action_from_link`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1177
+/// [PDF 32000-1:2008, 12.5.4]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1696585
+/// [PDF 32000-1:2008, 12.5.2]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.2292182
+pub(crate) fn build_link_annotation(
+    doc: &mut PdfDocument,
+    page_obj: &PdfObject,
+    link: &PdfLink,
+    annot_inv_ctm: &Option<Matrix>,
+    resolver: &mut impl DestPageResolver,
+) -> Result<PdfObject, Error> {
+    let rect = annot_inv_ctm
+        .as_ref()
+        .map(|inv_ctm| link.bounds.transform(inv_ctm))
+        .unwrap_or(link.bounds);
+
+    let mut annot = doc.new_dict_with_capacity(6)?;
+    annot.dict_put("Type", PdfObject::new_name("Annot")?)?;
+    annot.dict_put("Subtype", PdfObject::new_name("Link")?)?;
+
+    let mut rect_array = doc.new_array_with_capacity(4)?;
+    rect.encode_into(&mut rect_array)?;
+    annot.dict_put("Rect", rect_array)?;
+
+    let mut border_style = doc.new_dict_with_capacity(3)?;
+    border_style.dict_put("S", PdfObject::new_name("S")?)?;
+    border_style.dict_put("Type", PdfObject::new_name("Border")?)?;
+    border_style.dict_put("W", PdfObject::new_int(0)?)?;
+    annot.dict_put("BS", border_style)?;
+
+    set_link_action_on_annot_dict(doc, &mut annot, &link.action, resolver)?;
+
+    annot.dict_put_ref("P", page_obj)?;
+
+    Ok(annot)
+}
+
+/// Writes the link target entry onto an annotation dictionary from a [`LinkAction`]
+/// (see [PDF 32000-1:2008, 12.5.6.5], Table 173).
+///
+/// - [`LinkAction::Action`] -> delegates to [`set_action_on_annot_dict`] (writes `/A`).
+/// - [`LinkAction::Dest`] -> encodes the destination and writes it as `/Dest` directly.
+///
+/// Unlike MuPDF's [`pdf_create_link`] and [`pdf_set_link_uri`], which always write `/A`
+/// via [`pdf_new_action_from_link`], this function additionally supports writing `/Dest`
+/// directly, matching PDF link annotations that carry a direct destination instead of an
+/// action dictionary (see [PDF 32000-1:2008, 12.3.2]).
+///
+/// **Note:** Callers are responsible for removing the conflicting `/Dest` or `/A` entry before
+/// calling this function when updating existing annotations.
+///
+/// [PDF 32000-1:2008, 12.5.6.5]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1951136
+/// [PDF 32000-1:2008, 12.3.2]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.2063217
+/// [`pdf_create_link`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-annot.c#L717
+/// [`pdf_set_link_uri`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L614
+/// [`pdf_new_action_from_link`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1177
+pub(crate) fn set_link_action_on_annot_dict(
+    doc: &mut PdfDocument,
+    annot: &mut PdfObject,
+    action: &LinkAction,
+    resolver: &mut impl DestPageResolver,
+) -> Result<(), Error> {
+    match action {
+        LinkAction::Action(pdf_action) => {
+            set_action_on_annot_dict(doc, annot, pdf_action, resolver)
+        }
+        LinkAction::Dest(dest) => annot.dict_put("Dest", dest.encode_local(doc, resolver)?),
+    }
+}
+
+/// Builds and puts the `/A` action dictionary onto an annotation dictionary from a
+/// [`PdfAction`] (see [PDF 32000-1:2008, 12.6.4]).
+///
+/// This is the Rust analogue of MuPDF's [`pdf_new_action_from_link`], which dispatches on
+/// the URI scheme to build different action dictionary shapes. This function performs the
+/// same dispatch directly on structured [`PdfAction`] values. Unlike MuPDF's [`pdf_new_action_from_link`]
+/// this function upports [`PdfAction::Launch`].
+///
+/// # Action dictionary shapes
+///
+/// | Variant                   | `S` (type) | `D` entry (`URI` for `Uri`) | `F` entry     |
+/// |---------------------------|------------|-----------------------------|---------------|
+/// | `GoTo(Page { .. })`       | `GoTo`     | `[page_ref, /Kind, ...]`    | -             |
+/// | `GoTo(Named(..))`         | `GoTo`     | `(name)`                    | -             |
+/// | `Uri(..)`                 | `URI`      | `(uri)`                     | -             |
+/// | `GoToR { .. }` (explicit) | `GoToR`    | `[page_int, /Kind, ...]`    | filespec dict |
+/// | `GoToR { .. }` (named)    | `GoToR`    | `(name)`                    | filespec dict |
+/// | `Launch(..)`              | `Launch`   | -                           | filespec dict |
+///
+/// For `GoTo(Page { .. })`, destination coordinates are transformed from MuPDF page space to
+/// PDF default user space using the inverse CTM from the `resolver`. For `GoToR` coordinates
+/// are passed as-is (already in PDF default user space).
+///
+/// **Note:** Callers are responsible for removing any conflicting `/Dest` entry before calling
+/// this function when updating existing annotations.
+///
+/// # MuPDF source mapping
+///
+/// | Variant                   | MuPDF function(s)                                                          |
+/// |---------------------------|----------------------------------------------------------------------------|
+/// | `GoTo(Page { .. })`       | [`pdf_new_action_from_link`] (`#` branch) + [`pdf_new_dest_from_link`]     |
+/// | `GoTo(Named(..))`         | [`pdf_new_action_from_link`] (`#` branch) + [`pdf_new_dest_from_link`]     |
+/// | `Uri(..)`                 | [`pdf_new_action_from_link`] ([`fz_is_external_link`] branch)              |
+/// | `GoToR { .. }`            | [`pdf_new_action_from_link`] (`file:` branch) + [`pdf_new_dest_from_link`] |
+/// | `Launch(..)`              | (no direct MuPDF equivalent, see [PDF 32000-1:2008, 12.6.4.5])             |
+///
+/// [PDF 32000-1:2008, 12.6.4]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1697199
+/// [PDF 32000-1:2008, 12.6.4.5]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1952224
+/// [`pdf_new_action_from_link`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1177
+/// [`pdf_new_dest_from_link`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1286
+/// [`fz_is_external_link`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/fitz/link.c#L68
+fn set_action_on_annot_dict(
+    doc: &mut PdfDocument,
+    annot: &mut PdfObject,
+    action: &PdfAction,
+    resolver: &mut impl DestPageResolver,
+) -> Result<(), Error> {
+    match action {
+        PdfAction::GoTo(dest) => {
+            let dest_obj = dest.encode_local(doc, resolver)?;
+            // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1191
+            let mut action = doc.new_dict_with_capacity(2)?;
+            action.dict_put("S", PdfObject::new_name("GoTo")?)?;
+            action.dict_put("D", dest_obj)?;
+            annot.dict_put("A", action)
+        }
+        PdfAction::Uri(uri) => {
+            // MuPDF reads a URI action and stores the URI string as-is, since URI entries are ASCII strings
+            // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L545
+            // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1205
+            let mut action = doc.new_dict_with_capacity(2)?;
+            action.dict_put("S", PdfObject::new_name("URI")?)?;
+            action.dict_put("URI", PdfObject::new_string(uri)?)?;
+            annot.dict_put("A", action)
+        }
+        PdfAction::GoToR { file, dest } => {
+            // MuPDF: GoToR action uses destination + filespec
+            // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1197
+            let mut action = doc.new_dict_with_capacity(3)?;
+            action.dict_put("S", PdfObject::new_name("GoToR")?)?;
+            let dest_obj = dest.encode_remote(doc)?;
+            action.dict_put("D", dest_obj)?;
+
+            // Same as MuPDF `pdf_add_filespec_from_link` function
+            // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1152
+            let file_spec = file.encode_into(doc)?;
+
+            action.dict_put("F", file_spec)?;
+            annot.dict_put("A", action)
+        }
+        PdfAction::Launch(file) => {
+            // Same as MuPDF `pdf_add_filespec_from_link` function
+            // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1152
+            let file_spec = file.encode_into(doc)?;
+            // No direct MuPDF code, see PDF 32000-1:2008, section 12.6.4.5, Table 203.
+            // https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1952224
+            let mut action = doc.new_dict_with_capacity(2)?;
+            action.dict_put("S", PdfObject::new_name("Launch")?)?;
+            action.dict_put("F", file_spec)?;
+            annot.dict_put("A", action)
+        }
+    }
+}

--- a/src/pdf/links/extraction.rs
+++ b/src/pdf/links/extraction.rs
@@ -94,7 +94,14 @@ pub(crate) fn parse_external_link(uri: &str) -> Option<PdfAction> {
         let dest = match parse_params(params) {
             ParsedFragment::Explicit(page, kind) => PdfDestination::Page { page, kind },
             ParsedFragment::Named(name) => PdfDestination::Named(name),
-            ParsedFragment::ContainsUnknownKeys => PdfDestination::Named(uri.to_string()),
+            ParsedFragment::ContainsUnknownKeys => {
+                // Matches MuPDF's `parse_uri_named_dest` behavior
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L908
+                let name = strip_prefix_icase(params, "nameddest=")
+                    .map(|raw| raw.split_once(['&', '#']).map_or(raw, |(head, _)| head))
+                    .unwrap_or(params);
+                PdfDestination::Named(decode_uri_component(name).into_owned())
+            }
             ParsedFragment::Empty => return None,
         };
 

--- a/src/pdf/links/extraction.rs
+++ b/src/pdf/links/extraction.rs
@@ -1,0 +1,857 @@
+use percent_encoding::percent_decode_str;
+use std::borrow::Cow;
+
+use super::{FileSpec, LinkAction, PdfAction, PdfDestination};
+use crate::destination::not_nan;
+use crate::pdf::{PdfDocument, PdfObject};
+use crate::{DestinationKind, Error, Rect};
+
+/// Parses a [MuPDF-compatible] link URI string into a structured [`PdfAction`] based on the Adobe
+/// specification ["Parameters for Opening PDF Files"] from the Adobe Acrobat SDK, version 8.1.
+///
+/// This is the inverse of [`PdfAction`]'s [`fmt::Display`](std::fmt::Display) implementation.
+/// It takes the URI string that MuPDF produces when reading link annotations (via
+/// [`pdf_parse_link_action`]) and reconstructs the corresponding [`PdfAction`] variant.
+///
+/// # Input -> Output mapping
+///
+/// | Input pattern                                    | Output action                    |
+/// |--------------------------------------------------|----------------------------------|
+/// | `#page=<N><dest_params>`                         | `GoTo(Page { page: N-1, kind })` |
+/// | `#nameddest=<encoded>`                           | `GoTo(Named(decoded_name))`      |
+/// | `#<raw_name (encoded)>`                          | `GoTo(Named(decoded_name))`      |
+/// | `file://<path>.pdf#<params>`                     | `GoToR { file: Path(..), dest }` |
+/// | `file:<path>.pdf#<params>`                       | `GoToR { file: Path(..), dest }` |
+/// | `<scheme>://<host>/<..>.pdf#<params>` (external) | `GoToR { file: Url(..),  dest }` |
+/// | `<path>.pdf#<params>` (no scheme)                | `GoToR { file: Path(..), dest }` |
+/// | `file:<path>` (non-PDF)                          | `Launch(Path(..))`               |
+/// | `<local_path>` (non-external, non-PDF)           | `Launch(Path(..))`               |
+/// | `<scheme>://<..>` (non-PDF, external)            | `Uri(uri)`                       |
+///
+/// where:
+///
+/// - `<N>` is a 1-based page number (converted to 0-based)
+/// - `<dest_params>` are `&view=` / `&zoom=` / `&viewrect=` parameters, parsed into a [`DestinationKind`]
+///   (see [`pdf_new_explicit_dest_from_uri`] and ["Parameters for Opening PDF Files"])
+/// - `<params>` in the `GoToR` rows are parsed as:
+///   - explicit destination parameters
+///   - a named destination
+///   - or [`PdfDestination::default`]
+///
+/// File paths are percent-decoded and normalized (`.`/`..` resolved), matching MuPDF's
+/// [`parse_file_uri_path`]. Named destinations are percent-decoded matching MuPDF's
+/// [`fz_decode_uri_component`].
+///
+/// # Disambiguation
+///
+/// MuPDF flattens all PDF action types into a single URI string (via [`pdf_parse_link_action`]),
+/// so this function uses heuristics to reconstruct the original action type:
+///
+/// - Fragment-only (`#...`) -> `GoTo`
+/// - `.pdf` suffix in path -> `GoToR`
+/// - `file:` scheme or non-external path -> `Launch`
+/// - External URI (scheme length > 2, matching MuPDF's [`fz_is_external_link`]) -> `Uri`
+///
+/// A `Launch` with URL-based `FileSpec` (`FS`=`URL`) is indistinguishable from a `URI` action
+/// in the flattened string, so all external non-PDF URIs map to [`PdfAction::Uri`].
+///
+/// # MuPDF source mapping
+///
+/// | Step                     | MuPDF function(s)                                                         |
+/// |--------------------------|---------------------------------------------------------------------------|
+/// | Overall reconstruct      | [`pdf_new_action_from_link`]                                              |
+/// | `file:` detection        | [`is_file_uri`]                                                           |
+/// | External link detection  | [`fz_is_external_link`]                                                   |
+/// | Explicit dest parsing    | [`pdf_new_explicit_dest_from_uri`]                                        |
+/// | Named dest parsing       | [`parse_uri_named_dest`]                                                  |
+/// | File path decoding       | [`parse_file_uri_path`] -> [`fz_decode_uri_component`] + [`fz_cleanname`] |
+/// | Named dest decoding      | [`fz_decode_uri_component`]                                               |
+///
+/// ["Parameters for Opening PDF Files"]: https://web.archive.org/web/20170921000830/http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf
+/// [MuPDF-compatible]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/include/mupdf/pdf/annot.h#L317
+/// [`pdf_parse_link_action`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L519
+/// [`pdf_new_action_from_link`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1177
+/// [`is_file_uri`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L861
+/// [`fz_is_external_link`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/fitz/link.c#L68
+/// [`pdf_new_explicit_dest_from_uri`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L941
+/// [`parse_uri_named_dest`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L908
+/// [`parse_file_uri_path`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L886
+/// [`fz_decode_uri_component`]: https://github.com/ArtifexSoftware/mupdf/blob/b462c9bd31a7b023e4239b75c38f2e6098805c3e/source/fitz/string.c#L326
+/// [`fz_cleanname`]: https://github.com/ArtifexSoftware/mupdf/blob/b462c9bd31a7b023e4239b75c38f2e6098805c3e/source/fitz/string.c#L469
+pub(crate) fn parse_external_link(uri: &str) -> Option<PdfAction> {
+    let uri = uri.trim();
+    if uri.is_empty() {
+        return None;
+    }
+    let (head, params) = uri
+        .split_once('#')
+        .map(|(head, params)| (head.trim(), params.trim()))
+        .unwrap_or((uri, ""));
+
+    // MuPDF: fragment-only URIs map to GoTo (`pdf_new_action_from_link` function)
+    // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1189
+    if head.is_empty() {
+        let dest = match parse_params(params) {
+            ParsedFragment::Explicit(page, kind) => PdfDestination::Page { page, kind },
+            ParsedFragment::Named(name) => PdfDestination::Named(name),
+            ParsedFragment::ContainsUnknownKeys => PdfDestination::Named(uri.to_string()),
+            ParsedFragment::Empty => return None,
+        };
+
+        return Some(PdfAction::GoTo(dest));
+    }
+
+    // MuPDF: `is_file_uri` checks for the "file:" scheme
+    // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L861
+    // If the path starts with "/", MuPDF adds the "file://" prefix; otherwise, it adds the "file:" prefix
+    // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1066
+    // also MuPDF adds "file://" to unresolved Uri the
+    // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L539
+    let (link, is_explicit_file) = strip_prefix_icase(head, "file://")
+        .or_else(|| strip_prefix_icase(head, "file:"))
+        .map(|path| (path, true))
+        .unwrap_or((head, false));
+
+    if is_pdf_path(link) {
+        let dest = match parse_params(params) {
+            ParsedFragment::Empty => PdfDestination::default(),
+            ParsedFragment::Explicit(page, kind) => PdfDestination::Page { page, kind },
+            ParsedFragment::Named(name) => PdfDestination::Named(name),
+            ParsedFragment::ContainsUnknownKeys => return Some(PdfAction::Uri(uri.to_owned())),
+        };
+
+        let is_url = !is_explicit_file && is_external_link(link);
+
+        let file = if is_url {
+            FileSpec::Url(link.to_string())
+        } else {
+            // MuPDF: `parse_file_uri_path` does decode + cleanname
+            // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L896
+            FileSpec::Path(decode_and_clean_path(link))
+        };
+
+        return Some(PdfAction::GoToR { file, dest });
+    }
+
+    // MuPDF flattens `Launch` and `URI` actions into a single URI string, normalizing local files
+    // to `file:` scheme or relative paths. We use heuristics to reconstruct the action type:
+    //
+    // 1. `file:` scheme or URIs that do not look like external links (local paths) -> `Launch`.
+    // 2. URIs that look like external links (http, mailto, etc.) -> `Uri`.
+    //
+    // Note: The PDF specification allows a `Launch` with URL `FileSpec` (FS entry = URL).
+    // However, it is impossible to distinguish a "Launch with URL FileSpec" from a standard
+    // "URI Action" based solely on the flattened string provided by MuPDF. Therefore,
+    // all detected files are mapped to `FileSpec::Path`, and all web links to `PdfAction::Uri`.
+    //
+    // Look at MuPDF's `pdf_parse_link_action`/`convert_file_spec_to_URI` functions:
+    //
+    // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L519
+    // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L288
+
+    if link.is_empty() && is_explicit_file {
+        return None;
+    }
+
+    let action = if is_explicit_file {
+        PdfAction::Launch(FileSpec::Path(decode_and_clean_path(link)))
+    } else if !is_external_link(uri) {
+        PdfAction::Launch(FileSpec::Path(decode_and_clean_path(uri)))
+    } else {
+        // URI entries are ASCII strings, so we return uri as it is
+        // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L545
+        PdfAction::Uri(uri.to_string())
+    };
+    Some(action)
+}
+
+/// Rust port of [`fz_is_external_link`] function.
+///
+/// Checks if a string represents an external web URI (e.g., `http`, `mailto`).
+///
+/// # Heuristic
+///
+/// Checks for a colon (`:`) that appears at an index greater than 2 (i.e., the scheme length must be
+/// at least 3 characters). This constraint is used to distinguish external links from
+/// DOS/Windows drive letters (e.g., `C:` or `D:`).
+///
+/// [`fz_is_external_link`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/fitz/link.c#L68
+pub(super) fn is_external_link(uri: &str) -> bool {
+    let Some((scheme, _)) = uri.split_once(':') else {
+        return false;
+    };
+    if scheme.len() < 3 || !scheme.as_bytes()[0].is_ascii_alphabetic() {
+        return false;
+    }
+    scheme[1..]
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'+' | b'-' | b'.'))
+}
+
+/// Heuristic for determining whether a URI path targets a PDF file.
+/// Returns `true` if `file_name` ends with `.pdf` (case-insensitive).
+pub(super) fn is_pdf_path(file_name: &str) -> bool {
+    file_name
+        .get(file_name.len().saturating_sub(4)..)
+        .is_some_and(|extension| extension.eq_ignore_ascii_case(".pdf"))
+}
+
+#[derive(Debug, PartialEq)]
+enum ParsedFragment {
+    Empty,
+    Explicit(u32, DestinationKind),
+    Named(String),
+    ContainsUnknownKeys,
+}
+
+/// Parses destination parameters from a URI fragment string.
+///
+/// # Supported Parameters
+///
+/// - `page`: The target page number (1-based in string, converted to 0-based).
+/// - `nameddest`: A named destination (percent-decoded).
+/// - `view`: The zoom/view mode (`Fit`, `FitH`, `FitV`, etc.).
+/// - `zoom`: XYZ zoom parameters.
+/// - `viewrect`: Rectangle parameters for `FitR`.
+///
+/// # Behavior
+///
+/// - Iterates left-to-right over key-value pairs.
+///
+/// - `page` and `nameddest` are mutually exclusive, with the last one seen taking precedence
+///   and resetting the other (matching the Adobe specification)
+///
+/// - Returns [`ParsedFragment::ContainsUnknownKeys`] if an unrecognized parameter key is encountered.
+///   This signals that the fragment contains additional options (as per the Adobe specification)
+///   and should likely be treated as a standard URI rather than a PDF explicit destination
+///   to avoid losing information.
+///
+/// - Returns [`ParsedFragment::Empty`] if the fragment is empty or contains no parameters at all.
+///
+/// - Returns [`ParsedFragment::Named`] if:
+///   - an explicit `nameddest=` key was the last destination identifier, or
+///   - no key-value pairs were recognized (the entire fragment is treated as a raw
+///     named destination, matching MuPDF's [`parse_uri_named_dest`] fallback).
+///
+/// - Returns [`ParsedFragment::Explicit`] if at least one `page` or view parameter was parsed
+///   and no `nameddest` followed.
+///
+/// Named destinations are percent-decoded via [`decode_uri_component`].
+///
+/// This is the Rust analogue of MuPDF's [`pdf_new_explicit_dest_from_uri`] combined
+/// with [`parse_uri_named_dest`].
+///
+/// [`parse_uri_named_dest`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L908
+/// [`pdf_new_explicit_dest_from_uri`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L941
+fn parse_params(params: &str) -> ParsedFragment {
+    if params.is_empty() {
+        return ParsedFragment::Empty;
+    }
+    let mut page = None;
+    let mut kind = None;
+    let mut named_dest = None;
+
+    for (k, v) in fragment_kv_pairs(params) {
+        if k.eq_ignore_ascii_case("page") {
+            if let Some(new_page) = parse_page_1based_to_0based(v) {
+                page = Some(new_page);
+                // reset view state on page change
+                kind = Some(DestinationKind::default());
+                named_dest = None; // explicit page overrides named dest
+            }
+            continue;
+        }
+
+        if k.eq_ignore_ascii_case("nameddest") {
+            named_dest = Some(v);
+            page = None; // named dest overrides explicit page
+            kind = None;
+            continue;
+        }
+
+        let new_kind = if k.eq_ignore_ascii_case("viewrect") {
+            parse_viewrect(v)
+        } else if k.eq_ignore_ascii_case("zoom") {
+            Some(parse_zoom(v))
+        } else if k.eq_ignore_ascii_case("view") {
+            parse_view(v)
+        } else {
+            return ParsedFragment::ContainsUnknownKeys;
+        };
+
+        if let Some(k) = new_kind {
+            kind = Some(k);
+        }
+    }
+
+    if let Some(name) = named_dest {
+        return if !name.is_empty() {
+            ParsedFragment::Named(decode_uri_component(name).into())
+        } else {
+            ParsedFragment::Empty
+        };
+    }
+
+    match (page, kind) {
+        (None, None) => ParsedFragment::Named(decode_uri_component(params).into()),
+        (p, k) => ParsedFragment::Explicit(p.unwrap_or_default(), k.unwrap_or_default()),
+    }
+}
+
+/// Iterates over `key=value` pairs in a URI fragment string.
+///
+/// - Splits on `&` or `#`.
+/// - Skips segments that contain no `=` sign.
+fn fragment_kv_pairs(fragment: &str) -> impl Iterator<Item = (&str, &str)> {
+    fragment
+        .split(['&', '#'])
+        .filter_map(|part| part.split_once('='))
+}
+
+/// Parses a 1-based page number string to a 0-based integer. Returns 0 if the result
+/// would be negative. Mirrors MuPDF's logic in [`pdf_new_explicit_dest_from_uri:957`].
+///
+/// [`pdf_new_explicit_dest_from_uri:957`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L957
+fn parse_page_1based_to_0based(s: &str) -> Option<u32> {
+    let n: i32 = s.parse().ok()?;
+    if n < 2 {
+        Some(0)
+    } else {
+        Some(n as u32 - 1)
+    }
+}
+
+/// Parses a `viewrect=` fragment parameter into a [`DestinationKind::FitR`].
+/// Requires 4 comma-separated floats (left, bottom, width, height).
+///
+/// Mirrors MuPDF's parsing in [`pdf_new_explicit_dest_from_uri:963`].
+///
+/// [`pdf_new_explicit_dest_from_uri:963`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L963
+fn parse_viewrect(s: &str) -> Option<DestinationKind> {
+    let mut floats = FloatParser::new(s);
+    let x = floats.next_finite()?;
+    let y = floats.next_finite()?;
+    let w = floats.next_finite()?;
+    let h = floats.next_finite()?;
+
+    Some(DestinationKind::FitR {
+        left: x,
+        bottom: y,
+        right: x + w,
+        top: y + h,
+    })
+}
+
+/// Parses a `zoom=` fragment parameter into a [`DestinationKind::XYZ`].
+///
+/// Format: `zoom=[scale,left,top]`. All fields except the first are optional.
+/// The `scale` (zoom) is in percent (e.g., `150` for 150%). A value `≤ 0` or `inf`
+/// is normalized to `100%`.
+///
+/// Mirrors MuPDF's parsing in [`pdf_new_explicit_dest_from_uri:972`].
+///
+/// [`pdf_new_explicit_dest_from_uri:972`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L972
+fn parse_zoom(s: &str) -> DestinationKind {
+    let mut floats = FloatParser::new(s);
+    let zoom = floats.next_not_nan().map(|n| {
+        if n <= 0.0 || n.is_infinite() {
+            100.0
+        } else {
+            n
+        }
+    });
+
+    DestinationKind::XYZ {
+        left: floats.next_finite(),
+        top: floats.next_finite(),
+        zoom,
+    }
+}
+
+/// Parses a `view=` fragment parameter into a [`DestinationKind`] variant
+/// (Fit, FitH, FitV, etc.).
+///
+/// Mirrors MuPDF's parsing in [`pdf_new_explicit_dest_from_uri:983`].
+///
+/// [`pdf_new_explicit_dest_from_uri:983`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L983
+fn parse_view(s: &str) -> Option<DestinationKind> {
+    if s.is_empty() {
+        return None;
+    }
+
+    let mut iter = s.split(',').map(str::trim);
+    if let Some(key) = iter.next() {
+        if key.eq_ignore_ascii_case("Fit") {
+            return Some(DestinationKind::Fit);
+        } else if key.eq_ignore_ascii_case("FitB") {
+            return Some(DestinationKind::FitB);
+        }
+
+        let val = iter
+            .next()
+            .and_then(|s| s.parse::<f32>().ok())
+            .filter(|num| num.is_finite());
+
+        if key.eq_ignore_ascii_case("FitH") {
+            return Some(DestinationKind::FitH { top: val });
+        } else if key.eq_ignore_ascii_case("FitBH") {
+            return Some(DestinationKind::FitBH { top: val });
+        } else if key.eq_ignore_ascii_case("FitV") {
+            return Some(DestinationKind::FitV { left: val });
+        } else if key.eq_ignore_ascii_case("FitBV") {
+            return Some(DestinationKind::FitBV { left: val });
+        }
+    }
+
+    None
+}
+
+/// Helper for parsing comma-separated `f32` values.
+struct FloatParser<'a>(std::str::Split<'a, char>);
+
+impl<'a> FloatParser<'a> {
+    fn new(s: &'a str) -> Self {
+        Self(s.split(','))
+    }
+
+    fn next(&mut self) -> Option<f32> {
+        self.0.next().and_then(|p| p.trim().parse::<f32>().ok())
+    }
+
+    fn next_finite(&mut self) -> Option<f32> {
+        self.next().filter(|num| num.is_finite())
+    }
+
+    fn next_not_nan(&mut self) -> Option<f32> {
+        self.next().filter(|num| !num.is_nan())
+    }
+}
+
+/// Strips `pat` from the start of string using ASCII case-insensitive matching.
+/// Returns Some(remainder) if the prefix matches, otherwise None.
+fn strip_prefix_icase<'a>(s: &'a str, pat: &str) -> Option<&'a str> {
+    let len = pat.len();
+    s.get(..len)
+        .filter(|head| head.eq_ignore_ascii_case(pat))
+        .and_then(|_| s.get(len..))
+}
+
+/// Decodes URL-encoded sequences and normalizes the path.
+/// See [`decode_uri_component`] and [`cleanname`] documentation.
+fn decode_and_clean_path(path: &str) -> String {
+    let decoded = decode_uri_component(path);
+    cleanname(&decoded)
+}
+
+/// Normalizes a path, removing . and .. segments and collapsing duplicate slashes.
+/// Mirrors MuPDF's [`fz_cleanname`] behavior
+///
+/// [`fz_cleanname`]: https://github.com/ArtifexSoftware/mupdf/blob/b462c9bd31a7b023e4239b75c38f2e6098805c3e/source/fitz/string.c#L469
+fn cleanname(name: &str) -> String {
+    let rooted = name.starts_with('/');
+    let mut parts = Vec::with_capacity(8);
+    let mut dotdot_depth: usize = 0;
+
+    for component in name.split('/') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                if !rooted && parts.len() <= dotdot_depth {
+                    // relative path and can't backtrack — keep the ".."
+                    parts.push("..");
+                    dotdot_depth += 1;
+                } else if parts.len() > dotdot_depth {
+                    parts.pop();
+                }
+                // rooted path: ".." at root is just ignored
+            }
+            part => parts.push(part),
+        }
+    }
+
+    if parts.is_empty() {
+        return if rooted { "/".into() } else { ".".into() };
+    }
+
+    let cap = rooted as usize + parts.iter().map(|p| p.len()).sum::<usize>() + parts.len() - 1;
+
+    let mut out = String::with_capacity(cap);
+    if rooted {
+        out.push('/');
+    }
+    out.push_str(parts[0]);
+    for part in &parts[1..] {
+        out.push('/');
+        out.push_str(part);
+    }
+    out
+}
+
+/// Unescapes URL-encoded sequences (%XX) in a string.
+///
+/// Uses RFC 3986 compliant decoding via the percent-encoding crate.
+/// Falls back to the original string if the decoded bytes are not valid UTF-8.
+///
+/// The same as MuPDF's [`fz_decode_uri_component`] function
+///
+/// [`fz_decode_uri_component`]: https://github.com/ArtifexSoftware/mupdf/blob/b462c9bd31a7b023e4239b75c38f2e6098805c3e/source/fitz/string.c#L326
+pub(super) fn decode_uri_component(s: &str) -> Cow<'_, str> {
+    percent_decode_str(s)
+        .decode_utf8()
+        .unwrap_or(Cow::Borrowed(s))
+}
+
+/// Parses a [`LinkAction`] from a link annotation's PDF dictionary.
+///
+/// Reads entries in this priority (matching [`pdf_load_link`] in MuPDF):
+/// 1. `/Dest` entry reads as [`LinkAction::Dest`] (see [`parse_dest_value`]).
+/// 2. `/A` (Action) dictionary reads as [`LinkAction::Action`] (see [`parse_action_dict`]).
+/// 3. `/AA` (Additional Actions) reads as [`LinkAction::Action`]: tries `/D` (mouse-down)
+///    then `/U` (mouse-up).
+///
+/// `page_no` is the 0-based page number where this annotation resides, used to resolve
+/// relative `Named` actions (`PrevPage`, `NextPage`). Pass `None` if the page number is
+/// unknown. Absolute named actions (`FirstPage`, `LastPage`) are always resolved.
+///
+/// For `Page { .. }` destinations, the page index is resolved from an indirect page
+/// object reference via [`PdfDocument::lookup_page_number`], and coordinates are
+/// transformed to Fitz coordinate space (see [`parse_dest_array`]).
+///
+/// [`pdf_load_link`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L652
+pub(crate) fn parse_link_action_from_annot_dict(
+    obj: &PdfObject,
+    doc: &PdfDocument,
+    page_no: Option<i32>,
+) -> Result<Option<LinkAction>, Error> {
+    // 1. Check /Dest entry first (per PDF spec priority)
+    if let Some(dest_obj) = obj.get_dict("Dest")? {
+        return parse_dest_value(&dest_obj, doc).map(|dest| dest.map(LinkAction::Dest));
+    }
+
+    // 2. Check /A (Action) entry
+    if let Some(action_obj) = obj.get_dict("A")? {
+        return parse_action_dict(&action_obj, doc, page_no).map(|opt| opt.map(LinkAction::Action));
+    }
+    // 3. Check /AA (Additional Actions) - D (mouse-down) then U (mouse-up)
+    if let Some(add_action_obj) = obj.get_dict("AA")? {
+        // ISO 32000-2:2020 (PDF 2.0) - abbreviated names take precedence
+        // https://github.com/ArtifexSoftware/mupdf/blob/53d140db017352190eae56b2c5a71d93494dd226/source/pdf/pdf-object.c#L2466
+        if let Some(d) = add_action_obj.get_dict("D")? {
+            return parse_action_dict(&d, doc, page_no).map(|opt| opt.map(LinkAction::Action));
+        }
+        if let Some(u) = add_action_obj.get_dict("U")? {
+            return parse_action_dict(&u, doc, page_no).map(|opt| opt.map(LinkAction::Action));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Parses a raw destination PDF object defined in [PDF 32000-1:2008, 12.3.2]
+/// into a [`PdfDestination`]. This is the Rust analogue of MuPDF's [`pdf_parse_link_dest`].
+///
+/// [PDF 32000-1:2008, 12.3.2]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.2063217
+/// [`pdf_parse_link_dest`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1126
+fn parse_dest_value(dest: &PdfObject, doc: &PdfDocument) -> Result<Option<PdfDestination>, Error> {
+    if dest.is_array()? && dest.len()? > 0 {
+        parse_dest_array(dest, doc).map(Some)
+    } else if dest.is_name()? {
+        let name = std::str::from_utf8(dest.as_name()?).map_err(|_| Error::InvalidUtf8)?;
+        Ok(Some(PdfDestination::Named(name.to_owned())))
+    } else if dest.is_string()? {
+        Ok(Some(PdfDestination::Named(dest.as_string()?.to_owned())))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Parses an Explicit Destination array ([PDF 32000-1:2008, 12.3.2.2]) into a
+/// [`PdfDestination::Page`].
+///
+/// Expected format is `[page_ref, /View, ...params]`, where:
+/// - `page_ref` is an indirect reference to a page object (for local destinations)
+///   or an integer page number (for remote `GoToR` destinations).
+/// - `/View` is one of the supported fit types: `/XYZ`, `/Fit`, `/FitH`, `/FitV`,
+///   `/FitR`, `/FitB`, `/FitBH`, or `/FitBV`.
+///
+/// # Behavior
+///
+/// - Local destinations coordinates are transformed to Fitz space (Y-axis down) using the
+///   target page's CTM.
+/// - The resolved page index is clamped to `[0..page_count - 1]`.
+///
+/// Mirrors MuPDF's [`populate_destination`].
+///
+/// [PDF 32000-1:2008, 12.3.2.2]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1696125
+/// [`populate_destination`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L66
+fn parse_dest_array(array: &PdfObject, doc: &PdfDocument) -> Result<PdfDestination, Error> {
+    let page_obj = array
+        .get_array(0)?
+        .ok_or_else(|| Error::InvalidDestination("missing page reference in dest array".into()))?;
+
+    let (page_idx, page_obj) = if page_obj.is_int()? {
+        let idx = page_obj.as_int()?;
+        (idx, doc.find_page(idx)?)
+    } else {
+        (doc.lookup_page_number(&page_obj)?, page_obj)
+    };
+
+    let page_count = doc.page_count()?;
+    let page = if page_count > 0 {
+        page_idx.clamp(0, page_count - 1)
+    } else {
+        0
+    };
+
+    let mut kind = DestinationKind::decode_from(array)?;
+
+    // TODO: Find a way to use DestinationKind::transform here.
+    if page_obj.is_dict()? {
+        let ctm = page_obj.page_ctm()?;
+        kind = match kind {
+            DestinationKind::FitH { top } => DestinationKind::FitH {
+                top: top.map(|t| ctm.transform_xy(0.0, t).1),
+            },
+            DestinationKind::FitBH { top } => DestinationKind::FitBH {
+                top: top.map(|t| ctm.transform_xy(0.0, t).1),
+            },
+            DestinationKind::FitV { left } => DestinationKind::FitV {
+                left: left.map(|l| ctm.transform_xy(l, 0.0).0),
+            },
+            DestinationKind::FitBV { left } => DestinationKind::FitBV {
+                left: left.map(|l| ctm.transform_xy(l, 0.0).0),
+            },
+            DestinationKind::XYZ { left, top, zoom } => {
+                // MuPDF uses 0.0 for missing values before transform, then
+                // checks original presence afterward (pdf-link.c:137-141).
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L137
+                let (tx, ty) = ctm.transform_xy(left.unwrap_or(0.0), top.unwrap_or(0.0));
+                DestinationKind::XYZ {
+                    left: left.and(not_nan(tx)),
+                    top: top.and(not_nan(ty)),
+                    zoom,
+                }
+            }
+            DestinationKind::FitR {
+                left,
+                bottom,
+                right,
+                top,
+            } => {
+                // Explicit normalization matching pdf-link.c:149-152
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L149
+                let tr = Rect::new(left, bottom, right, top).transform(&ctm);
+                DestinationKind::FitR {
+                    left: tr.x0.min(tr.x1),
+                    bottom: tr.y0.min(tr.y1),
+                    right: tr.x0.max(tr.x1),
+                    top: tr.y0.max(tr.y1),
+                }
+            }
+            kind => kind,
+        }
+    }
+
+    Ok(PdfDestination::Page {
+        page: page as u32,
+        kind,
+    })
+}
+
+/// Dispatches on the `/S` (action sub-type) entry of a PDF action dictionary and
+/// constructs the corresponding [`PdfAction`] ([PDF 32000-1:2008, 12.6.4]).
+///
+/// `page_no` is the 0-based page number where this annotation resides, used to resolve
+/// relative `Named` actions (`PrevPage`, `NextPage`). Pass `None` if the page number is
+/// unknown. Absolute named actions (`FirstPage`, `LastPage`) are always resolved.
+///
+/// This is the Rust analogue of MuPDF's [`pdf_parse_link_action`].
+///
+/// # Supported action types
+///
+/// | `/S` value | Key(s) read          | Result                                              |
+/// |------------|----------------------|-----------------------------------------------------|
+/// | `GoTo`     | `/D` dest            | `PdfAction::GoTo(_)` via [`parse_dest_value`]       |
+/// | `URI`      | `/URI` string        | `PdfAction::Uri(_)`, base URI prepended if relative |
+/// | `GoToR`    | `/F` file, `/D` dest | `PdfAction::GoToR { .. }` via [`parse_filespec`]    |
+/// | `Launch`   | `/F` file            | `PdfAction::Launch(_)` via [`parse_filespec`]       |
+/// | `Named`    | `/N` name            | `PdfAction::GoTo(Page { .. })` for known names      |
+///
+/// [PDF 32000-1:2008, 12.6.4]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1697199
+/// [`pdf_parse_link_action`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L519
+fn parse_action_dict(
+    action: &PdfObject,
+    doc: &PdfDocument,
+    page_no: Option<i32>,
+) -> Result<Option<PdfAction>, Error> {
+    let Some(type_obj) = action.get_dict("S")? else {
+        return Ok(None);
+    };
+
+    match type_obj.as_name()? {
+        b"GoTo" => {
+            let Some(dest_obj) = action.get_dict("D")? else {
+                return Ok(None);
+            };
+            let dest = parse_dest_value(&dest_obj, doc)?;
+            Ok(dest.map(PdfAction::GoTo))
+        }
+        b"URI" => {
+            let Some(uri_obj) = action.get_dict("URI")? else {
+                return Ok(None);
+            };
+            let uri = uri_obj.as_string()?.to_owned();
+            // MuPDF prepends the document URI base for non-external URIs.
+            // pdf-link.c:536-543
+            if is_external_link(&uri) {
+                Ok(Some(PdfAction::Uri(uri)))
+            } else {
+                let base = doc
+                    .trailer()?
+                    .get_dict("Root")?
+                    .and_then(|root| root.get_dict("URI").ok().flatten())
+                    .and_then(|uri_dict| uri_dict.get_dict("Base").ok().flatten())
+                    .and_then(|base_obj| base_obj.as_string().ok().map(|s| s.to_owned()));
+                let mut full_uri = base.unwrap_or_else(|| "file://".to_owned());
+                full_uri.reserve(uri.len());
+                full_uri.push_str(&uri);
+                Ok(Some(PdfAction::Uri(full_uri)))
+            }
+        }
+        b"GoToR" => {
+            let file = match action.get_dict("F")? {
+                Some(f) => parse_filespec(&f)?,
+                None => return Ok(None),
+            };
+            let dest = match action.get_dict("D")? {
+                Some(dest) => {
+                    if dest.is_array()? && dest.len()? > 0 {
+                        // Remote dest arrays use integer page numbers
+                        let page_obj = dest.get_array(0)?.ok_or_else(|| {
+                            Error::InvalidDestination("missing page in GoToR dest".into())
+                        })?;
+                        let page = page_obj.as_int()? as u32;
+                        let kind = DestinationKind::decode_from(&dest)?;
+                        PdfDestination::Page { page, kind }
+                    } else if dest.is_name()? {
+                        let name =
+                            std::str::from_utf8(dest.as_name()?).map_err(|_| Error::InvalidUtf8)?;
+                        PdfDestination::Named(name.to_owned())
+                    } else if dest.is_string()? {
+                        PdfDestination::Named(dest.as_string()?.to_owned())
+                    } else {
+                        PdfDestination::default()
+                    }
+                }
+                None => PdfDestination::default(),
+            };
+            Ok(Some(PdfAction::GoToR { file, dest }))
+        }
+        b"Launch" => match action.get_dict("F")? {
+            Some(f) => Ok(Some(PdfAction::Launch(parse_filespec(&f)?))),
+            None => Ok(None),
+        },
+        // Named action (S=Named): navigates to a well-known page using the /N entry.
+        // MuPDF: pdf_parse_link_action, lines 558-580
+        // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L558
+        b"Named" => {
+            let Some(dest_obj) = action.get_dict("N")? else {
+                return Ok(None);
+            };
+            let total = doc.page_count()?;
+            let target = match dest_obj.as_name()? {
+                b"FirstPage" => Some(0),
+                b"LastPage" => Some((total - 1).max(0)),
+                b"PrevPage" => page_no.map(|p| (p - 1).max(0)),
+                b"NextPage" => page_no.map(|p| (p + 1).min(total - 1)),
+                _ => return Ok(None),
+            };
+            let Some(page) = target else {
+                return Ok(None);
+            };
+            Ok(Some(PdfAction::GoTo(PdfDestination::Page {
+                page: page as u32,
+                kind: DestinationKind::default(),
+            })))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Parses a PDF file specification object ([PDF 32000-1:2008, 7.11.3]) into a [`FileSpec`].
+///
+/// | Object type                                 | Result                                                   |
+/// |---------------------------------------------|----------------------------------------------------------|
+/// | String                                      | `FileSpec::Path(string)`                                 |
+/// | Dict with `FS = /URL` and `F` entry         | `FileSpec::Url(F value)`                                 |
+/// | Dict with `FS = /URL` but missing `F`       | falls back to name keys and returns `FileSpec::Path(..)` |
+/// | Dict without `FS = /URL`, with a name entry | `FileSpec::Path(name value)`                             |
+///
+/// # `FS = /URL` and key precedence
+///
+/// Per [PDF 32000-1:2008, 7.11.5], URL file specifications store the URL in the `F`
+/// entry (7-bit ASCII URL string). This parser therefore only returns
+/// [`FileSpec::Url`] when `FS = /URL` and `F` is a string.
+///
+/// If `FS = /URL` is present but `F` is absent or invalid, we do **not** reinterpret
+/// `UF`, `Unix`, `DOS`, or `Mac` as URL text, as MuPDF does, since `F` should be
+/// only a 7-bit ASCII URL string, whereas `UF`, for example, is Unicode text.
+/// Those keys are treated via the normal filename fallback and parsed as
+/// [`FileSpec::Path`]. MuPDF most likely does this unintentionally: it first [`resolves`]
+/// a MuPDF file string (from `UF`, `F`, `Unix`, `DOS`, or `Mac`, see [`get_file_stream_and_name`])
+/// and only [`afterward`] checks whether the resulting string is a URL.
+///
+/// This is the Rust analogue of MuPDF's [`convert_file_spec_to_URI`].
+///
+/// [PDF 32000-1:2008, 7.11.3]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G6.1640878
+/// [PDF 32000-1:2008, 7.11.5]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G6.1640997
+/// [`convert_file_spec_to_URI`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L287
+/// [`resolves`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L296
+/// [`get_file_stream_and_name`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L226
+/// [`afterward`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L304
+fn parse_filespec(obj: &PdfObject) -> Result<FileSpec, Error> {
+    if obj.is_string()? {
+        return Ok(FileSpec::Path(obj.as_string()?.to_owned()));
+    }
+
+    if obj.is_dict()? {
+        // Check if it's a URL-based file spec
+        if let Some(fs) = obj.get_dict("FS")? {
+            if fs.is_name()? && fs.as_name()? == b"URL" {
+                // If `FS = /URL` is present but `F` is absent or invalid, we do not reinterpret
+                // `UF`, `Unix`, `DOS`, or `Mac` as URL text, as MuPDF does, since `F` should be
+                // only a 7-bit ASCII URL string, whereas `UF`, for example, is Unicode text.
+                if let Some(f) = obj.get_dict("F")? {
+                    return Ok(FileSpec::Url(f.as_string()?.to_owned()));
+                }
+            }
+        }
+
+        if let Some(name) = get_file_name(obj)? {
+            if name.is_string()? {
+                return Ok(FileSpec::Path(name.as_string()?.to_owned()));
+            }
+        }
+    }
+
+    Err(Error::InvalidDestination(
+        "invalid file specification object".into(),
+    ))
+}
+
+/// Returns the filename object from a PDF file specification dictionary.
+///
+/// Tries the following keys in priority order, returning the value of the first
+/// one present: `UF`, `F`, `Unix`, `DOS`, `Mac`.
+///
+/// This mirrors the name-lookup portion of MuPDF's [`get_file_stream_and_name`].
+///
+/// [`get_file_stream_and_name`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L225
+fn get_file_name(fs: &PdfObject) -> Result<Option<PdfObject>, Error> {
+    for key in ["UF", "F", "Unix", "DOS", "Mac"] {
+        if let Some(v) = fs.get_dict(key)? {
+            return Ok(Some(v));
+        }
+    }
+    Ok(None)
+}

--- a/src/pdf/links/extraction.rs
+++ b/src/pdf/links/extraction.rs
@@ -730,7 +730,7 @@ fn parse_action_dict(
                         let page_obj = dest.get_array(0)?.ok_or_else(|| {
                             Error::InvalidDestination("missing page in GoToR dest".into())
                         })?;
-                        let page = page_obj.as_int()? as u32;
+                        let page = page_obj.as_int()?.max(0) as u32;
                         let kind = DestinationKind::decode_from(&dest)?;
                         PdfDestination::Page { page, kind }
                     } else if dest.is_name()? {

--- a/src/pdf/links/link_annot.rs
+++ b/src/pdf/links/link_annot.rs
@@ -1,0 +1,193 @@
+use std::ops::{Deref, DerefMut};
+
+use super::{
+    parse_link_action_from_annot_dict, set_link_action_on_annot_dict, DestPageResolver, LinkAction,
+    PdfLink, SingleResolver,
+};
+use crate::pdf::{DocOperation, PdfDocument, PdfObject};
+use crate::{Error, Matrix, Rect};
+
+/// A link annotation dictionary in a PDF document, identified by `Subtype=Link`.
+///
+/// Yielded by [`PdfLinkAnnotIter`](crate::pdf::page::PdfLinkAnnotIter), which is
+/// returned by [`PdfPage::link_annotations`](crate::pdf::PdfPage::link_annotations). Items are
+/// produced by iterating the page's `/Annots` array and filtering for link annotations.
+///
+/// # Why not `PdfAnnotation`?
+///
+/// MuPDF's `pdf_sync_annots` ([`PdfPage::annotations`](crate::pdf::PdfPage::annotations))
+/// skips `Subtype=Link` entries, so [`PdfAnnotation`](crate::pdf::PdfAnnotation) of type
+/// [`PdfAnnotationType::Link`](crate::pdf::PdfAnnotationType::Link) can never be produced
+/// from a page via the annotation iterator. This type bypasses that by working directly
+/// with the annotation dictionary object retrieved from the page's `/Annots` array.
+///
+/// Implements [`Deref<Target = PdfObject>`] for access to raw dictionary operations.
+#[derive(Debug)]
+pub struct PdfLinkAnnot {
+    inner: PdfObject,
+}
+
+impl PdfLinkAnnot {
+    pub(crate) fn new(obj: PdfObject) -> Self {
+        Self { inner: obj }
+    }
+
+    /// Reads the link action from this annotation's dictionary, preserving the `/Dest` vs
+    /// `/A` distinction and named destinations as-is.
+    ///
+    /// Returns `Ok(None)` if the annotation has no recognizable action entry.
+    ///
+    /// `page_no` is the 0-based page number where this annotation resides, used to resolve
+    /// relative `Named` actions (`PrevPage`, `NextPage`). Pass `None` if the page number is
+    /// unknown. Absolute named actions (`FirstPage`, `LastPage`) are always resolved.
+    ///
+    /// Unlike [`PdfPage::resolved_links`](crate::pdf::PdfPage::resolved_links), this method:
+    /// - Does not resolve named destinations to concrete page numbers
+    /// - Preserves `Launch` actions exactly as specified in the PDF document
+    /// - Preserves whether the original entry was `/Dest` or `/A`
+    /// - Does not clamp coordinates to the page bounds
+    pub fn action(
+        &self,
+        doc: &PdfDocument,
+        page_no: Option<i32>,
+    ) -> Result<Option<LinkAction>, Error> {
+        parse_link_action_from_annot_dict(&self.inner, doc, page_no)
+    }
+
+    /// Reads the annotation's `/Rect` entry and transforms it from PDF user space to Fitz
+    /// coordinate space using `page_ctm`.
+    ///
+    /// `page_ctm` should be the page's Current Transformation Matrix obtained from
+    /// [`PdfPage::ctm`](crate::pdf::PdfPage::ctm) or
+    /// [`PdfObject::page_ctm`](crate::pdf::PdfObject::page_ctm).
+    /// Pass `None` to skip the transformation and return raw PDF coordinates.
+    pub fn rect(&self, page_ctm: Option<&Matrix>) -> Result<Rect, Error> {
+        let rect_arr = self.inner.get_dict("Rect")?.ok_or_else(|| {
+            Error::InvalidDestination("link annotation missing /Rect entry".into())
+        })?;
+        let x0 = rect_arr
+            .get_array(0)?
+            .ok_or_else(|| Error::InvalidDestination("/Rect[0] missing".into()))?
+            .as_float()?;
+        let y0 = rect_arr
+            .get_array(1)?
+            .ok_or_else(|| Error::InvalidDestination("/Rect[1] missing".into()))?
+            .as_float()?;
+        let x1 = rect_arr
+            .get_array(2)?
+            .ok_or_else(|| Error::InvalidDestination("/Rect[2] missing".into()))?
+            .as_float()?;
+        let y1 = rect_arr
+            .get_array(3)?
+            .ok_or_else(|| Error::InvalidDestination("/Rect[3] missing".into()))?
+            .as_float()?;
+        let pdf_rect = Rect::new(x0, y0, x1, y1);
+        Ok(page_ctm
+            .map(|ctm| pdf_rect.transform(ctm))
+            .unwrap_or(pdf_rect))
+    }
+
+    /// Replaces the link action on this annotation dictionary.
+    ///
+    /// - [`LinkAction::Dest`] — writes a `/Dest` entry and removes `/A`.
+    /// - [`LinkAction::Action`] — writes an `/A` dictionary and removes `/Dest`.
+    ///
+    /// `GoTo` destination coordinates are transformed from Fitz space to PDF user space
+    /// using each destination page's own CTM (obtained on-demand via a fresh lookup).
+    ///
+    /// For bulk updates targeting many pages, prefer [`set_action_with_resolver`](Self::set_action_with_resolver)
+    /// with a [`CachedResolver`](super::CachedResolver) to avoid redundant page lookups.
+    pub fn set_action(&mut self, doc: &mut PdfDocument, action: &LinkAction) -> Result<(), Error> {
+        let mut resolver =
+            SingleResolver::new(|page_obj: &PdfObject| Ok(page_obj.page_ctm()?.invert()));
+        self.set_action_with_resolver(doc, action, &mut resolver)
+    }
+
+    /// Like [`set_action`](Self::set_action) but with a caller-provided [`DestPageResolver`]
+    /// for `GoTo` destination coordinate transformation.
+    ///
+    /// Use this when updating many annotations with destinations on shared pages — pass a
+    /// [`CachedResolver`](super::CachedResolver) to avoid per-annotation page lookups.
+    pub fn set_action_with_resolver(
+        &mut self,
+        doc: &mut PdfDocument,
+        action: &LinkAction,
+        resolver: &mut impl DestPageResolver,
+    ) -> Result<(), Error> {
+        let operation = DocOperation::begin(doc, "Set link action")?;
+
+        match action {
+            LinkAction::Action(_) => {
+                let _ = self.inner.dict_delete("Dest");
+            }
+            LinkAction::Dest(_) => {
+                let _ = self.inner.dict_delete("A");
+            }
+        }
+
+        set_link_action_on_annot_dict(operation.doc, &mut self.inner, action, resolver)?;
+
+        operation.commit();
+        Ok(())
+    }
+
+    /// Writes `rect` (in Fitz coordinate space) as the annotation's `/Rect` entry.
+    ///
+    /// `annot_inv_ctm` is the inverse of the page's CTM (see
+    /// [`Matrix::invert`](crate::Matrix::invert) on
+    /// [`PdfPage::ctm`](crate::pdf::PdfPage::ctm)).
+    /// Pass `None` to write coordinates as-is without transformation.
+    pub fn set_rect(
+        &mut self,
+        doc: &mut PdfDocument,
+        rect: Rect,
+        annot_inv_ctm: Option<&Matrix>,
+    ) -> Result<(), Error> {
+        let operation = DocOperation::begin(doc, "Set link rectangle")?;
+
+        let pdf_rect = annot_inv_ctm
+            .map(|inv_ctm| rect.transform(inv_ctm))
+            .unwrap_or(rect);
+        let mut rect_array = operation.doc.new_array_with_capacity(4)?;
+        pdf_rect.encode_into(&mut rect_array)?;
+        self.inner.dict_put("Rect", rect_array)?;
+
+        operation.commit();
+        Ok(())
+    }
+
+    /// Combines [`rect`](Self::rect) and [`action`](Self::action) into a [`PdfLink`].
+    ///
+    /// Returns `Ok(None)` if the annotation has no recognizable action.
+    pub fn to_pdf_link(
+        &self,
+        doc: &PdfDocument,
+        page_no: Option<i32>,
+        page_ctm: Option<&Matrix>,
+    ) -> Result<Option<PdfLink>, Error> {
+        let Some(action) = self.action(doc, page_no)? else {
+            return Ok(None);
+        };
+        let bounds = self.rect(page_ctm)?;
+        Ok(Some(PdfLink { bounds, action }))
+    }
+
+    /// Consumes this wrapper and returns the underlying [`PdfObject`].
+    pub fn into_inner(self) -> PdfObject {
+        self.inner
+    }
+}
+
+impl Deref for PdfLinkAnnot {
+    type Target = PdfObject;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for PdfLinkAnnot {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}

--- a/src/pdf/links/link_annot.rs
+++ b/src/pdf/links/link_annot.rs
@@ -116,6 +116,7 @@ impl PdfLinkAnnot {
     ) -> Result<(), Error> {
         let operation = DocOperation::begin(doc, "Set link action")?;
 
+        let _ = self.inner.dict_delete("AA");
         match action {
             LinkAction::Action(_) => {
                 let _ = self.inner.dict_delete("Dest");

--- a/src/pdf/links/link_annot.rs
+++ b/src/pdf/links/link_annot.rs
@@ -127,8 +127,7 @@ impl PdfLinkAnnot {
 
         set_link_action_on_annot_dict(operation.doc, &mut self.inner, action, resolver)?;
 
-        operation.commit();
-        Ok(())
+        operation.commit()
     }
 
     /// Writes `rect` (in Fitz coordinate space) as the annotation's `/Rect` entry.
@@ -152,8 +151,7 @@ impl PdfLinkAnnot {
         pdf_rect.encode_into(&mut rect_array)?;
         self.inner.dict_put("Rect", rect_array)?;
 
-        operation.commit();
-        Ok(())
+        operation.commit()
     }
 
     /// Combines [`rect`](Self::rect) and [`action`](Self::action) into a [`PdfLink`].

--- a/src/pdf/links/mod.rs
+++ b/src/pdf/links/mod.rs
@@ -1,0 +1,567 @@
+//! Link annotation extraction and creation helpers for PDFs.
+//!
+//! This module provides PDF-specific link handling built on MuPDF's low-level APIs.
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::fmt;
+
+use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+
+use crate::pdf::{PdfDocument, PdfObject};
+use crate::{DestinationKind, Error, Matrix, Rect};
+
+/// Percent-encoding set matching MuPDF's [`URIUNESCAPED`] (RFC 2396 unreserved characters).
+/// Encodes everything except: alphanumeric, `-`, `_`, `.`, `!`, `~`, `*`, `'`, `(`, `)`.
+///
+/// [`URIUNESCAPED`]: https://github.com/ArtifexSoftware/mupdf/blob/b462c9bd31a7b023e4239b75c38f2e6098805c3e/source/fitz/string.c#L298
+const URI_COMPONENT_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'!')
+    .remove(b'~')
+    .remove(b'*')
+    .remove(b'\'')
+    .remove(b'(')
+    .remove(b')');
+
+/// Same as [`URI_COMPONENT_SET`] but also preserves `/` for path encoding.
+/// Matches MuPDF's [`fz_encode_uri_pathname`].
+///
+/// [`fz_encode_uri_pathname`]: https://github.com/ArtifexSoftware/mupdf/blob/b462c9bd31a7b023e4239b75c38f2e6098805c3e/source/fitz/string.c#L408
+const URI_PATH_SET: &AsciiSet = &URI_COMPONENT_SET.remove(b'/');
+
+mod build;
+pub(crate) use build::build_link_annotation;
+pub(crate) use build::set_link_action_on_annot_dict;
+
+mod extraction;
+pub(crate) use extraction::parse_external_link;
+pub(crate) use extraction::parse_link_action_from_annot_dict;
+
+mod link_annot;
+pub use link_annot::PdfLinkAnnot;
+
+#[cfg(test)]
+mod tests_build;
+#[cfg(test)]
+mod tests_extraction;
+#[cfg(test)]
+mod tests_format;
+#[cfg(test)]
+mod tests_link_annot;
+
+/// Extracted link data from a source page.
+/// Contains all information needed to reconstruct the link in the destination document.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PdfLink {
+    /// Link rectangle in Fitz coordinate space.
+    pub bounds: Rect,
+    /// Link action or destination (see [PDF 32000-1:2008, 12.5.6.5], Table 173).
+    ///
+    /// [PDF 32000-1:2008, 12.5.6.5]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1951136
+    pub action: LinkAction,
+}
+
+/// A link annotation's action or destination entry (see [PDF 32000-1:2008, 12.5.6.5], Table 173).
+///
+/// [PDF 32000-1:2008, 12.5.6.5]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1951136
+#[derive(Debug, Clone, PartialEq)]
+pub enum LinkAction {
+    /// Action dictionary (`A` entry in the annotation dictionary) (see [PDF 32000-1:2008, 12.6.4]).
+    ///
+    /// [PDF 32000-1:2008, 12.6.4]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1697199
+    Action(PdfAction),
+    /// Direct destination (`Dest` entry in the annotation dictionary) (see [PDF 32000-1:2008, 12.3.2]).
+    ///
+    /// [PDF 32000-1:2008, 12.3.2]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.2063217
+    Dest(PdfDestination),
+}
+
+impl LinkAction {
+    /// Converts this `LinkAction` into a [`PdfAction`].
+    ///
+    /// `Dest(d)` becomes `PdfAction::GoTo(d)`, `Action(a)` passes through.
+    pub fn into_pdf_action(self) -> PdfAction {
+        match self {
+            LinkAction::Action(a) => a,
+            LinkAction::Dest(d) => PdfAction::GoTo(d),
+        }
+    }
+
+    /// Returns the destination, if any.
+    ///
+    /// Returns `Some` for `Dest(d)` or `Action(GoTo(d))`.
+    pub fn destination(&self) -> Option<&PdfDestination> {
+        match self {
+            LinkAction::Action(PdfAction::GoTo(d)) => Some(d),
+            LinkAction::Dest(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    /// Convenience method that returns the [`Display`](fmt::Display) output as an owned `String`.
+    ///
+    /// See [`fmt::Display`] impl for output format details and MuPDF source references.
+    pub fn to_uri(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl fmt::Display for LinkAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LinkAction::Action(action) => write!(f, "{action}"),
+            LinkAction::Dest(dest) => write!(f, "#{dest}"),
+        }
+    }
+}
+
+impl From<PdfAction> for LinkAction {
+    fn from(action: PdfAction) -> Self {
+        LinkAction::Action(action)
+    }
+}
+
+impl From<PdfDestination> for LinkAction {
+    fn from(dest: PdfDestination) -> Self {
+        LinkAction::Dest(dest)
+    }
+}
+
+/// PDF link destination representing an action associated with a link annotation
+/// (see [PDF 32000-1:2008, 12.6.4]).
+///
+/// Maps the standard PDF action types — GoTo, GoToR, Launch, and URI to Rust variants.
+/// Each variant corresponds to a specific action dictionary `S` (type) value defined in Table 198.
+///
+/// [PDF 32000-1:2008, 12.6.4]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1697199
+#[derive(Debug, Clone, PartialEq)]
+pub enum PdfAction {
+    /// Go-to action (`S`=`GoTo`): changes the view to a destination in the current document
+    /// (see PDF 32000-1:2008, [12.6.4.2], Table 199).
+    ///
+    /// The `D` entry in the action dictionary specifies the destination to jump to,
+    /// represented here as a [`PdfDestination`].
+    ///
+    /// [12.6.4.2]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1963731
+    GoTo(PdfDestination),
+    /// Remote go-to action (`S`=`GoToR`): jumps to a destination in another PDF file
+    /// (see PDF 32000-1:2008, [12.6.4.3], Table 200).
+    ///
+    /// `file` is the remote file specification (`F` entry) and `dest` is the
+    /// destination within that file (`D` entry).
+    ///
+    /// [12.6.4.3]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1951685
+    GoToR {
+        file: FileSpec,
+        dest: PdfDestination,
+    },
+    /// Launch action (`S`=`Launch`): launches an application or opens/prints a document
+    /// (see PDF 32000-1:2008, [12.6.4.5], Table 203).
+    ///
+    /// The `F` entry in the action dictionary specifies the file to be launched,
+    /// represented here as a [`FileSpec`].
+    ///
+    /// [12.6.4.5]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1952224
+    Launch(FileSpec),
+    /// URI action (`S`=`URI`): resolves a uniform resource identifier
+    /// (see PDF 32000-1:2008, [12.6.4.7], Table 206).
+    ///
+    /// **Constraint:** The value should be a [7-bit ASCII] string (e.g., `"https://example.com"`).
+    ///
+    /// [12.6.4.7]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.1939903
+    Uri(String),
+}
+
+impl PdfAction {
+    /// Convenience method that returns the [`Display`](fmt::Display) output as an owned `String`.
+    ///
+    /// See [`fmt::Display`] impl for output format details and MuPDF source references.
+    pub fn to_uri(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl fmt::Display for PdfAction {
+    /// Formats this action as a [MuPDF-compatible] link URI string based on the Adobe specification
+    /// ["Parameters for Opening PDF Files"] from the Adobe Acrobat SDK, version 8.1.
+    ///
+    /// This is the Rust analogue of MuPDF's [`pdf_parse_link_action`] output - the URI string
+    /// that MuPDF produces when reading link annotations from a PDF document. MuPDF uses this
+    /// URI format both internally and in its public API as the canonical representation of link
+    /// destinations.
+    ///
+    /// # Output shapes
+    ///
+    /// - `GoTo` with explicit dest -> `#page=<N><dest_suffix>`
+    /// - `GoTo` with named dest -> `#nameddest=<percent-encoded name>`
+    /// - `Uri` -> the URI string as-is
+    /// - `Launch` -> `<file_spec_uri>#page=1`
+    /// - `GoToR` with explicit dest -> `<file_spec_uri>#page=<N><dest_suffix>`
+    /// - `GoToR` with named dest -> `<file_spec_uri>#nameddest=<percent-encoded name>`
+    ///
+    /// where:
+    ///
+    /// - `<dest_suffix>` is the [`DestinationKind`] fragment (e.g. `&view=Fit`, `&zoom=100,10,20`)
+    /// - `<file_spec_uri>` is the [`FileSpec`] formatted as a URI prefix:
+    ///   - `file://<path>` for absolute [`FileSpec::Path`]
+    ///   - `file:<path>` for relative [`FileSpec::Path`]
+    ///   - the URL as-is for [`FileSpec::Url`] (see [`convert_file_spec_to_URI`])
+    /// - `<N>` is the 1-based page number
+    ///
+    /// For `GoToR`, the fragment separator is `&` instead of `#` when the file spec URI
+    /// already contains a `#` (possible only for [`FileSpec::Url`]).
+    ///
+    /// # MuPDF source mapping
+    ///
+    /// | Variant                   | MuPDF function(s)                                                                |
+    /// |---------------------------|----------------------------------------------------------------------------------|
+    /// | `GoTo(Page { .. })`       | [`pdf_new_uri_from_explicit_dest`] -> [`format_explicit_dest_link_uri`]          |
+    /// | `GoTo(Named(..))`         | [`pdf_format_remote_link_uri_from_name`] -> [`format_named_dest_link_uri`]       |
+    /// | `Uri(..)`                 | [`pdf_parse_link_action`] (returns URI as-is)                                    |
+    /// | `Launch(..)`              | [`pdf_parse_link_action`] -> [`convert_file_spec_to_URI`]                        |
+    /// | `GoToR { .. }` (explicit) | [`pdf_new_uri_from_path_and_explicit_dest`] -> [`format_explicit_dest_link_uri`] |
+    /// | `GoToR { .. }` (named)    | [`pdf_new_uri_from_path_and_named_dest`] -> [`format_named_dest_link_uri`]       |
+    ///
+    /// File spec conversion (`FileSpec` -> URI prefix) follows [`convert_file_spec_to_URI`],
+    /// and named destination percent-encoding follows [`pdf_append_named_dest_to_uri`].
+    ///
+    /// ["Parameters for Opening PDF Files"]: https://web.archive.org/web/20170921000830/http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf
+    /// [MuPDF-compatible]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/include/mupdf/pdf/annot.h#L317
+    /// [`pdf_parse_link_action`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L519
+    /// [`pdf_new_uri_from_explicit_dest`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1120
+    /// [`format_explicit_dest_link_uri`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L771
+    /// [`pdf_format_remote_link_uri_from_name`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L845
+    /// [`format_named_dest_link_uri`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L835
+    /// [`convert_file_spec_to_URI`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L288
+    /// [`pdf_new_uri_from_path_and_explicit_dest`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1089
+    /// [`pdf_new_uri_from_path_and_named_dest`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1052
+    /// [`pdf_append_named_dest_to_uri`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1023
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PdfAction::GoTo(dest) => write!(f, "#{dest}"),
+            PdfAction::Uri(uri) => {
+                // MuPDF: pdf_parse_link_action returns URI as-is
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L545
+                f.write_str(uri)
+            }
+            PdfAction::Launch(file) => {
+                // MuPDF: convert_file_spec_to_URI
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L288
+                let sep = match file {
+                    FileSpec::Url(url) if url.contains('#') => '&',
+                    _ => '#',
+                };
+                write!(f, "{file}{sep}page=1")
+            }
+            PdfAction::GoToR { file, dest } => {
+                // MuPDF: convert_file_spec_to_URI
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L288
+                // `FileSpec::Path` never contains '#' (it gets percent-encoded),
+                // so only `FileSpec::Url` can already have a fragment.
+                let sep = match file {
+                    FileSpec::Url(url) if url.contains('#') => '&',
+                    _ => '#',
+                };
+                write!(f, "{file}{sep}{dest}")
+            }
+        }
+    }
+}
+
+/// PDF file specification (see [PDF 32000-1:2008, 7.11]).
+///
+/// Represents a file reference that can be either a local filesystem path
+/// (absolute or relative, per [7.11.2]) or a URL-based reference (when `FS` is `URL`,
+/// per [7.11.5]).
+///
+/// [PDF 32000-1:2008, 7.11]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G6.1640832
+/// [7.11.2]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G6.1914353
+/// [7.11.5]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G6.1640997
+#[derive(Debug, Clone, PartialEq)]
+pub enum FileSpec {
+    /// Local filesystem path (e.g., `/Docs/path/file.pdf`, `path/file.pdf`, or `../file.pdf`).
+    ///
+    /// This variant accepts a UTF-8 string, covering the full Unicode range.
+    ///
+    /// When serialized to PDF, this is stored in the `UF` (Unicode File) entry of the
+    /// file specification dictionary (see [7.11.2.2]) encoded as UTF-16BE (per PDF 32000-1:2008,
+    /// [7.9.2.2]), ensuring cross-platform compatibility for non-ASCII filenames.
+    ///
+    /// [7.9.2.2]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G6.1957385
+    /// [7.11.2.2]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G6.1958046
+    Path(String),
+
+    /// URL-based file specification (e.g., `http://example.com/file.pdf`).
+    ///
+    /// **Constraint:** Must be a 7-bit ASCII string (per PDF 32000-1:2008, [7.11.5]).
+    ///
+    /// Any characters that are not representable in 7-bit U.S. ASCII or are considered
+    /// unsafe according to RFC 1738 must be percent-encoded (escaped).
+    ///
+    /// Note that for relative URL-based specifications, RFC 1808 rules apply, and
+    /// sections such as scheme, query, or fragment are not allowed (per PDF 32000-1:2008, [7.11.2.2]).
+    ///
+    /// [7.11.2.2]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G6.1958046
+    /// [7.11.5]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G6.1640997
+    Url(String),
+}
+
+impl FileSpec {
+    /// Encodes this file specification as a PDF file specification dictionary
+    /// (see [PDF 32000-1:2008, 7.11]) and adds it as an indirect object.
+    ///
+    /// - `Path`: creates a dict with `/Type /Filespec`, `/F` (ASCII-safe), `/UF` (Unicode).
+    ///   Rust analogue of MuPDF's [`pdf_add_filespec`].
+    /// - `Url`: creates a dict with `/Type /Filespec`, `/FS /URL`, `/F`.
+    ///   Rust analogue of MuPDF's [`pdf_add_url_filespec`].
+    ///
+    /// [PDF 32000-1:2008, 7.11]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G6.1640832
+    /// [`pdf_add_filespec`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1223
+    /// [`pdf_add_url_filespec`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1268
+    pub(crate) fn encode_into(&self, doc: &mut PdfDocument) -> Result<PdfObject, Error> {
+        match self {
+            FileSpec::Path(path) => {
+                let mut spec = doc.new_dict_with_capacity(3)?;
+                spec.dict_put("Type", PdfObject::new_name("Filespec")?)?;
+                let asciiname: String = path
+                    .chars()
+                    .map(|c| if matches!(c, ' '..='~') { c } else { '_' })
+                    .collect();
+                spec.dict_put("F", PdfObject::new_string(&asciiname)?)?;
+                spec.dict_put("UF", PdfObject::new_string(path)?)?;
+                // MuPDF uses pdf_add_new_dict which creates an indirect object (pdf-link.c:1249)
+                doc.add_object(&spec)
+            }
+            FileSpec::Url(url) => {
+                let mut spec = doc.new_dict_with_capacity(3)?;
+                spec.dict_put("Type", PdfObject::new_name("Filespec")?)?;
+                spec.dict_put("FS", PdfObject::new_name("URL")?)?;
+                spec.dict_put("F", PdfObject::new_string(url)?)?;
+                // MuPDF uses pdf_add_new_dict which creates an indirect object (pdf-link.c:1268)
+                doc.add_object(&spec)
+            }
+        }
+    }
+}
+
+impl fmt::Display for FileSpec {
+    /// Formats this file specification as a [MuPDF-compatible] URI string.
+    ///
+    /// Follows MuPDF's [`convert_file_spec_to_URI`] logic:
+    /// - `FileSpec::Path` -> `file://<percent-encoded path>` (absolute) or `file:<percent-encoded path>` (relative)
+    /// - `FileSpec::Url` -> the URL string as-is
+    ///
+    /// [`convert_file_spec_to_URI`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L288
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FileSpec::Path(path) => {
+                let prefix = if path.starts_with('/') {
+                    "file://"
+                } else {
+                    "file:"
+                };
+                write!(f, "{prefix}{}", utf8_percent_encode(path, URI_PATH_SET))
+            }
+            FileSpec::Url(url) => f.write_str(url),
+        }
+    }
+}
+
+/// Destination within a PDF document (see [PDF 32000-1:2008, 12.3.2]).
+///
+/// Represents the `D` entry in both `GoTo` and `GoToR` [`PdfAction`] or
+/// `Dest` entry in [`LinkAction`].
+///
+/// [PDF 32000-1:2008, 12.3.2]: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.2063217
+#[derive(Debug, Clone, PartialEq)]
+pub enum PdfDestination {
+    /// Explicit destination: zero-based page number with view settings (e.g., page 0, Fit).
+    Page { page: u32, kind: DestinationKind },
+    /// Named destination string resolved in the remote document's name tree (e.g., `"Chapter1"`).
+    Named(String),
+}
+
+impl PdfDestination {
+    /// Convenience method that returns the [`Display`](fmt::Display) output as an owned `String`.
+    ///
+    /// See [`fmt::Display`] impl for output format details and MuPDF source references.
+    pub fn to_uri(&self) -> String {
+        self.to_string()
+    }
+
+    /// Encode as a local destination (for `/GoTo` actions and direct `/Dest` entries).
+    ///
+    /// - `Page { page, kind }`: resolves page to indirect ref via `resolver`,
+    ///   transforms coordinates from Fitz space to PDF user space, and builds
+    ///   the destination array `[page_ref, /Kind, params...]`.
+    /// - `Named(name)`: returns a PDF string object.
+    pub(crate) fn encode_local(
+        &self,
+        doc: &mut PdfDocument,
+        resolver: &mut impl DestPageResolver,
+    ) -> Result<PdfObject, Error> {
+        match self {
+            PdfDestination::Page { page, kind } => {
+                // MuPDF: GoTo action + explicit destination array
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1315
+                let mut dest = doc.new_array_with_capacity(6)?;
+                let (dest_page_obj, dest_inv_ctm) = resolver.resolve(doc, *page)?;
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1325
+                dest.array_push_ref(dest_page_obj)?;
+
+                // MuPDF uses inv_ctm to transform coordinates
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1328
+                let dest_kind = dest_inv_ctm
+                    .as_ref()
+                    .map(|inv_ctm| kind.transform(inv_ctm))
+                    .unwrap_or(*kind);
+                dest_kind.encode_into(&mut dest)?;
+                Ok(dest)
+            }
+            // MuPDF stores the named destination as-is
+            // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1297
+            // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1192
+            PdfDestination::Named(name) => PdfObject::new_string(name),
+        }
+    }
+
+    /// Encode as a remote destination (for `/GoToR` actions).
+    ///
+    /// - `Page { page, kind }`: pushes page as integer, encodes kind as-is
+    ///   (coordinates are already in PDF default user space).
+    /// - `Named(name)`: returns a PDF string object.
+    pub(crate) fn encode_remote(&self, doc: &mut PdfDocument) -> Result<PdfObject, Error> {
+        match self {
+            PdfDestination::Page { page, kind } => {
+                let mut dest = doc.new_array_with_capacity(6)?;
+                // Push the page as-is.
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1319
+                dest.array_push(PdfObject::new_int(*page as i32)?)?;
+                // MuPDF uses an identity matrix to transform coordinates, but we could just not do that
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1320
+                kind.encode_into(&mut dest)?;
+                Ok(dest)
+            }
+            // same as PdfDestination::Named(_) in encode_local
+            PdfDestination::Named(name) => PdfObject::new_string(name),
+        }
+    }
+}
+
+impl Default for PdfDestination {
+    fn default() -> Self {
+        Self::Page {
+            page: 0,
+            kind: DestinationKind::default(),
+        }
+    }
+}
+
+impl fmt::Display for PdfDestination {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PdfDestination::Page { page, kind } => {
+                write!(f, "page={}{kind}", page.saturating_add(1))
+            }
+            PdfDestination::Named(name) => {
+                // MuPDF: pdf_append_named_dest_to_uri
+                // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L1023
+                write!(
+                    f,
+                    "nameddest={}",
+                    utf8_percent_encode(name, URI_COMPONENT_SET)
+                )
+            }
+        }
+    }
+}
+
+/// Resolves destination page objects and their inverse CTMs for link building.
+///
+/// This trait abstracts the retrieval of page objects and their inverse CTMs,
+/// allowing callers to control caching strategy. For example, a [`HashMap`]-backed
+/// implementation avoids redundant lookups when many links target the same page,
+/// while a single-slot implementation is lighter for one-off operations.
+pub trait DestPageResolver {
+    fn resolve(
+        &mut self,
+        doc: &PdfDocument,
+        page_num: u32,
+    ) -> Result<(&PdfObject, Option<&Matrix>), Error>;
+}
+
+/// Resolver for bulk operations. Caches pages in a HashMap.
+pub struct CachedResolver<'a, F> {
+    cache: &'a mut HashMap<u32, (PdfObject, Option<Matrix>)>,
+    fn_dest_inv_ctm: F,
+}
+
+impl<'a, F> CachedResolver<'a, F> {
+    pub fn new(
+        cache: &'a mut HashMap<u32, (PdfObject, Option<Matrix>)>,
+        fn_dest_inv_ctm: F,
+    ) -> Self {
+        Self {
+            cache,
+            fn_dest_inv_ctm,
+        }
+    }
+}
+
+impl<'a, F> DestPageResolver for CachedResolver<'a, F>
+where
+    F: FnMut(&PdfObject) -> Result<Option<Matrix>, Error>,
+{
+    fn resolve(
+        &mut self,
+        doc: &PdfDocument,
+        page_num: u32,
+    ) -> Result<(&PdfObject, Option<&Matrix>), Error> {
+        match self.cache.entry(page_num) {
+            Entry::Occupied(entry) => {
+                let (obj, mat) = entry.into_mut();
+                Ok((obj, mat.as_ref()))
+            }
+            Entry::Vacant(entry) => {
+                let page_obj = doc.find_page(page_num as i32)?;
+                let inv_ctm = (self.fn_dest_inv_ctm)(&page_obj)?;
+                let (obj, mat) = entry.insert((page_obj, inv_ctm));
+                Ok((obj, mat.as_ref()))
+            }
+        }
+    }
+}
+
+/// Resolver for single operations. Uses a single `Option` slot to own the data.
+pub struct SingleResolver<F> {
+    slot: Option<(PdfObject, Option<Matrix>)>,
+    fn_dest_inv_ctm: F,
+}
+
+impl<F> SingleResolver<F> {
+    pub fn new(fn_dest_inv_ctm: F) -> Self {
+        Self {
+            slot: None,
+            fn_dest_inv_ctm,
+        }
+    }
+}
+
+impl<F> DestPageResolver for SingleResolver<F>
+where
+    F: FnMut(&PdfObject) -> Result<Option<Matrix>, Error>,
+{
+    fn resolve(
+        &mut self,
+        doc: &PdfDocument,
+        page_num: u32,
+    ) -> Result<(&PdfObject, Option<&Matrix>), Error> {
+        let page_obj = doc.find_page(page_num as i32)?;
+        let inv_ctm = (self.fn_dest_inv_ctm)(&page_obj)?;
+        let (obj, mat) = self.slot.insert((page_obj, inv_ctm));
+        Ok((obj, mat.as_ref()))
+    }
+}

--- a/src/pdf/links/tests_build.rs
+++ b/src/pdf/links/tests_build.rs
@@ -1503,3 +1503,34 @@ fn test_links_on_different_page_sizes() {
         tester.assert_links(&links).unwrap();
     }
 }
+
+#[test]
+fn test_named_dest_with_extra_keys() {
+    let page_count = 3;
+    let name = "Chapter1&foo=bar";
+
+    let links = [PdfAction::GoTo(PdfDestination::Named(name.into()))].create_links();
+
+    let resolved = repeat_n(LinkAction::Action(NAMED_DEST_RESOLVED), 1).create_links();
+
+    let mut tr = PdfTester::with_links(page_count, &links);
+    tr.add_named_destinations(&[name]).unwrap();
+
+    // URI-flattening paths resolve named dests to page numbers. Raw URIs and
+    // link annotations preserve named destinations as written. Here we test that named
+    // destinations containing URI control characters, like "Chapter1&foo=bar", are resolvable.
+    // This succeeds (except for the `links_from_annotations_lossy` call) because MuPDF uses
+    // `fz_encode_uri_component`. Thus, "Chapter1&foo=bar" becomes "Chapter1%26foo%3Dbar",
+    // which prevents the parser from inappropriately splitting on the `&` character.
+    tr.assert_links_split(&resolved, &links, &links).unwrap();
+
+    let extracted = tr.extract_raw_uri_links().unwrap();
+    assert_eq!(&extracted, &["#nameddest=Chapter1%26foo%3Dbar"]);
+
+    // However, if we provide the unescaped string "#nameddest=Chapter1&foo=bar" directly
+    // to the Rust parsing logic, the extra keys are stripped/clipped. This exactly matches
+    // the behavior of MuPDF's `parse_uri_named_dest` function.
+    let action = parse_external_link("#nameddest=Chapter1&foo=bar");
+    let expected = PdfAction::GoTo(PdfDestination::Named("Chapter1".into()));
+    assert_eq!(action, Some(expected));
+}

--- a/src/pdf/links/tests_build.rs
+++ b/src/pdf/links/tests_build.rs
@@ -1,0 +1,1505 @@
+use std::error;
+use std::fmt;
+use std::iter::repeat_n;
+use std::slice;
+use std::sync::LazyLock;
+use std::{ffi::CStr, ptr::NonNull};
+
+use super::*;
+use crate::pdf::{PdfDocument, PdfObject, PdfPage};
+use crate::{context, DestinationKind, Error, Rect, Size};
+
+struct TestError {
+    message: String,
+    source: Option<Box<dyn error::Error + 'static>>,
+}
+
+impl TestError {
+    fn new<M: Into<String>, E>(message: M, source: E) -> Self
+    where
+        E: Into<Box<dyn error::Error + 'static>>,
+    {
+        Self {
+            message: message.into(),
+            source: Some(source.into()),
+        }
+    }
+
+    fn msg(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            source: None,
+        }
+    }
+}
+
+impl fmt::Display for TestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl fmt::Debug for TestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)?;
+        if let Some(source) = &self.source {
+            write!(f, "\nCaused by: {:?}", source)?;
+        }
+        Ok(())
+    }
+}
+
+impl error::Error for TestError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        self.source.as_deref()
+    }
+}
+
+type TestResult<T> = Result<T, TestError>;
+
+trait TestContext<T> {
+    fn context<M: Into<String>>(self, msg: M) -> TestResult<T>;
+}
+
+impl<T, E: error::Error + 'static> TestContext<T> for Result<T, E> {
+    fn context<M: Into<String>>(self, msg: M) -> TestResult<T> {
+        self.map_err(|e| TestError::new(msg, e))
+    }
+}
+
+pub(super) const PAGE_SIZE: Size = Size::A4;
+pub(super) const PAGE_HEIGHT: f32 = PAGE_SIZE.height;
+pub(super) const PAGE_WIDTH: f32 = PAGE_SIZE.width;
+
+/// The [`DestinationKind`] used by [`add_named_destinations`] for all named destinations.
+const NAMED_DEST_KIND: DestinationKind = DestinationKind::FitV { left: Some(200.0) };
+
+/// The resolved [`PdfAction`] expected when a named destination is resolved.
+/// All named destinations point to page 0 with [`NAMED_DEST_KIND`].
+const NAMED_DEST_RESOLVED: PdfAction = PdfAction::GoTo(PdfDestination::Page {
+    page: 0,
+    kind: NAMED_DEST_KIND,
+});
+
+/// Generate a non-overlapping rectangle for link at given index.
+/// These coordinates are in Fitz space (top-left origin).
+pub(super) fn test_link_rect(index: usize) -> Rect {
+    let y = PAGE_HEIGHT - 50.0 - (index as f32 * 15.0);
+    Rect {
+        x0: 50.0,
+        y0: y - 10.0,
+        x1: 250.0,
+        y1: y,
+    }
+}
+
+trait LinksCreator {
+    fn create_links(self) -> Vec<PdfLink>;
+}
+
+impl<T: IntoIterator<Item = U>, U: Into<LinkAction>> LinksCreator for T {
+    fn create_links(self) -> Vec<PdfLink> {
+        let create_link = |(idx, action): (usize, U)| PdfLink {
+            bounds: test_link_rect(idx),
+            action: action.into(),
+        };
+        self.into_iter().enumerate().map(create_link).collect()
+    }
+}
+
+impl PdfPage {
+    /// Equivalent to [`PdfPage::resolved_links`] collected into a `Vec`, but relies exclusively
+    /// on the Rust-side [`parse_external_link`] implementation for testing purposes.
+    fn resolved_links_rust_parsed(&self) -> Result<Vec<PdfLink>, Error> {
+        use mupdf_sys::*;
+
+        struct LinksGuard {
+            links_head: *mut fz_link,
+        }
+
+        impl Drop for LinksGuard {
+            fn drop(&mut self) {
+                if !self.links_head.is_null() {
+                    unsafe {
+                        fz_drop_link(context(), self.links_head);
+                    }
+                }
+            }
+        }
+
+        let links_head =
+            unsafe { ffi_try!(mupdf_load_links(context(), self.inner.as_ptr().cast())) }?;
+
+        let doc_ptr =
+            NonNull::new(unsafe { (*self.inner.as_ptr()).doc }).ok_or(Error::UnexpectedNullPtr)?;
+
+        let doc = unsafe { PdfDocument::from_raw(pdf_keep_document(context(), doc_ptr.as_ptr())) };
+
+        let mut output = Vec::new();
+
+        let guard = LinksGuard { links_head };
+
+        let mut next = guard.links_head;
+
+        while !next.is_null() {
+            let node = next;
+            unsafe {
+                next = (*node).next;
+                let uri = CStr::from_ptr((*node).uri);
+
+                let action = match parse_external_link(uri.to_string_lossy().as_ref()) {
+                    Some(action) => match action {
+                        PdfAction::GoTo(PdfDestination::Named(_)) => {
+                            let dest = ffi_try!(mupdf_resolve_link_dest(
+                                context(),
+                                doc.inner,
+                                uri.as_ptr()
+                            ))?;
+                            if dest.loc.page < 0 {
+                                continue;
+                            }
+                            PdfAction::GoTo(PdfDestination::Page {
+                                page: dest.loc.page as u32,
+                                kind: dest.into(),
+                            })
+                        }
+                        action => action,
+                    },
+                    None => continue,
+                };
+                let bounds = (*node).rect.into();
+                output.push(PdfLink {
+                    bounds,
+                    action: action.into(),
+                });
+            }
+        }
+
+        Ok(output)
+    }
+}
+
+struct PdfTester {
+    doc: PdfDocument,
+    page: usize,
+}
+
+impl PdfTester {
+    /// Creates a new PDF document with the specified number of blank pages.
+    /// The focus page defaults to 0
+    fn new(page_count: u32) -> Self {
+        assert!(page_count > 0, "page_count must be > 0");
+        let mut doc = PdfDocument::new();
+        for _ in 0..page_count {
+            doc.new_page(PAGE_SIZE).unwrap();
+        }
+        Self { doc, page: 0 }
+    }
+
+    /// Creates a new PDF and adds links on page 0
+    fn with_links(page_count: u32, links: &[PdfLink]) -> Self {
+        let mut test_pdf = Self::new(page_count);
+        test_pdf.add_links(links).unwrap();
+        test_pdf
+    }
+
+    /// Creates a new PDF with pages of the specified sizes
+    fn with_sizes(sizes: &[Size]) -> Self {
+        assert!(!sizes.is_empty(), "must provide at least one size");
+        let mut doc = PdfDocument::new();
+        for &size in sizes {
+            doc.new_page(size).unwrap();
+        }
+        Self { doc, page: 0 }
+    }
+
+    /// Sets the focus page for subsequent operations
+    fn on_page(&mut self, page: usize) -> &mut Self {
+        self.page = page;
+        self
+    }
+
+    /// Adds a new page with the given size
+    fn new_page(&mut self, size: Size) -> &mut Self {
+        self.doc.new_page(size).unwrap();
+        self
+    }
+
+    fn page_count(&self) -> usize {
+        self.doc.page_count().unwrap() as usize
+    }
+
+    /// Loads the current focus page
+    fn load_page(&self) -> TestResult<PdfPage> {
+        self.doc
+            .load_pdf_page(self.page as i32)
+            .context(format!("Page {} load failed", self.page))
+    }
+
+    /// Adds links on the current focus page
+    fn add_links(&mut self, links: &[PdfLink]) -> TestResult<&mut Self> {
+        self.load_page()?
+            .add_links(&mut self.doc, links)
+            .context(format!("add_links: Failed on page {}", self.page))?;
+        Ok(self)
+    }
+
+    /// Sets rotation on the current focus page
+    fn set_rotation(&mut self, rotation: i32) -> TestResult<&mut Self> {
+        self.load_page()?
+            .set_rotation(rotation)
+            .context(format!("set_rotation: Failed on page {}", self.page))?;
+        Ok(self)
+    }
+
+    /// Adds named destinations pointing to page 0 with `FitV { left: 200 }`
+    fn add_named_destinations<T: AsRef<str>>(&mut self, names: &[T]) -> TestResult<&mut Self> {
+        add_named_destinations(&mut self.doc, names).context("add named destinations failed")?;
+        Ok(self)
+    }
+
+    fn bounds(&self) -> TestResult<Rect> {
+        self.load_page()?
+            .bounds()
+            .context(format!("bounds: Failed on page {}", self.page))
+    }
+
+    fn extract_links(&self) -> TestResult<Vec<PdfLink>> {
+        self.load_page()?
+            .resolved_links()
+            .context("[resolved_links] Iterator init failed")?
+            .collect::<Result<Vec<_>, _>>()
+            .context("[resolved_links] Collection failed")
+    }
+
+    fn extract_rust_parsed_links(&self) -> TestResult<Vec<PdfLink>> {
+        self.load_page()?
+            .resolved_links_rust_parsed()
+            .context("[rust_parsed] Extraction failed")
+    }
+
+    fn extract_links_from_annotations(&self) -> TestResult<Vec<PdfLink>> {
+        self.load_page()?
+            .links_from_annotations()
+            .context("[link_annotations] Extraction failed")
+    }
+
+    fn extract_raw_uri_links(&self) -> TestResult<Vec<String>> {
+        self.load_page()?
+            .links()
+            .context("[raw_uri_links] Iterator init failed")
+            .map(|iter| iter.map(|link| link.uri).collect())
+    }
+
+    /// Saves to memory and reloads, preserving the focus page
+    fn reload(&self) -> TestResult<Self> {
+        let mut buf = Vec::new();
+        self.doc.write_to(&mut buf).context("Failed to write PDF")?;
+        Ok(Self {
+            doc: PdfDocument::from_bytes(&buf).context("Failed to load PDF from buffer")?,
+            page: self.page,
+        })
+    }
+
+    fn assert_links(&self, expected: &[PdfLink]) -> TestResult<()> {
+        self.assert_links_split(expected, expected, expected)
+    }
+
+    fn assert_links_split(
+        &self,
+        expected_resolved: &[PdfLink],
+        expected_annots: &[PdfLink],
+        expected_uris: &[PdfLink],
+    ) -> TestResult<()> {
+        self.assert_links_split_impl(expected_resolved, expected_annots, expected_uris)
+            .context(format!("[Original PDF, focus page {}]", self.page))?;
+        self.reload()?
+            .assert_links_split_impl(expected_resolved, expected_annots, expected_uris)
+            .context(format!("[Reloaded PDF, focus page {}]", self.page))
+    }
+
+    fn assert_links_split_impl(
+        &self,
+        expected_resolved: &[PdfLink],
+        expected_annots: &[PdfLink],
+        expected_uris: &[PdfLink],
+    ) -> TestResult<()> {
+        let resolved = self.extract_links()?;
+        assert_slice_eq(&resolved, expected_resolved, "[resolved_links]", "Link")?;
+
+        let rust_parsed = self.extract_rust_parsed_links()?;
+        assert_slice_eq(&rust_parsed, expected_resolved, "[rust_parsed]", "Link")?;
+
+        let annots = self.extract_links_from_annotations()?;
+        assert_slice_eq(&annots, expected_annots, "[link_annotations]", "Link")?;
+
+        let extracted = self.extract_raw_uri_links()?;
+        let expected_uris: Vec<_> = expected_uris.iter().map(|l| l.action.to_string()).collect();
+        assert_slice_eq(&extracted, &expected_uris, "[Raw URI match]", "Raw URI")
+    }
+}
+
+fn add_named_destinations<T>(doc: &mut PdfDocument, names: &[T]) -> Result<(), crate::Error>
+where
+    T: AsRef<str>,
+{
+    if names.is_empty() {
+        return Ok(());
+    }
+
+    let page_obj = doc.find_page(0)?;
+    let mut names_array = doc.new_array_with_capacity((names.len() * 2) as i32)?;
+
+    for name in names {
+        let mut dest = doc.new_array_with_capacity(6)?;
+        dest.array_push_ref(&page_obj)?;
+        NAMED_DEST_KIND.encode_into(&mut dest)?;
+
+        names_array.array_push(PdfObject::new_string(name.as_ref())?)?;
+        names_array.array_push(dest)?;
+    }
+
+    let mut dests = doc.new_dict_with_capacity(1)?;
+    dests.dict_put("Names", names_array)?;
+
+    let mut names_dict = doc.new_dict_with_capacity(1)?;
+    names_dict.dict_put("Dests", dests)?;
+
+    doc.catalog()?.dict_put("Names", names_dict)?;
+    Ok(())
+}
+
+fn assert_slice_eq<T>(actual: &[T], expected: &[T], label: &str, item_name: &str) -> TestResult<()>
+where
+    T: PartialEq + fmt::Debug,
+{
+    if actual.len() != expected.len() {
+        return Err(TestError::msg(format!(
+            "{label} {item_name} count mismatch: extracted {}, expected {}",
+            actual.len(),
+            expected.len()
+        )));
+    }
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        if a != e {
+            return Err(TestError::msg(format!(
+                "{label} {item_name} No '{i}' mismatch:\n  extracted: {a:?}\n  expected:  {e:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Convert [`DestinationKind`] into [`PdfDestination`] actions, cycling page indices.
+fn page_dests(
+    page_count: u32,
+    kinds: impl IntoIterator<Item = DestinationKind>,
+) -> impl Iterator<Item = PdfDestination> {
+    kinds
+        .into_iter()
+        .enumerate()
+        .map(move |(i, kind)| PdfDestination::Page {
+            page: (i as u32) % page_count,
+            kind,
+        })
+}
+
+/// Convert DestinationKinds into GoToR actions, cycling page indices
+/// and alternating between `path` and `url` file specs.
+fn gotor_actions(
+    dests: impl IntoIterator<Item = PdfDestination>,
+    path: &'static str,
+    url: &'static str,
+) -> impl Iterator<Item = PdfAction> {
+    dests
+        .into_iter()
+        .enumerate()
+        .map(move |(i, dest)| PdfAction::GoToR {
+            file: if i % 2 == 0 {
+                FileSpec::Path(path.to_owned())
+            } else {
+                FileSpec::Url(url.to_owned())
+            },
+            dest,
+        })
+}
+
+pub(super) const fn xyz_dest(
+    left: Option<f32>,
+    top: Option<f32>,
+    zoom: Option<f32>,
+) -> DestinationKind {
+    DestinationKind::XYZ { left, top, zoom }
+}
+
+pub(super) const fn fit_r_dest(left: f32, bottom: f32, right: f32, top: f32) -> DestinationKind {
+    DestinationKind::FitR {
+        left,
+        bottom,
+        right,
+        top,
+    }
+}
+
+#[test]
+fn test_url_and_gotor_url() {
+    let page_count = 7;
+    let cases = [
+        "https://example.com/hello%20world",
+        "https://example.com/test%2Fpath",
+        "https://example.com/name%3Dvalue",
+        "https://example.com/%%25",
+        "https://example.com/%E4%B8%AD",
+        "https://example.com/%E3%81%82",
+        "https://example.com/hello%E4%B8%AD%E6%96%87",
+        "https://example.com/%FF%FE",
+        "https://example.com/100%%",
+        "http://example.com/page",
+        "https://example.com/secure",
+        "ftp://ftp.example.com/file.txt",
+        "custom://resource/path",
+    ];
+    let links = cases.map(|l| PdfAction::Uri(l.to_owned())).create_links();
+
+    let tester = PdfTester::with_links(1, &links);
+    tester.assert_links(&links).unwrap();
+
+    let links = cases
+        .into_iter()
+        .enumerate()
+        .map(|(i, url)| (i as u32 % page_count, FileSpec::Url(format!("{url}.pdf"))))
+        .map(|(page, file)| PdfAction::GoToR {
+            file,
+            dest: PdfDestination::Page {
+                page,
+                kind: DestinationKind::default(),
+            },
+        })
+        .create_links();
+
+    let tester = PdfTester::with_links(page_count, &links);
+    tester.assert_links(&links).unwrap();
+}
+
+#[test]
+fn test_uri_links() {
+    let links = [
+        PdfAction::Uri("http://example.com/page".into()),
+        PdfAction::Uri("https://example.com/secure".into()),
+        PdfAction::Uri("mailto:user@example.com".into()),
+        PdfAction::Uri("ftp://ftp.example.com/file.txt".into()),
+        PdfAction::Uri("tel:+1-555-123-4567".into()),
+        PdfAction::Uri("HTTP://EXAMPLE.COM".into()),
+        PdfAction::Uri("custom://resource/path".into()),
+        PdfAction::Uri("cmd://goto-page/12".into()),
+    ];
+    let links = links.create_links();
+    let tester = PdfTester::with_links(1, &links);
+    tester.assert_links(&links).unwrap();
+}
+
+pub(super) const EXPLICIT_DESTS: [DestinationKind; 20] = [
+    DestinationKind::Fit,
+    DestinationKind::FitB,
+    DestinationKind::FitH { top: Some(500.0) },
+    DestinationKind::FitH { top: None },
+    DestinationKind::FitV { left: Some(100.0) },
+    DestinationKind::FitV { left: None },
+    DestinationKind::FitBH { top: Some(300.0) },
+    DestinationKind::FitBH { top: None },
+    DestinationKind::FitBV { left: Some(50.0) },
+    DestinationKind::FitBV { left: None },
+    xyz_dest(None, None, None),
+    xyz_dest(Some(0.0), Some(0.0), Some(50.0)),
+    xyz_dest(Some(100.0), None, None),
+    xyz_dest(None, Some(250.0), None),
+    xyz_dest(None, None, Some(200.0)),
+    xyz_dest(Some(100.0), Some(600.0), Some(150.0)),
+    xyz_dest(Some(50.0), Some(700.0), None),
+    xyz_dest(Some(50.0), None, Some(300.0)),
+    xyz_dest(Some(200.0), Some(PAGE_HEIGHT), Some(100.0)),
+    xyz_dest(None, Some(500.0), Some(75.0)),
+];
+
+pub(super) fn get_named_str(dest: &PdfDestination) -> &str {
+    match dest {
+        PdfDestination::Named(name) => name.as_str(),
+        _ => unreachable!("Expected PdfDestination::Named"),
+    }
+}
+
+pub(super) static NAMED_DESTS: LazyLock<Vec<PdfDestination>> = LazyLock::new(|| {
+    let mut names: Vec<_> = [
+        "Chapter1",
+        "G11.2063217",
+        "section_1.1.b",
+        "anchor-42",
+        "Reference:Index",
+        // Names that imitate parameters
+        "page=10",
+        "zoom=200,10,10",
+        "view=FitH,100",
+        "nameddest=True",
+        "12345",
+        "Name With Spaces",
+        // Special characters and punctuation in PDF
+        "Name/With/Slashes",
+        "Name(With)Parens",
+        "Name[With]Brackets",
+        "Quote's",
+        "Double\"Quotes",
+        // Complete set of ASCII
+        "~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./",
+        // Unicode and complex encodings
+        "Заголовок_Кириллица",
+        "章节",
+        "😁_Emoji_Dest",
+        "A\u{00A0}B",          // Non-breaking space
+        "C\u{2003}D",          // Em-space
+        "Z\u{200D}W\u{200D}J", // Zero-width joiners
+        // Normal percent-encoding
+        "hello%20world",
+        "test%2Fpath",
+        "name%3Dvalue",
+        "SimpleName",
+        // Unicode (UTF-8) percent-encoding
+        "%E4%B8%AD",
+        "%E3%81%82",
+        "hello%E4%B8%AD%E6%96%87",
+        // Invalid percent-encoding
+        "%FF%FE",
+        "100%%",
+        "bad%2",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect();
+
+    names.push("A".repeat(1024));
+    names.into_iter().map(PdfDestination::Named).collect()
+});
+
+#[test]
+fn test_goto_and_gotor_links() {
+    let page_count = 7;
+
+    let links = page_dests(page_count, EXPLICIT_DESTS)
+        .map(PdfAction::GoTo)
+        .create_links();
+    let tester = PdfTester::with_links(page_count, &links);
+    tester.assert_links(&links).unwrap();
+
+    let links = gotor_actions(
+        page_dests(page_count, EXPLICIT_DESTS),
+        "page_destinations.pdf",
+        "https://example.com/document.pdf",
+    );
+    let links = links.create_links();
+    let tester = PdfTester::with_links(page_count, &links);
+    tester.assert_links(&links).unwrap();
+}
+
+#[test]
+fn test_fitr_goto_and_gotor_links() {
+    let page_count = 3;
+    let dests = [PdfDestination::Page {
+        page: 1,
+        kind: fit_r_dest(50.0, 100.0, 200.0, 300.0),
+    }];
+
+    let links = dests.iter().cloned().map(PdfAction::GoTo).create_links();
+    let tester = PdfTester::with_links(page_count, &links);
+    tester.assert_links(&links).unwrap();
+
+    let links = dests
+        .map(|dest| PdfAction::GoToR {
+            file: FileSpec::Path("page_destinations.pdf".into()),
+            dest,
+        })
+        .create_links();
+    let tester = PdfTester::with_links(page_count, &links);
+    tester.assert_links(&links).unwrap();
+}
+
+#[test]
+fn test_rotated_target_page() {
+    // This test combines the CTM checks for landing pages.
+    // We check:
+    // 1. Exact coordinate hits (full XYZ).
+    // 2. Single-axis snapping (FitH, FitV, etc.) taking into account data loss at 90/270 degrees.
+    // 3. Partial XYZ coordinates (Some/None) and their behavior when rotated.
+
+    let rotations = [0, 90, 180, 270];
+    let mut tester = PdfTester::new(rotations.len() as u32);
+
+    for (idx, &rotation) in rotations.iter().enumerate() {
+        tester.on_page(idx).set_rotation(rotation).unwrap();
+    }
+
+    for (target_page_idx, &rotation) in rotations.iter().enumerate() {
+        tester.new_page(PAGE_SIZE);
+        let source_page_idx = tester.page_count() - 1;
+
+        let context_msg = format!(
+            "Failed at rotation: {}°, target_page: {}",
+            rotation, target_page_idx
+        );
+
+        let mut actions = Vec::new();
+
+        let bounds = tester.on_page(target_page_idx).bounds().unwrap();
+        let target_page_idx = target_page_idx as u32;
+        // Calculate key points
+        let mid_x = (bounds.x0 + bounds.x1) * 0.5;
+        let mid_y = (bounds.y0 + bounds.y1) * 0.5;
+
+        // Full XYZ Points
+        let inset = 1.25;
+        let points = [
+            (bounds.x0 + inset, bounds.y0 + inset), // near top-left
+            (mid_x, mid_y),                         // center
+            (bounds.x1 - inset, bounds.y1 - inset), // near bottom-right
+        ];
+
+        for (left, top) in points {
+            actions.push(PdfAction::GoTo(PdfDestination::Page {
+                page: target_page_idx,
+                kind: xyz_dest(Some(left), Some(top), Some(100.0)),
+            }));
+        }
+
+        let is_orthogonal = rotation == 90 || rotation == 270;
+
+        // Single Axis
+        let target_top = if is_orthogonal { None } else { Some(mid_y) };
+        let target_left = if is_orthogonal { None } else { Some(mid_x) };
+
+        actions.push(PdfAction::GoTo(PdfDestination::Page {
+            page: target_page_idx,
+            kind: DestinationKind::FitH { top: target_top },
+        }));
+        actions.push(PdfAction::GoTo(PdfDestination::Page {
+            page: target_page_idx,
+            kind: DestinationKind::FitBH { top: target_top },
+        }));
+        actions.push(PdfAction::GoTo(PdfDestination::Page {
+            page: target_page_idx,
+            kind: DestinationKind::FitV { left: target_left },
+        }));
+        actions.push(PdfAction::GoTo(PdfDestination::Page {
+            page: target_page_idx,
+            kind: DestinationKind::FitBV { left: target_left },
+        }));
+
+        // Partial XYZ
+        // These combinations only work correctly at 0/180 due to the peculiarities of MuPDF
+        if !is_orthogonal {
+            actions.push(PdfAction::GoTo(PdfDestination::Page {
+                page: target_page_idx,
+                kind: xyz_dest(Some(mid_x), None, None),
+            }));
+            actions.push(PdfAction::GoTo(PdfDestination::Page {
+                page: target_page_idx,
+                kind: xyz_dest(None, Some(mid_y), None),
+            }));
+        }
+        // These always work (Zoom Only or Empty)
+        actions.push(PdfAction::GoTo(PdfDestination::Page {
+            page: target_page_idx,
+            kind: xyz_dest(None, None, Some(100.0)),
+        }));
+        actions.push(PdfAction::GoTo(PdfDestination::Page {
+            page: target_page_idx,
+            kind: xyz_dest(None, None, None),
+        }));
+
+        let links = actions.create_links();
+        tester.on_page(source_page_idx).add_links(&links).unwrap();
+        tester.assert_links(&links).context(context_msg).unwrap();
+    }
+}
+
+#[test]
+fn test_fitr_rotated_target_page() {
+    let rotations = [0, 90, 180, 270];
+    let mut tester = PdfTester::new(rotations.len() as u32);
+
+    for (idx, &rotation) in rotations.iter().enumerate() {
+        tester.on_page(idx).set_rotation(rotation).unwrap();
+    }
+
+    for (target_page_idx, &rotation) in rotations.iter().enumerate() {
+        tester.new_page(PAGE_SIZE);
+        let source_page_idx = tester.page_count() - 1;
+
+        let context_msg = format!(
+            "Failed at rotation: {}°, target_page: {}",
+            rotation, target_page_idx
+        );
+
+        let mut actions = Vec::new();
+
+        let bounds = tester.on_page(target_page_idx).bounds().unwrap();
+
+        let inset = 10.0;
+        let min_x = bounds.x0 + inset;
+        let min_y = bounds.y0 + inset;
+        let max_x = bounds.x1 - inset;
+        let max_y = bounds.y1 - inset;
+        let mid_x = (min_x + max_x) * 0.5;
+        let mid_y = (min_y + max_y) * 0.5;
+        let quarter_w = (max_x - min_x) * 0.25;
+        let quarter_h = (max_y - min_y) * 0.25;
+        let target_page_idx = target_page_idx as u32;
+        // Small rect near top-left
+        actions.push(PdfAction::GoTo(PdfDestination::Page {
+            page: target_page_idx,
+            kind: fit_r_dest(min_x, min_y, min_x + quarter_w, min_y + quarter_h),
+        }));
+        // Rect at center
+        actions.push(PdfAction::GoTo(PdfDestination::Page {
+            page: target_page_idx,
+            kind: fit_r_dest(
+                mid_x - quarter_w * 0.5,
+                mid_y - quarter_h * 0.5,
+                mid_x + quarter_w * 0.5,
+                mid_y + quarter_h * 0.5,
+            ),
+        }));
+        // Rect near bottom-right
+        actions.push(PdfAction::GoTo(PdfDestination::Page {
+            page: target_page_idx,
+            kind: fit_r_dest(max_x - quarter_w, max_y - quarter_h, max_x, max_y),
+        }));
+
+        let links = actions.clone().create_links();
+
+        tester.on_page(source_page_idx).add_links(&links).unwrap();
+        tester.assert_links(&links).context(context_msg).unwrap();
+    }
+}
+
+#[test]
+fn test_rotated_source_page() {
+    for source_rotation in [90, 180, 270] {
+        let mut tester = PdfTester::new(2);
+        tester.set_rotation(source_rotation).unwrap();
+        let bounds = tester.bounds().unwrap();
+
+        let inset = 20.0;
+        let link_bounds = Rect {
+            x0: bounds.x0 + inset,
+            y0: bounds.y0 + inset,
+            x1: bounds.x0 + inset + 200.0,
+            y1: bounds.y0 + inset + 10.0,
+        };
+
+        let links = [
+            PdfLink {
+                bounds: link_bounds,
+                action: LinkAction::Action(PdfAction::GoTo(PdfDestination::Page {
+                    page: 1,
+                    kind: xyz_dest(Some(50.0), Some(400.0), Some(100.0)),
+                })),
+            },
+            PdfLink {
+                bounds: Rect {
+                    x0: link_bounds.x0,
+                    y0: link_bounds.y1 + 5.0,
+                    x1: link_bounds.x1,
+                    y1: link_bounds.y1 + 15.0,
+                },
+                action: LinkAction::Action(PdfAction::GoTo(PdfDestination::Page {
+                    page: 1,
+                    kind: DestinationKind::Fit,
+                })),
+            },
+            PdfLink {
+                bounds: Rect {
+                    x0: link_bounds.x0,
+                    y0: link_bounds.y1 + 20.0,
+                    x1: link_bounds.x1,
+                    y1: link_bounds.y1 + 30.0,
+                },
+                action: LinkAction::Action(PdfAction::GoTo(PdfDestination::Page {
+                    page: 1,
+                    kind: DestinationKind::FitH { top: Some(300.0) },
+                })),
+            },
+            PdfLink {
+                bounds: Rect {
+                    x0: link_bounds.x0,
+                    y0: link_bounds.y1 + 35.0,
+                    x1: link_bounds.x1,
+                    y1: link_bounds.y1 + 45.0,
+                },
+                action: LinkAction::Action(PdfAction::Uri("https://example.com".into())),
+            },
+        ];
+
+        tester.add_links(&links).unwrap();
+        tester.assert_links(&links).unwrap();
+    }
+}
+
+#[test]
+fn test_named_goto_and_gotor_links() {
+    let page_count = 3;
+    let links = NAMED_DESTS
+        .iter()
+        .cloned()
+        .map(PdfAction::GoTo)
+        .create_links();
+
+    let resolved =
+        repeat_n(LinkAction::Action(NAMED_DEST_RESOLVED), NAMED_DESTS.len()).create_links();
+
+    let names: Vec<&str> = NAMED_DESTS.iter().map(get_named_str).collect();
+    let mut tr = PdfTester::with_links(page_count, &links);
+    tr.add_named_destinations(&names).unwrap();
+    // URI-flattening paths resolve named dests to page numbers. Raw uri and
+    // link_annotations preserves Named destinations as written.
+    tr.assert_links_split(&resolved, &links, &links).unwrap();
+
+    let links = gotor_actions(
+        NAMED_DESTS.iter().cloned(),
+        "page_destinations.pdf",
+        "https://example.com/document.pdf",
+    )
+    .create_links();
+
+    let tester = PdfTester::with_links(page_count, &links);
+    tester.assert_links(&links).unwrap();
+}
+
+#[test]
+fn test_path_links_with_launch_and_gotor() {
+    let paths = [
+        // Simple file
+        "readme",
+        // Absolute path
+        "/path/to/document",
+        // Relative paths
+        "other/path/document",
+        "../path/document",
+        // UNC / Server path
+        "/server/share/doc",
+        // Edge cases with dots
+        "",
+        ".",
+        "../report",
+        "a/..",
+        // Normal percent-encoding
+        "/path/to/hello%20world",
+        "/path/to/test%2Fpath",
+        "/path/to/name%3Dvalue",
+        "/path/to/SimpleName",
+        "../to/hello%20world",
+        "../to/test%2Fpath",
+        "../to/name%3Dvalue",
+        "../to/SimpleName",
+        // Unicode (UTF-8) percent-encoding
+        "/path/to/%E4%B8%AD",
+        "/path/to/%E3%81%82",
+        "/path/to/hello%E4%B8%AD%E6%96%87",
+        "../to/%E4%B8%AD",
+        "../to/%E3%81%82",
+        "../to/hello%E4%B8%AD%E6%96%87",
+        // Invalid percent-encoding
+        "/path/to/%FF%FE",
+        "/path/to/100%%",
+        "/path/to/bad%2",
+        "../to/%FF%FE",
+        "../to/100%%",
+        "../to/bad%2",
+        // Unicode
+        "文件",
+        "документ",
+    ];
+
+    // 1. Test Launch actions
+
+    let links = paths
+        .iter()
+        .map(|path| PdfAction::Launch(FileSpec::Path(format!("{path}.docx"))))
+        .create_links();
+
+    let tester = PdfTester::with_links(1, &links);
+    tester.assert_links(&links).unwrap();
+
+    // 2. Test GoToR actions (same paths)
+    let links = paths
+        .iter()
+        .enumerate()
+        .map(|(idx, path)| PdfAction::GoToR {
+            file: if idx % 2 == 0 || !path.is_ascii() {
+                FileSpec::Path(format!("{path}.pdf"))
+            } else {
+                FileSpec::Url(format!("https://example.com/{path}.pdf"))
+            },
+            dest: PdfDestination::default(),
+        })
+        .create_links();
+
+    let tester = PdfTester::with_links(1, &links);
+    tester.assert_links(&links).unwrap();
+
+    // 3. Test Path Normalization
+
+    let paths = [
+        // Path for paths normalization
+        "a/../b",
+        "a/../../b",
+        "/a//b/./c",
+        "/../a",
+        "/a/../../b",
+    ];
+
+    let clean_paths = ["b", "../b", "/a/b/c", "/a", "/b"];
+
+    // 3a. Launch Normalization
+
+    let links = paths
+        .iter()
+        .map(|path| PdfAction::Launch(FileSpec::Path(format!("{path}.docx"))))
+        .create_links();
+    let clean_links = clean_paths
+        .iter()
+        .map(|path| PdfAction::Launch(FileSpec::Path(format!("{path}.docx"))))
+        .create_links();
+
+    let tr = PdfTester::with_links(1, &links);
+    // URI-flattening paths normalize paths via cleanname, link_annotations returns stored paths.
+    tr.assert_links_split(&clean_links, &links, &clean_links)
+        .unwrap();
+
+    // 3b. GoToR Normalization
+
+    let links = paths
+        .iter()
+        .map(|path| PdfAction::GoToR {
+            file: FileSpec::Path(format!("{path}.pdf")),
+            dest: PdfDestination::default(),
+        })
+        .create_links();
+    let clean_links = clean_paths
+        .iter()
+        .map(|path| PdfAction::GoToR {
+            file: FileSpec::Path(format!("{path}.pdf")),
+            dest: PdfDestination::default(),
+        })
+        .create_links();
+
+    let tr = PdfTester::with_links(1, &links);
+    // URI-flattening paths normalize paths via cleanname, link_annotations returns stored paths.
+    tr.assert_links_split(&clean_links, &links, &clean_links)
+        .unwrap();
+}
+
+#[test]
+fn test_uri_and_lauch() {
+    let links = [
+        PdfAction::Uri("file:///absolute/path".into()),
+        PdfAction::Uri("file://relative/path".into()),
+    ]
+    .create_links();
+    let resolved = [
+        PdfAction::Launch(FileSpec::Path("/absolute/path".into())),
+        PdfAction::Launch(FileSpec::Path("relative/path".into())),
+    ]
+    .create_links();
+
+    let tr = PdfTester::with_links(1, &links);
+    tr.assert_links_split(&resolved, &links, &links).unwrap()
+}
+
+#[test]
+fn test_mixed_links() {
+    let names = ["Chapter1", "G11.2063217"];
+    let named_actions = [
+        LinkAction::Action(PdfAction::GoTo(PdfDestination::Named(names[0].to_string()))),
+        LinkAction::Dest(PdfDestination::Named(names[1].to_string())),
+    ];
+
+    let unnamed_actions = [
+        LinkAction::Action(PdfAction::GoTo(PdfDestination::Page {
+            page: 2,
+            kind: DestinationKind::Fit,
+        })),
+        LinkAction::Action(PdfAction::GoTo(PdfDestination::Page {
+            page: 3,
+            kind: xyz_dest(Some(100.0), Some(500.0), Some(150.0)),
+        })),
+        LinkAction::Action(PdfAction::GoToR {
+            file: FileSpec::Path("other.pdf".into()),
+            dest: PdfDestination::Page {
+                page: 0,
+                kind: DestinationKind::Fit,
+            },
+        }),
+        LinkAction::Action(PdfAction::GoToR {
+            file: FileSpec::Url("https://example.com/doc.pdf".into()),
+            dest: PdfDestination::Page {
+                page: 3,
+                kind: DestinationKind::FitB,
+            },
+        }),
+        LinkAction::Action(PdfAction::GoToR {
+            file: FileSpec::Path("other.pdf".into()),
+            dest: PdfDestination::Named("Chapter123".into()),
+        }),
+        LinkAction::Action(PdfAction::GoToR {
+            file: FileSpec::Url("https://example.com/doc.pdf".into()),
+            dest: PdfDestination::Named("Chapter123".into()),
+        }),
+        LinkAction::Action(PdfAction::GoToR {
+            file: FileSpec::Url("https://example.com/doc.pdf".into()),
+            dest: PdfDestination::Named("G11.2063217mmk".into()),
+        }),
+        LinkAction::Action(PdfAction::Uri("https://example.com".into())),
+        LinkAction::Action(PdfAction::Launch(FileSpec::Path("readme.txt".into()))),
+        LinkAction::Dest(PdfDestination::Page {
+            page: 1,
+            kind: DestinationKind::Fit,
+        }),
+    ];
+
+    let links = named_actions
+        .iter()
+        .chain(&unnamed_actions)
+        .cloned()
+        .create_links();
+
+    let resolved = repeat_n(LinkAction::Action(NAMED_DEST_RESOLVED), named_actions.len())
+        .chain(unnamed_actions)
+        .map(|action| LinkAction::Action(action.clone().into_pdf_action()))
+        .create_links();
+
+    let mut tr = PdfTester::with_links(5, &links);
+    tr.add_named_destinations(&names).unwrap();
+    // URI-flattening paths resolve named dests to page numbers. Raw uri and
+    // link_annotations preserves Named destinations as written.
+    // Dest(Named) and GoTo(Named) produce the same URI string (#nameddest=...).
+    tr.assert_links_split(&resolved, &links, &links).unwrap();
+}
+
+/// Test large coordinates handling.
+///
+/// Note: MuPDF clamps coordinates to page bounds during link resolution.
+/// This is expected behavior - coordinates outside the page are clamped.
+///
+/// We don't use [`extract_rust_parsed_links`], since the coordinate clamping
+/// logic is not implemented on the Rust side.
+#[test]
+fn test_large_coordinates() {
+    let links = [PdfAction::GoTo(PdfDestination::Page {
+        page: 1,
+        kind: xyz_dest(Some(10000.0), Some(10000.0), Some(500.0)),
+    })];
+    let links = links.create_links();
+
+    let expected_mupdf = [PdfAction::GoTo(PdfDestination::Page {
+        page: 1,
+        kind: xyz_dest(Some(PAGE_SIZE.width), Some(PAGE_SIZE.height), Some(500.0)),
+    })];
+    let expected_mupdf = expected_mupdf.create_links();
+
+    let tester = PdfTester::with_links(2, &links);
+    let resolved = tester.extract_links().unwrap();
+    assert_slice_eq(&resolved, &expected_mupdf, "[resolved_links]", "Link").unwrap();
+
+    let rust_parsed = tester.extract_rust_parsed_links().unwrap();
+    assert_slice_eq(&rust_parsed, &links, "[rust_parsed]", "Link").unwrap();
+
+    let annots = tester.extract_links_from_annotations().unwrap();
+    assert_slice_eq(&annots, &links, "[link_annotations]", "Link").unwrap();
+}
+
+#[test]
+fn test_no_links() {
+    let tester = PdfTester::with_links(1, &[]);
+    tester.assert_links(&[]).unwrap();
+}
+
+#[test]
+fn test_many_links() {
+    let links = (0..100)
+        .map(|i| {
+            if i % 4 == 0 {
+                PdfAction::Uri(format!("https://example.com/page{i}"))
+            } else if i % 4 == 1 {
+                PdfAction::GoTo(PdfDestination::Page {
+                    page: (i % 5) as u32,
+                    kind: DestinationKind::Fit,
+                })
+            } else if i % 4 == 2 {
+                PdfAction::Launch(FileSpec::Path(format!("file{i}.txt")))
+            } else {
+                PdfAction::GoToR {
+                    file: FileSpec::Path(format!("doc{i}.pdf")),
+                    dest: PdfDestination::default(),
+                }
+            }
+        })
+        .create_links();
+
+    let tester = PdfTester::with_links(6, &links);
+    tester.assert_links(&links).unwrap();
+}
+
+#[test]
+fn test_gotor_url_with_existing_fragment() {
+    let links = [
+        PdfAction::GoToR {
+            file: FileSpec::Url("http://example.org/doc.pdf#pagemode=bookmarks".into()),
+            dest: PdfDestination::Page {
+                page: 1,
+                kind: DestinationKind::Fit,
+            },
+        },
+        PdfAction::GoToR {
+            file: FileSpec::Url("http://example.org/doc.pdf#pagemode=none".into()),
+            dest: PdfDestination::Named("Chapter1".into()),
+        },
+    ];
+    let links = links.create_links();
+
+    // MuPDF's URI-flattening path collapses GoToR-with-URL-fragment to Uri,
+    // but link_annotations preserves the original GoToR structure.
+    let resolved = [
+        PdfAction::Uri("http://example.org/doc.pdf#pagemode=bookmarks&page=2&view=Fit".into()),
+        PdfAction::Uri("http://example.org/doc.pdf#pagemode=none&nameddest=Chapter1".into()),
+    ];
+    let resolved = resolved.create_links();
+
+    let tr = PdfTester::with_links(3, &links);
+    tr.assert_links_split(&resolved, &links, &resolved).unwrap();
+}
+
+#[test]
+#[should_panic(
+    expected = "PdfPage ownership mismatch: the page is not attached to the provided PdfDocument"
+)]
+fn test_add_links_with_wrong_document_context() {
+    let tester = PdfTester::new(1);
+
+    let mut page = tester.doc.load_pdf_page(0).unwrap();
+
+    let mut doc_alien = PdfDocument::new();
+
+    let links = [PdfAction::Uri("https://fail.com".into())].create_links();
+    page.add_links(&mut doc_alien, &links).unwrap();
+}
+
+#[test]
+fn test_link_with_explicit_dest_action() {
+    let page_count = 3;
+    let dest_action = page_dests(page_count, EXPLICIT_DESTS)
+        .map(LinkAction::Dest)
+        .collect::<Vec<_>>();
+    let links = dest_action.clone().create_links();
+
+    // URI-flattening paths return Action(GoTo) since they process the stored URI,
+    // link_annotations preserves the Dest variant as written.
+    let resolved = dest_action
+        .into_iter()
+        .map(|action| action.into_pdf_action())
+        .create_links();
+
+    let tr = PdfTester::with_links(page_count, &links);
+    // Dest(Page) and Action(GoTo(Page)) produce the same URI string.
+    tr.assert_links_split(&resolved, &links, &resolved).unwrap();
+}
+
+#[test]
+fn test_link_with_named_dest_action() {
+    let links = NAMED_DESTS
+        .iter()
+        .cloned()
+        .map(LinkAction::Dest)
+        .create_links();
+
+    let names: Vec<&str> = NAMED_DESTS.iter().map(get_named_str).collect();
+
+    // URI-flattening paths resolve named dests to page destinations,
+    // link_annotations preserves the Named variant as written.
+    let resolved =
+        repeat_n(LinkAction::Action(NAMED_DEST_RESOLVED), NAMED_DESTS.len()).create_links();
+
+    let mut tr = PdfTester::with_links(1, &links);
+    tr.add_named_destinations(&names).unwrap();
+    // Dest(Named) and GoTo(Named) produce the same URI string (#nameddest=...).
+    tr.assert_links_split(&resolved, &links, &links).unwrap();
+}
+
+#[test]
+fn test_link_action_action_removes_dest() {
+    let dest_action = LinkAction::Dest(PdfDestination::Page {
+        page: 1,
+        kind: DestinationKind::Fit,
+    });
+    let action_uri = LinkAction::Action(PdfAction::Uri("https://example.com".into()));
+
+    let initial = PdfLink {
+        bounds: test_link_rect(0),
+        action: dest_action.clone(),
+    };
+    let action_link = PdfLink {
+        bounds: test_link_rect(0),
+        action: action_uri.clone(),
+    };
+    // URI-flattening paths see Dest(Page) as Action(GoTo(Page)) since they process the URI.
+    let dest_as_action = PdfLink {
+        bounds: test_link_rect(0),
+        action: LinkAction::Action(PdfAction::GoTo(PdfDestination::Page {
+            page: 1,
+            kind: DestinationKind::Fit,
+        })),
+    };
+
+    let mut tester = PdfTester::with_links(2, slice::from_ref(&initial));
+
+    // Initial state: link_annotations sees Dest, URI-flattening sees Action(GoTo).
+    let res = tester.assert_links_split(
+        slice::from_ref(&dest_as_action),
+        slice::from_ref(&initial),
+        slice::from_ref(&dest_as_action),
+    );
+    res.unwrap();
+
+    // Obtain the link annotation for in-place mutation; drop the page immediately after.
+    let mut annot = {
+        let page = tester.doc.load_pdf_page(0).unwrap();
+        page.link_annotations().unwrap().next().unwrap().unwrap()
+    };
+
+    // Switch to Action — should remove /Dest and set /A.
+    annot.set_action(&mut tester.doc, &action_uri).unwrap();
+
+    // After switch to Action: all extraction paths see Action(Uri).
+    tester.assert_links(slice::from_ref(&action_link)).unwrap();
+
+    // Switch back to Dest — should remove /A and set /Dest.
+    annot.set_action(&mut tester.doc, &dest_action).unwrap();
+
+    // After switch back to Dest: link_annotations sees Dest, URI-flattening sees Action(GoTo).
+    let res = tester.assert_links_split(
+        slice::from_ref(&dest_as_action),
+        slice::from_ref(&initial),
+        slice::from_ref(&dest_as_action),
+    );
+    res.unwrap();
+}
+
+#[test]
+fn test_multiple_add_links_calls() {
+    let all_actions = [
+        PdfAction::Uri("https://example.com/first".into()),
+        PdfAction::GoTo(PdfDestination::Page {
+            page: 1,
+            kind: DestinationKind::Fit,
+        }),
+        PdfAction::Launch(FileSpec::Path("readme.txt".into())),
+        PdfAction::GoToR {
+            file: FileSpec::Path("other.pdf".into()),
+            dest: PdfDestination::default(),
+        },
+    ];
+
+    let all_links = all_actions.create_links();
+    let (batch1, batch2) = all_links.split_at(2);
+
+    let mut tester = PdfTester::with_links(3, batch1);
+    tester.assert_links(batch1).unwrap();
+    tester.add_links(batch2).unwrap();
+    tester.assert_links(&all_links).unwrap();
+
+    // Adding an empty batch should not disturb existing links.
+    tester.add_links(&[]).unwrap();
+    tester.assert_links(&all_links).unwrap();
+}
+
+#[test]
+fn test_add_links_goto_out_of_range_page() {
+    let mut tester = PdfTester::new(3);
+
+    let links = [PdfAction::GoTo(PdfDestination::Page {
+        page: 999,
+        kind: DestinationKind::Fit,
+    })]
+    .create_links();
+
+    // add_links calls doc.find_page(999) internally via the resolver.
+    // This should fail because page 999 doesn't exist.
+    let result = tester.add_links(&links);
+    assert!(result.is_err(), "Expected error for out-of-range GoTo page");
+}
+
+#[test]
+fn test_links_on_non_zero_page() {
+    let mut tester = PdfTester::with_sizes(&[PAGE_SIZE, Size::LETTER, PAGE_SIZE]);
+
+    let links = [
+        PdfAction::GoTo(PdfDestination::Page {
+            page: 0,
+            kind: xyz_dest(Some(50.0), Some(400.0), Some(100.0)),
+        }),
+        PdfAction::GoTo(PdfDestination::Page {
+            page: 2,
+            kind: DestinationKind::Fit,
+        }),
+        PdfAction::Uri("https://example.com".into()),
+    ]
+    .create_links();
+
+    // Add links to page 1 (LETTER size) instead of page 0.
+    tester.on_page(1).add_links(&links).unwrap();
+
+    // Extract from page 1.
+    let extracted = tester.extract_links().unwrap();
+    assert_eq!(extracted, links);
+
+    let from_annots = tester.extract_links_from_annotations().unwrap();
+    assert_eq!(from_annots, links);
+
+    let mut tester = PdfTester::new(5);
+
+    let links = [PdfAction::GoTo(PdfDestination::Page {
+        page: 0,
+        kind: DestinationKind::Fit,
+    })]
+    .create_links();
+
+    let last_page_idx = tester.page_count() - 1;
+    tester.on_page(last_page_idx).add_links(&links).unwrap();
+
+    let extracted = tester.extract_links().unwrap();
+    assert_eq!(extracted, links);
+}
+
+#[test]
+fn test_link_annotations_filters_non_link_annots() {
+    let links = [PdfAction::Uri("https://example.com".into())].create_links();
+    let tester = PdfTester::with_links(1, &links);
+
+    // Add a non-link annotation (Text) via MuPDF's annotation API.
+    {
+        let mut page = tester.doc.load_pdf_page(0).unwrap();
+        page.create_annotation(crate::pdf::PdfAnnotationType::Text)
+            .unwrap();
+    }
+
+    let page = tester.doc.load_pdf_page(0).unwrap();
+
+    // link_annotations() should yield only the link, not the text annotation.
+    let link_annots: Vec<_> = page
+        .link_annotations()
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(link_annots.len(), 1);
+    let from_annots = page.links_from_annotations().unwrap();
+    assert_eq!(from_annots, links);
+}
+
+#[test]
+fn test_negative_coordinates() {
+    let page_count = 3;
+
+    let original_kinds = [
+        xyz_dest(Some(-50.0), Some(-100.0), Some(100.0)),
+        DestinationKind::FitH { top: Some(-200.0) },
+        DestinationKind::FitV { left: Some(-150.0) },
+        DestinationKind::FitBH { top: Some(-300.0) },
+        DestinationKind::FitBV { left: Some(-250.0) },
+        fit_r_dest(-10.0, -20.0, -5.0, -15.0),
+    ];
+
+    let clamped_kinds = [
+        xyz_dest(Some(0.0), Some(0.0), Some(100.0)),
+        DestinationKind::FitH { top: Some(0.0) },
+        DestinationKind::FitV { left: Some(0.0) },
+        DestinationKind::FitBH { top: Some(0.0) },
+        DestinationKind::FitBV { left: Some(0.0) },
+        fit_r_dest(0.0, 0.0, 5.0, 5.0),
+    ];
+
+    let links = page_dests(page_count, original_kinds)
+        .map(PdfAction::GoTo)
+        .create_links();
+
+    let tester = PdfTester::with_links(page_count, &links);
+
+    let from_annots = tester.extract_links_from_annotations().unwrap();
+    assert_eq!(from_annots, links);
+
+    let clamped_links = page_dests(page_count, clamped_kinds)
+        .map(PdfAction::GoTo)
+        .create_links();
+
+    let mupdf_links = tester.extract_links().unwrap();
+    assert_eq!(mupdf_links, clamped_links);
+}
+
+#[test]
+fn test_empty_named_destination() {
+    let links = [PdfAction::GoToR {
+        file: FileSpec::Path("other.pdf".into()),
+        dest: PdfDestination::Named(String::new()),
+    }];
+    let links = links.create_links();
+
+    let resolved = [PdfAction::GoToR {
+        file: FileSpec::Path("other.pdf".to_owned()),
+        dest: PdfDestination::default(),
+    }];
+    let resolved = resolved.create_links();
+
+    let tr = PdfTester::with_links(1, &links);
+    // URI-flattening paths resolve empty named dests to default PdfDestination. Raw uri and
+    // link_annotations preserves Named destinations as written.
+    tr.assert_links_split(&resolved, &links, &links).unwrap();
+}
+
+#[test]
+fn test_goto_self_page() {
+    let links = [PdfAction::GoTo(PdfDestination::Page {
+        page: 0,
+        kind: xyz_dest(Some(50.0), Some(100.0), Some(200.0)),
+    })]
+    .create_links();
+
+    let tester = PdfTester::with_links(1, &links);
+    tester.assert_links(&links).unwrap();
+}
+
+#[test]
+fn test_goto_last_page() {
+    let page_count = 10;
+    let links = [PdfAction::GoTo(PdfDestination::Page {
+        page: (page_count - 1) as u32,
+        kind: DestinationKind::Fit,
+    })]
+    .create_links();
+
+    let tester = PdfTester::with_links(page_count, &links);
+    tester.assert_links(&links).unwrap();
+}
+
+#[test]
+fn test_links_on_different_page_sizes() {
+    let sizes = [Size::A4, Size::LETTER, Size::A3, Size::new(200.0, 300.0)];
+    let mut tester = PdfTester::with_sizes(&sizes);
+
+    let links = [PdfAction::GoTo(PdfDestination::Page {
+        page: 0,
+        kind: xyz_dest(Some(10.0), Some(20.0), Some(100.0)),
+    })];
+    let links = links.create_links();
+
+    for page_idx in 0..sizes.len() {
+        tester.on_page(page_idx).add_links(&links).unwrap();
+        tester.assert_links(&links).unwrap();
+    }
+}

--- a/src/pdf/links/tests_build.rs
+++ b/src/pdf/links/tests_build.rs
@@ -280,7 +280,7 @@ impl PdfTester {
 
     fn extract_links_from_annotations(&self) -> TestResult<Vec<PdfLink>> {
         self.load_page()?
-            .links_from_annotations()
+            .links_from_annotations_lossy()
             .context("[link_annotations] Extraction failed")
     }
 
@@ -1399,7 +1399,7 @@ fn test_link_annotations_filters_non_link_annots() {
         .unwrap();
 
     assert_eq!(link_annots.len(), 1);
-    let from_annots = page.links_from_annotations().unwrap();
+    let from_annots = page.links_from_annotations_lossy().unwrap();
     assert_eq!(from_annots, links);
 }
 

--- a/src/pdf/links/tests_extraction.rs
+++ b/src/pdf/links/tests_extraction.rs
@@ -154,17 +154,19 @@ fn test_parse_page_params() {
 }
 
 #[test]
-fn test_parse_named_dest2() {
+fn test_parse_named_dest() {
     let cases = [
         ("#nameddest=Chapter1", "Chapter1"),
         ("#nameddest=%E7%AB%A0%E8%8A%82", "章节"), // UTF-8 encoded
+        ("#nameddest=Chapter1&foo=bar", "Chapter1"),
         ("#Introduction", "Introduction"),
         ("#%E7%AB%A0%E8%8A%82", "章节"), // UTF-8 encoded
+        ("#page=2&comment=keep-me", "page=2&comment=keep-me"),
     ];
 
     for (input, expected_name) in cases {
         let expected = Some(PdfAction::GoTo(PdfDestination::Named(expected_name.into())));
-        assert_eq!(parse_external_link(input), expected,);
+        assert_eq!(parse_external_link(input), expected);
     }
 }
 

--- a/src/pdf/links/tests_extraction.rs
+++ b/src/pdf/links/tests_extraction.rs
@@ -1,0 +1,997 @@
+use super::tests_build::{fit_r_dest, xyz_dest};
+use super::{extraction::*, *};
+use crate::DestinationKind;
+
+#[test]
+fn test_url_unescape() {
+    // Simple ASCII percent-encoding
+    assert_eq!(decode_uri_component("hello%20world"), "hello world");
+    assert_eq!(decode_uri_component("test%2Fpath"), "test/path");
+    assert_eq!(decode_uri_component("name%3Dvalue"), "name=value");
+    assert_eq!(decode_uri_component("%%25"), "%%");
+
+    // UTF-8 multi-byte sequences (Chinese character "中")
+    assert_eq!(decode_uri_component("%E4%B8%AD"), "中");
+    // Japanese hiragana "あ"
+    assert_eq!(decode_uri_component("%E3%81%82"), "あ");
+    // Mixed ASCII and UTF-8
+    assert_eq!(decode_uri_component("hello%E4%B8%AD%E6%96%87"), "hello中文");
+
+    // Strings without percent-encoding should pass through unchanged
+    assert_eq!(decode_uri_component("hello"), "hello");
+    assert_eq!(decode_uri_component("Chapter1"), "Chapter1");
+    assert_eq!(decode_uri_component(""), "");
+
+    // Invalid UTF-8 sequence should fall back to original string
+    // %FF%FE is not valid UTF-8, so we expect the original back
+    assert_eq!(decode_uri_component("%FF%FE"), "%FF%FE");
+    assert_eq!(decode_uri_component("100%%"), "100%%");
+}
+
+#[test]
+fn test_parse_uri_schemes() {
+    let cases = [
+        "http://example.com/page",
+        "https://example.com/secure",
+        "mailto:user@example.com",
+        "ftp://ftp.example.com/file.txt",
+        "tel:+1-555-123-4567",
+        "HTTP://EXAMPLE.COM",
+    ];
+
+    for uri in cases {
+        let expected = Some(PdfAction::Uri(uri.into()));
+        assert_eq!(parse_external_link(uri), expected);
+    }
+}
+
+#[test]
+fn test_parse_page_params() {
+    let out = parse_external_link("#page=5");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 4,
+        kind: xyz_dest(None, None, None),
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=0");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 0,
+        kind: xyz_dest(None, None, None),
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=-3");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 0,
+        kind: xyz_dest(None, None, None),
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=0&zoom=50");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 0,
+        kind: xyz_dest(None, None, Some(50.0)),
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=-5&zoom=-20,555");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 0,
+        kind: xyz_dest(Some(555.0), None, Some(100.0)),
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=3&zoom=0,100,200");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 2,
+        kind: xyz_dest(Some(100.0), Some(200.0), Some(100.0)),
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=30&zoom=nan,456,nan");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 29,
+        kind: xyz_dest(Some(456.0), None, None),
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=30&zoom=nan,nan,456");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 29,
+        kind: xyz_dest(None, Some(456.0), None),
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=30&zoom=nan,nan,nan");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 29,
+        kind: xyz_dest(None, None, None),
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=1&zoom=100,-50,-100");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 0,
+        kind: xyz_dest(Some(-50.0), Some(-100.0), Some(100.0)),
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=1&view=FitH,-200");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 0,
+        kind: DestinationKind::FitH { top: Some(-200.0) },
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=1&view=FitV,-300.5");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 0,
+        kind: DestinationKind::FitV { left: Some(-300.5) },
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=1&zoom=0");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 0,
+        kind: xyz_dest(None, None, Some(100.0)),
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=1&zoom=-50");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 0,
+        kind: xyz_dest(None, None, Some(100.0)),
+    });
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("#page=1&zoom=inf");
+    let expected = PdfAction::GoTo(PdfDestination::Page {
+        page: 0,
+        kind: xyz_dest(None, None, Some(100.0)),
+    });
+    assert_eq!(out, Some(expected));
+}
+
+#[test]
+fn test_parse_named_dest2() {
+    let cases = [
+        ("#nameddest=Chapter1", "Chapter1"),
+        ("#nameddest=%E7%AB%A0%E8%8A%82", "章节"), // UTF-8 encoded
+        ("#Introduction", "Introduction"),
+        ("#%E7%AB%A0%E8%8A%82", "章节"), // UTF-8 encoded
+    ];
+
+    for (input, expected_name) in cases {
+        let expected = Some(PdfAction::GoTo(PdfDestination::Named(expected_name.into())));
+        assert_eq!(parse_external_link(input), expected,);
+    }
+}
+
+#[test]
+fn test_parse_remote_file_scheme() {
+    let out = parse_external_link("file:///path/to/document.pdf");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/path/to/document.pdf".to_string()),
+        dest: PdfDestination::default(),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("/path/to/document.pdf");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/path/to/document.pdf".to_string()),
+        dest: PdfDestination::default(),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("document.pdf");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("document.pdf".to_string()),
+        dest: PdfDestination::default(),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///path/to/document2.pdf#page=5");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/path/to/document2.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 4,
+            kind: xyz_dest(None, None, None),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///path/doc.pdf#page=0");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/path/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: xyz_dest(None, None, None),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///path/doc2.pdf#page=-55");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/path/doc2.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: xyz_dest(None, None, None),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///path/doc.pdf#nameddest=Chapter3");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/path/doc.pdf".to_string()),
+        dest: PdfDestination::Named("Chapter3".to_string()),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///path/doc22.pdf#Part555");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/path/doc22.pdf".to_string()),
+        dest: PdfDestination::Named("Part555".to_string()),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///doc.pdf#page=10&view=Fit");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 9,
+            kind: DestinationKind::Fit,
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///doc.pdf#page=-5&view=FitH,-100");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitH { top: Some(-100.0) },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///doc.pdf#page=-5&view=FitH");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitH { top: None },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///doc.pdf#page=2&view=FitV,50.5");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 1,
+            kind: DestinationKind::FitV { left: Some(50.5) },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///doc.pdf#page=2&view=FitV");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 1,
+            kind: DestinationKind::FitV { left: None },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///doc.pdf#page=1&view=FitB");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitB,
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///doc.pdf#page=1&view=FitBH,200");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitBH { top: Some(200.0) },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///doc.pdf#page=1&view=FitBH");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitBH { top: None },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///doc.pdf#page=1&view=FitBV,150");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitBV { left: Some(150.0) },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///doc.pdf#page=1&view=FitBV");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitBV { left: None },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    // Spec: viewrect=left,top,wd,ht (in PDF space)
+    let out = parse_external_link("file:///doc.pdf#page=1&viewrect=15,25,500,600");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: fit_r_dest(15.0, 25.0, 515.0, 625.0),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///doc.pdf#page=1&viewrect=10,20,100");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::default(),
+    };
+    assert_eq!(out, Some(expected));
+
+    // Spec: zoom=scale,left,top.
+    let out = parse_external_link("file:///doc.pdf#page=1&zoom=150");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: xyz_dest(None, None, Some(150.0)),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///doc.pdf#page=3&zoom=200,10,20");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 2,
+            kind: xyz_dest(Some(10.0), Some(20.0), Some(200.0)),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    // Spec: "it is possible that later actions will override the effects of previous actions".
+    let out = parse_external_link("file:///doc.pdf#page=5&view=FitH,33#page=10");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 9,
+            kind: DestinationKind::default(),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:////server/share/doc.pdf");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/server/share/doc.pdf".to_string()),
+        dest: PdfDestination::default(),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:////server/share/doc.pdf#page=3&view=FitV,120");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/server/share/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 2,
+            kind: DestinationKind::FitV { left: Some(120.0) },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("//server/share/document.pdf");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/server/share/document.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::default(),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///a/b/../c.pdf");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/a/c.pdf".to_string()),
+        dest: PdfDestination::default(),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:a/b/../../c.pdf");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("c.pdf".into()),
+        dest: PdfDestination::default(),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///a/b/../../c.pdf");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/c.pdf".into()),
+        dest: PdfDestination::default(),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("my%20document.pdf");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("my document.pdf".into()),
+        dest: PdfDestination::default(),
+    };
+    assert_eq!(out, Some(expected));
+}
+
+#[test]
+fn test_parse_remote_url_scheme() {
+    let out = parse_external_link("http://example.org/doc.pdf#Chapter6");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("http://example.org/doc.pdf".to_owned()),
+        dest: PdfDestination::Named("Chapter6".to_owned()),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("http://example.org/doc.pdf#page=3");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("http://example.org/doc.pdf".to_owned()),
+        dest: PdfDestination::Page {
+            page: 2,
+            kind: xyz_dest(None, None, None),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("http://example.org/doc.pdf#page=3&zoom=200,250,100");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("http://example.org/doc.pdf".to_owned()),
+        dest: PdfDestination::Page {
+            page: 2,
+            kind: xyz_dest(Some(250.0), Some(100.0), Some(200.0)),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("http://example.org/doc.pdf#zoom=50");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("http://example.org/doc.pdf".to_owned()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: xyz_dest(None, None, Some(50.0)),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("http://example.org/doc.pdf#page=72&view=fitH,100");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("http://example.org/doc.pdf".to_owned()),
+        dest: PdfDestination::Page {
+            page: 71,
+            kind: DestinationKind::FitH { top: Some(100.0) },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("http://example.org/doc.pdf#pagemode=none");
+    let expected = PdfAction::Uri("http://example.org/doc.pdf#pagemode=none".to_owned());
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("http://example.org/doc.pdf#pagemode=bookmarks&page=2");
+    let expected =
+        PdfAction::Uri("http://example.org/doc.pdf#pagemode=bookmarks&page=2".to_owned());
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("http://example.org/doc.pdf#page=3&pagemode=thumbs");
+    let expected = PdfAction::Uri("http://example.org/doc.pdf#page=3&pagemode=thumbs".to_owned());
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link(
+        "http://example.org/doc.pdf#collab=DAVFDF@http://review_server/Collab/user1",
+    );
+    let expected = PdfAction::Uri(
+        "http://example.org/doc.pdf#collab=DAVFDF@http://review_server/Collab/user1".to_owned(),
+    );
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link(
+        "http://example.org/doc.pdf#page=1&comment=452fde0e-fd22-457c-84aa-2cf5bed5a349",
+    );
+    let expected = PdfAction::Uri(
+        "http://example.org/doc.pdf#page=1&comment=452fde0e-fd22-457c-84aa-2cf5bed5a349".to_owned(),
+    );
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("http://example.org/doc.pdf#fdf=http://example.org/doc.fdf");
+    let expected =
+        PdfAction::Uri("http://example.org/doc.pdf#fdf=http://example.org/doc.fdf".to_owned());
+    assert_eq!(out, Some(expected));
+}
+
+#[test]
+fn test_parse_relative_pdf_path() {
+    let out = parse_external_link("manual.pdf#Chapter6");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("manual.pdf".to_string()),
+        dest: PdfDestination::Named("Chapter6".to_string()),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("../other/document.pdf");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("../other/document.pdf".to_string()),
+        dest: PdfDestination::default(),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("/another/document.pdf");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/another/document.pdf".to_string()),
+        dest: PdfDestination::default(),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("other.pdf#page=10");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("other.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 9,
+            kind: DestinationKind::default(),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("manual.pdf#nameddest=Chapter5");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("manual.pdf".to_string()),
+        dest: PdfDestination::Named("Chapter5".to_string()),
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("document.pdf#page=1");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("document.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: xyz_dest(None, None, None),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("document.pdf#page=0");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("document.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: xyz_dest(None, None, None),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("document.pdf#page=-5");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("document.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: xyz_dest(None, None, None),
+        },
+    };
+    assert_eq!(out, Some(expected));
+}
+
+#[test]
+fn test_parse_non_pdf() {
+    let out = parse_external_link("readme.txt");
+    let expected = PdfAction::Launch(FileSpec::Path("readme.txt".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///path/to/document.doc");
+    let expected = PdfAction::Launch(FileSpec::Path("/path/to/document.doc".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:///path/to/document.doc#page=0");
+    let expected = PdfAction::Launch(FileSpec::Path("/path/to/document.doc".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:other/path/document.txt");
+    let expected = PdfAction::Launch(FileSpec::Path("other/path/document.txt".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:another/path/document.docx#page=10");
+    let expected = PdfAction::Launch(FileSpec::Path("another/path/document.docx".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:////server/share/doc.doc#page=1&view=Fit");
+    let expected = PdfAction::Launch(FileSpec::Path("/server/share/doc.doc".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:.docx");
+    let expected = PdfAction::Launch(FileSpec::Path(".docx".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:..docx");
+    let expected = PdfAction::Launch(FileSpec::Path("..docx".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:../report.docx");
+    let expected = PdfAction::Launch(FileSpec::Path("../report.docx".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:a/...docx");
+    let expected = PdfAction::Launch(FileSpec::Path("a/...docx".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:a/../b.docx");
+    let expected = PdfAction::Launch(FileSpec::Path("b.docx".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:a/../../b.docx");
+    let expected = PdfAction::Launch(FileSpec::Path("../b.docx".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:/a//b/./c.docx");
+    let expected = PdfAction::Launch(FileSpec::Path("/a/b/c.docx".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:/../a.docx");
+    let expected = PdfAction::Launch(FileSpec::Path("/a.docx".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:/a/../../b.docx");
+    let expected = PdfAction::Launch(FileSpec::Path("/b.docx".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("ab:some/path");
+    let expected = PdfAction::Launch(FileSpec::Path("ab:some/path".to_string()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("file:a/./b/../c.txt");
+    let expected = PdfAction::Launch(FileSpec::Path("a/c.txt".into()));
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("my%20file.txt");
+    let expected = PdfAction::Launch(FileSpec::Path("my file.txt".into()));
+    assert_eq!(out, Some(expected));
+}
+
+#[test]
+fn test_parse_edge_cases() {
+    let expected = FileSpec::Path("path with spaces.pdf".into());
+    assert!(matches!(
+        parse_external_link("path%20with%20spaces.pdf"),
+        Some(PdfAction::GoToR { file, .. }) if file == expected
+    ));
+
+    let uri_cases = [
+        "custom://resource/path",
+        "http://example.com/a%2Fb",
+        "cmd://goto-page/12",
+        "abc:some/path",
+    ];
+
+    for uri in uri_cases {
+        let expected = Some(PdfAction::Uri(uri.into()));
+        assert_eq!(parse_external_link(uri), expected, "Failed on URI: {}", uri);
+    }
+}
+
+// ==========================================================================
+// is_external_link tests
+// ==========================================================================
+
+#[test]
+fn test_is_external_link() {
+    assert!(!is_external_link("/path/to/file.pdf"));
+    assert!(!is_external_link("/usr/local/bin"));
+
+    assert!(!is_external_link("\\\\server\\share\\file.pdf"));
+    assert!(!is_external_link("//server/share/file.pdf"));
+
+    // Windows drive letters should be detected
+    assert!(!is_external_link("C:/docs/a.pdf"));
+    assert!(!is_external_link("C:\\docs\\a.pdf"));
+    assert!(!is_external_link("D:/file.txt"));
+    assert!(!is_external_link("C:/path/to/file"));
+    assert!(!is_external_link("D:\\path\\to\\file"));
+    assert!(!is_external_link("x:something"));
+
+    assert!(!is_external_link("./file.pdf"));
+    assert!(!is_external_link("../other/file.pdf"));
+    assert!(!is_external_link(".\\file.pdf"));
+    assert!(!is_external_link("..\\other\\file.pdf"));
+    assert!(!is_external_link("ab:some/path"));
+    // Scheme must start with alpha.
+    assert!(!is_external_link("123:path"));
+    assert!(!is_external_link("-ab:path"));
+    // No colon at all -> not external.
+    assert!(!is_external_link("just-a-path"));
+    assert!(!is_external_link(""));
+
+    // These should NOT be detected as local paths (they're URIs)
+    assert!(is_external_link("http://example.com"));
+    assert!(is_external_link("mailto:user@example.com"));
+    assert!(is_external_link("file:///path/to/file"));
+    assert!(is_external_link("file:path/to/file"));
+    assert!(is_external_link("abc:some/path"));
+    // Scheme can contain digits, +, -, .
+    assert!(is_external_link("svn+ssh://server/path"));
+    assert!(is_external_link("coap+tcp://device/path"));
+    assert!(is_external_link("a.b.c:path"));
+}
+
+// ==========================================================================
+// Windows path handling tests
+// ==========================================================================
+
+#[test]
+fn test_parse_windows_path() {
+    let paths = [
+        "C:/docs/document.pdf",
+        "/C:/docs/document.pdf",
+        "C:\\docs\\document.pdf",
+        "/C:\\docs\\document.pdf",
+    ];
+
+    for (idx, path) in paths.into_iter().enumerate() {
+        let expected = PdfAction::GoToR {
+            file: FileSpec::Path(path.into()),
+            dest: PdfDestination::default(),
+        };
+        assert_eq!(parse_external_link(path), Some(expected), "index: {idx}");
+    }
+}
+
+// ==========================================================================
+// is_valid_pdf_path tests
+// ==========================================================================
+
+#[test]
+fn test_is_pdf_path() {
+    let valid = ["file.pdf", "file.PDF", "file.Pdf", "F.PDF", "f.pdf", ".pdf"];
+    let invalid = ["file.txt", "pdf", ".pd"];
+
+    for path in valid {
+        assert!(is_pdf_path(path), "Should be valid: {path}");
+    }
+    for path in invalid {
+        assert!(!is_pdf_path(path), "Should be invalid: {path}");
+    }
+}
+
+// ==========================================================================
+// Command case-insensitivity
+// ==========================================================================
+#[test]
+fn test_case_insensitive() {
+    // Change 'nameddest' -> 'NaMedDesT'
+    let out = parse_external_link("https://path/doc.pdf#NaMedDesT=Chapter3");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://path/doc.pdf".to_string()),
+        dest: PdfDestination::Named("Chapter3".to_string()),
+    };
+    assert_eq!(out, Some(expected));
+
+    // Named destination without key
+    let out = parse_external_link("https://path/doc22.PdF#Part555");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://path/doc22.PdF".to_string()),
+        dest: PdfDestination::Named("Part555".to_string()),
+    };
+    assert_eq!(out, Some(expected));
+
+    // 'page' -> 'PaGe', 'view' -> 'ViEw', 'Fit' -> 'fIt'
+    let out = parse_external_link("https://doc.pdf#PaGe=10&ViEw=fIt");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 9,
+            kind: DestinationKind::Fit,
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    // 'page' -> 'pAgE', 'view' -> 'vIeW', 'FitH' -> 'FiTh'
+    let out = parse_external_link("https://doc.pdf#pAgE=-5&vIeW=FiTh,-100");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitH { top: Some(-100.0) },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("https://doc.pdf#PAGE=-5&VIEW=fITh");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitH { top: None },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    // 'page' -> 'PaGe', 'view' -> 'ViEw', 'FitV' -> 'FiTv'
+    let out = parse_external_link("https://doc.pdf#PaGe=2&ViEw=FiTv,50.5");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 1,
+            kind: DestinationKind::FitV { left: Some(50.5) },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("https://doc.pdf#pAge=2&viEW=FITv");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 1,
+            kind: DestinationKind::FitV { left: None },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    // 'FitB' -> 'fItB'
+    let out = parse_external_link("https://doc.pdf#PAGE=1&VIEW=fItB");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitB,
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    // 'FitBH' -> 'fiTbh'
+    let out = parse_external_link("https://doc.pdf#PaGe=1&ViEw=fiTbh,200");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitBH { top: Some(200.0) },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("https://doc.pdf#page=1&view=FITBH");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitBH { top: None },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    // 'FitBV' -> 'FiTbV'
+    let out = parse_external_link("https://doc.pdf#PaGe=1&ViEw=FiTbV,150");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitBV { left: Some(150.0) },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    let out = parse_external_link("https://doc.pdf#page=1&view=FITBV");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: DestinationKind::FitBV { left: None },
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    // 'viewrect' -> 'VIEWRECT' (in PDF space)
+    let out = parse_external_link("https://doc.pdf#PaGe=1&ViEwReCt=10,20,100,200");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: fit_r_dest(10.0, 20.0, 110.0, 220.0),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    // 'VIEWRECT' (Caps)
+    let out = parse_external_link("https://doc.pdf#pAGe=1&VIEWRECT=10,20,100");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::default(),
+    };
+    assert_eq!(out, Some(expected));
+
+    // Spec: zoom=scale,left,top. -> 'ZooM'
+    let out = parse_external_link("https://doc.pdf#page=1&ZooM=150");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 0,
+            kind: xyz_dest(None, None, Some(150.0)),
+        },
+    };
+    assert_eq!(out, Some(expected));
+
+    // 'zOoM'
+    let out = parse_external_link("https://doc.pdf#Page=3&zOoM=200,10,20");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Url("https://doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 2,
+            kind: xyz_dest(Some(10.0), Some(20.0), Some(200.0)),
+        },
+    };
+    assert_eq!(out, Some(expected));
+}
+
+#[test]
+fn test_order_zoom_before_page_page_overrides_zoom() {
+    // Per spec note: later actions may override earlier actions; recommended order is page then zoom.
+    // Here we encode the expected "page resets view" behavior:
+    let out = parse_external_link("file:///doc.pdf#zoom=200&page=3");
+    let expected = PdfAction::GoToR {
+        file: FileSpec::Path("/doc.pdf".to_string()),
+        dest: PdfDestination::Page {
+            page: 2,
+            kind: DestinationKind::default(), // zoom overridden by later page action
+        },
+    };
+    assert_eq!(out, Some(expected));
+}
+
+#[test]
+fn test_other_specification_params2() {
+    let cases = [
+        "file:///doc.pdf#page=1&comment=452fde0e-fd22-2cf5bed5a349&view=FitH,255",
+        "file:///doc.pdf#pagemode=bookmarks#search=\"word1 word2\"#page=35",
+        "file:///doc.pdf#pagemode=thumbs#toolbar=1#statusbar=1#messages=1#page=895",
+        "file:///doc.pdf#pagemode=none#navpanes=1#highlight=10,55,33,45#page=48",
+        "file:///doc.pdf#collab=DAVFDF@http://review/Collab/user1##fdf=http://example.org/doc.fdf#page=2&view=FitV,56",
+    ];
+
+    for (idx, input) in cases.into_iter().enumerate() {
+        let expected = PdfAction::Uri(input.into());
+        assert_eq!(parse_external_link(input), Some(expected), "index: {idx}");
+    }
+}
+
+#[test]
+fn test_parse_invalid_uri() {
+    assert_eq!(parse_external_link(""), None);
+    assert_eq!(parse_external_link("   "), None);
+    assert_eq!(parse_external_link("\t"), None);
+    assert_eq!(parse_external_link(" \n "), None);
+    assert_eq!(parse_external_link("#"), None);
+    assert_eq!(parse_external_link("#nameddest="), None);
+    assert_eq!(parse_external_link("file:"), None);
+}
+
+#[test]
+fn test_parse_very_large_page_number() {
+    // Very large page number overflows i32::parse() -> None -> falls back to Named(params)
+    // Handling this as a special case is redundant because a non-existent Named destination
+    // would simply be ignored anyway.
+    let out = parse_external_link("#page=999999999999");
+    let expected = PdfAction::GoTo(PdfDestination::Named("page=999999999999".to_owned()));
+    assert_eq!(out, Some(expected));
+}

--- a/src/pdf/links/tests_format.rs
+++ b/src/pdf/links/tests_format.rs
@@ -113,6 +113,10 @@ fn test_pdf_action_format() {
             goto_named("Name/With/Slashes"),
             "#nameddest=Name%2FWith%2FSlashes",
         ),
+        (
+            goto_named("Chapter1&foo=bar"),
+            "#nameddest=Chapter1%26foo%3Dbar",
+        ),
         (goto_named("page=10"), "#nameddest=page%3D10"),
         (
             goto_named("a-b_c.d!e~f*g'h(i)j"),

--- a/src/pdf/links/tests_format.rs
+++ b/src/pdf/links/tests_format.rs
@@ -1,0 +1,255 @@
+use super::tests_build::{fit_r_dest, xyz_dest};
+use super::{FileSpec, PdfAction, PdfDestination};
+use crate::DestinationKind;
+
+#[test]
+fn test_pdf_action_format() {
+    let goto = |page, kind| PdfAction::GoTo(PdfDestination::Page { page, kind });
+    let goto_named = |name: &str| PdfAction::GoTo(PdfDestination::Named(name.into()));
+    let gotor_path = |path: &str, dest| PdfAction::GoToR {
+        file: FileSpec::Path(path.into()),
+        dest,
+    };
+    let gotor_url = |url: &str, dest| PdfAction::GoToR {
+        file: FileSpec::Url(url.into()),
+        dest,
+    };
+
+    let cases = vec![
+        (goto(0, DestinationKind::default()), "#page=1"),
+        (goto(4, DestinationKind::default()), "#page=5"),
+        (goto(0, DestinationKind::Fit), "#page=1&view=Fit"),
+        (goto(0, DestinationKind::FitB), "#page=1&view=FitB"),
+        (
+            goto(0, DestinationKind::FitH { top: Some(500.0) }),
+            "#page=1&view=FitH,500",
+        ),
+        (
+            goto(0, DestinationKind::FitH { top: None }),
+            "#page=1&view=FitH",
+        ),
+        (
+            goto(0, DestinationKind::FitV { left: Some(100.0) }),
+            "#page=1&view=FitV,100",
+        ),
+        (
+            goto(0, DestinationKind::FitV { left: None }),
+            "#page=1&view=FitV",
+        ),
+        (
+            goto(4, DestinationKind::FitBH { top: Some(200.0) }),
+            "#page=5&view=FitBH,200",
+        ),
+        (
+            goto(0, DestinationKind::FitBH { top: None }),
+            "#page=1&view=FitBH",
+        ),
+        (
+            goto(0, DestinationKind::FitBV { left: Some(50.0) }),
+            "#page=1&view=FitBV,50",
+        ),
+        (
+            goto(0, DestinationKind::FitBV { left: None }),
+            "#page=1&view=FitBV",
+        ),
+        (
+            goto(0, xyz_dest(Some(100.0), Some(600.0), Some(150.0))),
+            "#page=1&zoom=150,100,600",
+        ),
+        (
+            goto(0, xyz_dest(None, None, Some(200.0))),
+            "#page=1&zoom=200,nan,nan",
+        ),
+        (
+            goto(0, xyz_dest(Some(100.0), None, None)),
+            "#page=1&zoom=nan,100,nan",
+        ),
+        (
+            goto(0, xyz_dest(None, Some(250.0), None)),
+            "#page=1&zoom=nan,nan,250",
+        ),
+        (
+            goto(2, xyz_dest(Some(10.0), Some(20.0), None)),
+            "#page=3&zoom=nan,10,20",
+        ),
+        (
+            goto(2, xyz_dest(Some(100.0), None, Some(150.0))),
+            "#page=3&zoom=150,100,nan",
+        ),
+        (
+            goto(0, xyz_dest(None, Some(500.0), Some(75.0))),
+            "#page=1&zoom=75,nan,500",
+        ),
+        (goto(0, xyz_dest(None, None, Some(0.0))), "#page=1"),
+        (
+            goto(0, xyz_dest(Some(50.0), None, Some(0.0))),
+            "#page=1&zoom=nan,50,nan",
+        ),
+        (
+            goto(0, xyz_dest(Some(f32::NAN), Some(f32::NAN), Some(f32::NAN))),
+            "#page=1",
+        ),
+        (
+            goto(0, xyz_dest(Some(0.0), Some(0.0), Some(50.0))),
+            "#page=1&zoom=50,0,0",
+        ),
+        (
+            goto(1, fit_r_dest(50.0, 100.0, 200.0, 300.0)),
+            "#page=2&viewrect=50,100,150,200",
+        ),
+        (goto_named("Chapter1"), "#nameddest=Chapter1"),
+        (goto_named("section_1.1.b"), "#nameddest=section_1.1.b"),
+        (goto_named("章节"), "#nameddest=%E7%AB%A0%E8%8A%82"),
+        (
+            goto_named("Кириллица"),
+            "#nameddest=%D0%9A%D0%B8%D1%80%D0%B8%D0%BB%D0%BB%D0%B8%D1%86%D0%B0",
+        ),
+        (goto_named("😁"), "#nameddest=%F0%9F%98%81"),
+        (
+            goto_named("Name With Spaces"),
+            "#nameddest=Name%20With%20Spaces",
+        ),
+        (
+            goto_named("Name/With/Slashes"),
+            "#nameddest=Name%2FWith%2FSlashes",
+        ),
+        (goto_named("page=10"), "#nameddest=page%3D10"),
+        (
+            goto_named("a-b_c.d!e~f*g'h(i)j"),
+            "#nameddest=a-b_c.d!e~f*g'h(i)j",
+        ),
+        (goto_named(""), "#nameddest="),
+        (
+            PdfAction::Uri("https://example.com".into()),
+            "https://example.com",
+        ),
+        (
+            PdfAction::Uri("http://example.com/page".into()),
+            "http://example.com/page",
+        ),
+        (
+            PdfAction::Uri("mailto:user@example.com".into()),
+            "mailto:user@example.com",
+        ),
+        (
+            PdfAction::Uri("ftp://ftp.example.com/file.txt".into()),
+            "ftp://ftp.example.com/file.txt",
+        ),
+        (
+            PdfAction::Uri("custom://resource/path".into()),
+            "custom://resource/path",
+        ),
+        (
+            PdfAction::Uri("https://example.com/hello%20world".into()),
+            "https://example.com/hello%20world",
+        ),
+        (PdfAction::Uri(String::new()), ""),
+        (
+            PdfAction::Launch(FileSpec::Path("docs/readme.txt".into())),
+            "file:docs/readme.txt#page=1",
+        ),
+        (
+            PdfAction::Launch(FileSpec::Path("/path/to/file.pdf".into())),
+            "file:///path/to/file.pdf#page=1",
+        ),
+        (
+            PdfAction::Launch(FileSpec::Path("/path with spaces.pdf".into())),
+            "file:///path%20with%20spaces.pdf#page=1",
+        ),
+        (
+            PdfAction::Launch(FileSpec::Path("文件.docx".into())),
+            "file:%E6%96%87%E4%BB%B6.docx#page=1",
+        ),
+        (
+            PdfAction::Launch(FileSpec::Path("../report.pdf".into())),
+            "file:../report.pdf#page=1",
+        ),
+        (
+            PdfAction::Launch(FileSpec::Path(String::new())),
+            "file:#page=1",
+        ),
+        (
+            PdfAction::Launch(FileSpec::Url("https://example.com/doc.pdf".into())),
+            "https://example.com/doc.pdf#page=1",
+        ),
+        (
+            gotor_path("/path with spaces.pdf", PdfDestination::default()),
+            "file:///path%20with%20spaces.pdf#page=1",
+        ),
+        (
+            gotor_path(
+                "other.pdf",
+                PdfDestination::Page {
+                    page: 0,
+                    kind: DestinationKind::Fit,
+                },
+            ),
+            "file:other.pdf#page=1&view=Fit",
+        ),
+        (
+            gotor_path(
+                "doc.pdf",
+                PdfDestination::Page {
+                    page: 2,
+                    kind: xyz_dest(Some(100.0), Some(200.0), Some(150.0)),
+                },
+            ),
+            "file:doc.pdf#page=3&zoom=150,100,200",
+        ),
+        (
+            gotor_url(
+                "https://example.com/doc.pdf",
+                PdfDestination::Page {
+                    page: 1,
+                    kind: DestinationKind::Fit,
+                },
+            ),
+            "https://example.com/doc.pdf#page=2&view=Fit",
+        ),
+        (
+            gotor_url(
+                "https://example.com/doc.pdf#frag",
+                PdfDestination::Page {
+                    page: 1,
+                    kind: DestinationKind::Fit,
+                },
+            ),
+            "https://example.com/doc.pdf#frag&page=2&view=Fit",
+        ),
+        (
+            gotor_path("other.pdf", PdfDestination::Named("Chapter1".into())),
+            "file:other.pdf#nameddest=Chapter1",
+        ),
+        (
+            gotor_url(
+                "https://example.com/doc.pdf",
+                PdfDestination::Named("Chapter1".into()),
+            ),
+            "https://example.com/doc.pdf#nameddest=Chapter1",
+        ),
+        (
+            gotor_url(
+                "https://example.com/doc.pdf#frag",
+                PdfDestination::Named("Chapter1".into()),
+            ),
+            "https://example.com/doc.pdf#frag&nameddest=Chapter1",
+        ),
+        (
+            gotor_path("doc.pdf", PdfDestination::Named("章节".into())),
+            "file:doc.pdf#nameddest=%E7%AB%A0%E8%8A%82",
+        ),
+    ];
+
+    for (i, (action, expected)) in cases.iter().enumerate() {
+        let actual = action.to_string();
+        assert_eq!(
+            &actual, expected,
+            "Case {i} failed:\n  action:   {action:?}\n  expected: {expected}\n  actual:   {actual}"
+        );
+        assert_eq!(
+            action.to_uri(),
+            actual,
+            "Case {i}: to_uri() differs from to_string()"
+        );
+    }
+}

--- a/src/pdf/links/tests_link_annot.rs
+++ b/src/pdf/links/tests_link_annot.rs
@@ -1,0 +1,939 @@
+use std::collections::HashMap;
+
+use super::build::{build_link_annotation, set_link_action_on_annot_dict};
+use super::tests_build::{
+    test_link_rect, EXPLICIT_DESTS, NAMED_DESTS, PAGE_HEIGHT, PAGE_SIZE, PAGE_WIDTH,
+};
+use super::{
+    extraction::parse_link_action_from_annot_dict, CachedResolver, DestPageResolver, FileSpec,
+    LinkAction, PdfAction, PdfDestination, PdfLink, SingleResolver,
+};
+use crate::pdf::links::tests_build::xyz_dest;
+use crate::pdf::{PdfDocument, PdfLinkAnnot, PdfObject};
+use crate::{DestinationKind, Error, Matrix, Rect};
+
+/// Helper: creates a doc with `page_count` pages, builds an annot dict via `setup`,
+/// injects it on page 0, parses the action, and returns it.
+struct LinkAnnotTester {
+    doc: PdfDocument,
+    page: Option<i32>,
+}
+
+impl LinkAnnotTester {
+    #[track_caller]
+    fn new(page_count: usize) -> Self {
+        let mut doc = PdfDocument::new();
+        for _ in 0..page_count {
+            doc.new_page(PAGE_SIZE).unwrap();
+        }
+        Self { doc, page: None }
+    }
+
+    /// Sets the focus page for subsequent operations
+    fn on_page(&mut self, page: i32) -> &mut Self {
+        self.page = Some(page);
+        self
+    }
+
+    #[track_caller]
+    fn build_annotation_object(&mut self, setup: AnnotSetup) -> PdfObject {
+        let mut page_obj = self.doc.find_page(self.page.unwrap_or_default()).unwrap();
+        let mut resolver = noop_resolver();
+        let mut annot = build_link_annotation(
+            &mut self.doc,
+            &page_obj,
+            &dummy_link(),
+            &None,
+            &mut resolver,
+        )
+        .unwrap();
+        let _ = annot.dict_delete("A");
+        setup.apply(&mut self.doc, &mut annot).unwrap();
+        self.inject_annot(&mut page_obj, &annot);
+        annot
+    }
+
+    #[track_caller]
+    fn parse_annotation_object(&self, annot: &PdfObject) -> Option<LinkAction> {
+        parse_link_action_from_annot_dict(annot, &self.doc, self.page).unwrap()
+    }
+
+    /// Validates both parsed action and MuPDF URI output.
+    #[track_caller]
+    fn build_and_assert_annot_objects(&mut self, setup: AnnotSetup, expected: &LinkAction) {
+        let annot = self.build_annotation_object(setup);
+        let result = self.parse_annotation_object(&annot);
+        assert_eq!(result.as_ref(), Some(expected));
+        assert_eq!(
+            self.read_first_mupdf_link_uri(),
+            expected.to_uri(),
+            "MuPDF uri vs expected uri"
+        );
+    }
+
+    fn doc_mut(&mut self) -> &mut PdfDocument {
+        &mut self.doc
+    }
+
+    /// Encodes a [`LinkAction`] into its raw PDF action/destination object
+    /// using production code ([`set_link_action_on_annot_dict`]).
+    #[track_caller]
+    fn encode_action(&mut self, action: &LinkAction) -> PdfObject {
+        let mut dict = self.doc.new_dict_with_capacity(1).unwrap();
+        let mut resolver = noop_resolver();
+        set_link_action_on_annot_dict(&mut self.doc, &mut dict, action, &mut resolver).unwrap();
+        match action {
+            LinkAction::Action(_) => dict.get_dict("A").unwrap().unwrap(),
+            LinkAction::Dest(_) => dict.get_dict("Dest").unwrap().unwrap(),
+        }
+    }
+
+    /// Injects an annotation dict into a page's /Annots array.
+    #[track_caller]
+    fn inject_annot(&mut self, page_obj: &mut PdfObject, annot: &PdfObject) {
+        let mut annots = match page_obj.get_dict("Annots").unwrap() {
+            Some(a) if a.is_array().unwrap() => a,
+            _ => self.doc.new_array_with_capacity(4).unwrap(),
+        };
+
+        let indirect = self.doc.add_object(annot).unwrap();
+        annots.array_push(indirect).unwrap();
+        page_obj.dict_put("Annots", annots).unwrap();
+    }
+
+    /// Builds a Named action dict (e.g. FirstPage, LastPage, PrevPage, NextPage).
+    #[track_caller]
+    fn make_named_action_dict(&mut self, name: &str) -> PdfObject {
+        let mut action_dict = self.doc.new_dict_with_capacity(2).unwrap();
+        action_dict
+            .dict_put("S", PdfObject::new_name("Named").unwrap())
+            .unwrap();
+        action_dict
+            .dict_put("N", PdfObject::new_name(name).unwrap())
+            .unwrap();
+        action_dict
+    }
+
+    /// Sets Root/URI/Base on the document catalog.
+    #[track_caller]
+    fn set_uri_base(&mut self, base: &str) {
+        let mut uri_dict = self.doc.new_dict_with_capacity(1).unwrap();
+        uri_dict
+            .dict_put("Base", PdfObject::new_string(base).unwrap())
+            .unwrap();
+        self.doc
+            .catalog()
+            .unwrap()
+            .dict_put("URI", uri_dict)
+            .unwrap();
+    }
+
+    /// Adds a placeholder link and returns its [`PdfLinkAnnot`].
+    #[track_caller]
+    fn add_link_annot(&mut self) -> PdfLinkAnnot {
+        let page_no = self.page.unwrap_or_default();
+        let mut page = self.doc.load_pdf_page(page_no).unwrap();
+        page.add_links(&mut self.doc, &[dummy_link()]).unwrap();
+        self.link_annot()
+    }
+
+    /// Returns the first link annotation from focused page.
+    fn link_annot(&self) -> PdfLinkAnnot {
+        let page_no = self.page.unwrap_or_default();
+        let page = self.doc.load_pdf_page(page_no).unwrap();
+        page.link_annotations().unwrap().next().unwrap().unwrap()
+    }
+
+    /// Returns the URI string that MuPDF's native link loader produces for the
+    /// first link on focused page.
+    #[track_caller]
+    fn read_first_mupdf_link_uri(&self) -> String {
+        let page_no = self.page.unwrap_or_default();
+        let mut links = self.doc.load_page(page_no).unwrap().links().unwrap();
+        let link = links.next().expect("At least one link was expected");
+        assert!(links.next().is_none(), "MuPDF returned multiple elements");
+        link.uri
+    }
+
+    /// Sets an action via both [`PdfLinkAnnot::set_action`] and
+    /// [`PdfLinkAnnot::set_action_with_resolver`], asserting
+    /// equality and MuPDF URI match after each write.
+    #[track_caller]
+    fn set_action_and_assert(
+        &mut self,
+        annot: &mut PdfLinkAnnot,
+        cache: &mut HashMap<u32, (PdfObject, Option<Matrix>)>,
+        action: &LinkAction,
+        label: &str,
+    ) {
+        annot.set_action(&mut self.doc, action).unwrap();
+        assert_eq!(
+            self.link_annot().action(&self.doc, None).unwrap(),
+            Some(action.clone()),
+            "[{label}], set_action test"
+        );
+        assert_eq!(
+            self.read_first_mupdf_link_uri(),
+            action.to_uri(),
+            "[{label}], set_action raw uri comparison"
+        );
+
+        let mut resolver = CachedResolver::new(cache, resolve_page_inv_ctm);
+        annot
+            .set_action_with_resolver(&mut self.doc, action, &mut resolver)
+            .unwrap();
+        assert_eq!(
+            self.link_annot().action(&self.doc, None).unwrap().as_ref(),
+            Some(action),
+            "[{label}], set_action_with_resolver test"
+        );
+        assert_eq!(
+            self.read_first_mupdf_link_uri(),
+            action.to_uri(),
+            "[{label}], set_action_with_resolver raw uri comparison"
+        );
+    }
+}
+
+#[derive(Default)]
+struct AnnotSetup {
+    dest: Option<PdfObject>,
+    action: Option<PdfObject>,
+    aa_d: Option<PdfObject>,
+    aa_u: Option<PdfObject>,
+}
+
+impl AnnotSetup {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn with_dest(mut self, value: PdfObject) -> Self {
+        self.dest = Some(value);
+        self
+    }
+
+    fn with_action(mut self, value: PdfObject) -> Self {
+        self.action = Some(value);
+        self
+    }
+
+    fn with_aa_d(mut self, value: PdfObject) -> Self {
+        self.aa_d = Some(value);
+        self
+    }
+
+    fn with_aa_u(mut self, value: PdfObject) -> Self {
+        self.aa_u = Some(value);
+        self
+    }
+
+    fn apply(self, doc: &mut PdfDocument, annot: &mut PdfObject) -> Result<(), Error> {
+        if let Some(dest) = self.dest {
+            annot.dict_put("Dest", dest)?;
+        }
+        if let Some(action) = self.action {
+            annot.dict_put("A", action)?;
+        }
+
+        if self.aa_d.is_some() || self.aa_u.is_some() {
+            let mut aa = doc.new_dict_with_capacity(2)?;
+            if let Some(d) = self.aa_d {
+                aa.dict_put("D", d)?;
+            }
+            if let Some(u) = self.aa_u {
+                aa.dict_put("U", u)?;
+            }
+            annot.dict_put("AA", aa)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn dummy_link() -> PdfLink {
+    PdfLink {
+        bounds: test_link_rect(0),
+        action: LinkAction::Action(PdfAction::Uri("https://dummy.test".into())),
+    }
+}
+
+fn noop_resolver() -> SingleResolver<impl FnMut(&PdfObject) -> Result<Option<Matrix>, Error>> {
+    SingleResolver::new(|_: &PdfObject| Ok(None))
+}
+
+fn resolve_page_inv_ctm(page_obj: &PdfObject) -> Result<Option<Matrix>, Error> {
+    Ok(page_obj.page_ctm()?.invert())
+}
+
+#[test]
+fn test_set_action_explicit_page_destinations() {
+    // Three pages so that target page indices 0–2 are all valid.
+    let mut tester = LinkAnnotTester::new(3);
+    let mut annot = tester.add_link_annot();
+    let mut cache: HashMap<u32, (PdfObject, Option<Matrix>)> = HashMap::new();
+
+    for (index, kind) in EXPLICIT_DESTS.into_iter().enumerate() {
+        let page = (index % 3) as u32;
+
+        // 1. LinkAction::Action(GoTo(Page{..}))
+        let action = LinkAction::Action(PdfAction::GoTo(PdfDestination::Page { page, kind }));
+        let label = format!("GoTo index: {index}");
+        tester.set_action_and_assert(&mut annot, &mut cache, &action, &label);
+        assert!(cache.contains_key(&page));
+
+        // 2. LinkAction::Action(GoToR { ..., Page{..} })
+        let file_spec = if index % 2 == 0 {
+            FileSpec::Path("page_destinations.pdf".into())
+        } else {
+            FileSpec::Url("https://example.com/document.pdf".into())
+        };
+        let action = LinkAction::Action(PdfAction::GoToR {
+            file: file_spec,
+            dest: PdfDestination::Page { page, kind },
+        });
+        let cache_len_before = cache.len();
+        let label = format!("GoToR index: {index}");
+        tester.set_action_and_assert(&mut annot, &mut cache, &action, &label);
+        assert_eq!(cache.len(), cache_len_before);
+
+        // 3. LinkAction::Dest(Page{..})
+        let action = LinkAction::Dest(PdfDestination::Page { page, kind });
+        let label = format!("Dest index: {index}");
+        tester.set_action_and_assert(&mut annot, &mut cache, &action, &label);
+        assert!(cache.contains_key(&page));
+    }
+}
+
+#[test]
+fn test_set_action_named_destinations() {
+    let mut tester = LinkAnnotTester::new(1);
+    let mut annot = tester.add_link_annot();
+    let mut cache: HashMap<u32, (PdfObject, Option<Matrix>)> = HashMap::new();
+
+    for (index, dest) in NAMED_DESTS.iter().enumerate() {
+        // 1. LinkAction::Action(GoTo(Named))
+        let action = LinkAction::Action(PdfAction::GoTo(dest.clone()));
+        let label = format!("GoTo index: {index}");
+        tester.set_action_and_assert(&mut annot, &mut cache, &action, &label);
+
+        // 2. LinkAction::Action(GoToR { ..., dest: Named })
+        let file_spec = if index % 2 == 0 {
+            FileSpec::Path("page_destinations.pdf".into())
+        } else {
+            FileSpec::Url("https://example.com/document.pdf".into())
+        };
+        let action = LinkAction::Action(PdfAction::GoToR {
+            file: file_spec,
+            dest: dest.clone(),
+        });
+        let label = format!("GoToR index: {index}");
+        tester.set_action_and_assert(&mut annot, &mut cache, &action, &label);
+
+        // 3. LinkAction::Dest(Named)
+        let action = LinkAction::Dest(dest.clone());
+        let label = format!("Dest index: {index}");
+        tester.set_action_and_assert(&mut annot, &mut cache, &action, &label);
+    }
+    assert!(cache.is_empty());
+}
+
+#[test]
+fn test_set_action_misc() {
+    let mut tester = LinkAnnotTester::new(1);
+    let mut annot = tester.add_link_annot();
+
+    let cases = [
+        LinkAction::Action(PdfAction::GoTo(PdfDestination::Named("Chapter1".into()))),
+        LinkAction::Action(PdfAction::GoTo(PdfDestination::Named("Section.2.3".into()))),
+        LinkAction::Action(PdfAction::GoToR {
+            file: FileSpec::Path("other.pdf".into()),
+            dest: PdfDestination::Page {
+                page: 0,
+                kind: DestinationKind::Fit,
+            },
+        }),
+        LinkAction::Action(PdfAction::GoToR {
+            file: FileSpec::Path("other.pdf".into()),
+            dest: PdfDestination::Named("Appendix".into()),
+        }),
+        LinkAction::Action(PdfAction::GoToR {
+            file: FileSpec::Url("https://example.com/doc.pdf".into()),
+            dest: PdfDestination::Page {
+                page: 2,
+                kind: xyz_dest(Some(100.0), Some(200.0), Some(150.0)),
+            },
+        }),
+        LinkAction::Action(PdfAction::GoToR {
+            file: FileSpec::Url("https://example.com/doc.pdf".into()),
+            dest: PdfDestination::Named("Table1".into()),
+        }),
+        LinkAction::Action(PdfAction::Launch(FileSpec::Path("readme.txt".into()))),
+        LinkAction::Action(PdfAction::Launch(FileSpec::Url(
+            "https://example.com/report.pdf".into(),
+        ))),
+        LinkAction::Action(PdfAction::Uri("https://example.com".into())),
+        LinkAction::Action(PdfAction::Uri("mailto:user@example.com".into())),
+    ];
+
+    for (index, action) in cases.into_iter().enumerate() {
+        annot.set_action(tester.doc_mut(), &action).unwrap();
+        let result = tester.link_annot().action(&tester.doc, None).unwrap();
+        // Skip Launch(Url): MuPDF's pdf_parse_link_dest_to_file_with_uri doesn't
+        // handle Launch with FileSpec::Url
+        if !matches!(
+            &action,
+            LinkAction::Action(PdfAction::Launch(FileSpec::Url(_)))
+        ) {
+            assert_eq!(
+                tester.read_first_mupdf_link_uri(),
+                action.to_uri(),
+                "mupdf uri, index: {index}"
+            );
+        }
+        assert_eq!(result, Some(action), "index: {index}");
+    }
+}
+
+#[test]
+fn test_switches_between_dest_and_action_entries() {
+    let mut tester = LinkAnnotTester::new(2);
+    let mut annot = tester.add_link_annot();
+
+    let as_dest = LinkAction::Dest(PdfDestination::Page {
+        page: 1,
+        kind: DestinationKind::Fit,
+    });
+    let as_action = LinkAction::Action(PdfAction::Uri("https://example.com".into()));
+
+    // Write /Dest — /A must be absent.
+    annot.set_action(tester.doc_mut(), &as_dest).unwrap();
+    assert!(annot.get_dict("Dest").unwrap().is_some());
+    assert!(
+        annot.get_dict("A").unwrap().is_none(),
+        "/A should be absent after writing /Dest"
+    );
+
+    // Switch to /A — /Dest must be cleared.
+    annot.set_action(tester.doc_mut(), &as_action).unwrap();
+    assert!(
+        annot.get_dict("Dest").unwrap().is_none(),
+        "/Dest should be absent after writing /A"
+    );
+    assert!(annot.get_dict("A").unwrap().is_some());
+
+    // Switch back to /Dest — /A must be cleared again.
+    annot.set_action(tester.doc_mut(), &as_dest).unwrap();
+    assert!(annot.get_dict("Dest").unwrap().is_some());
+    assert!(
+        annot.get_dict("A").unwrap().is_none(),
+        "/A should be absent after writing /Dest"
+    );
+}
+
+/// `set_rect` — with `None` CTM writes coordinates as-is.
+#[test]
+fn test_set_rect_without_ctm_preserves_coordinates() {
+    let mut tester = LinkAnnotTester::new(1);
+    let mut annot = tester.add_link_annot();
+
+    let cases = [
+        Rect::new(10.0, 20.0, 200.0, 80.0),
+        Rect::new(0.0, 0.0, PAGE_WIDTH, PAGE_HEIGHT),
+        Rect::new(100.0, 300.0, 400.0, 600.0),
+        // Coordinates outside the page are stored verbatim.
+        Rect::new(-200.0, -50.0, PAGE_WIDTH + 200.0, PAGE_HEIGHT + 50.0),
+        // Zero-area rect.
+        Rect::new(50.0, 50.0, 50.0, 50.0),
+    ];
+
+    for (index, expected) in cases.into_iter().enumerate() {
+        annot.set_rect(tester.doc_mut(), expected, None).unwrap();
+        let actual = annot.rect(None).unwrap();
+        assert_eq!(actual, expected, "index: {index}");
+    }
+}
+
+/// `set_rect` — with a non-identity CTM transforms coordinates correctly.
+#[test]
+fn test_set_rect_with_ctm() {
+    let mut tester = LinkAnnotTester::new(1);
+    let mut annot = tester.add_link_annot();
+
+    let (page_ctm, inv_ctm) = {
+        let page = tester.doc_mut().find_page(0).unwrap();
+        let ctm = page.page_ctm().unwrap();
+        let inv = ctm.invert().expect("page CTM must be invertible");
+        (ctm, inv)
+    };
+
+    let fitz_rects = [
+        Rect::new(50.0, 50.0, 250.0, 100.0),
+        // Full page bounds in Fitz space.
+        Rect::new(0.0, 0.0, PAGE_WIDTH, PAGE_HEIGHT),
+        Rect::new(100.0, 200.0, 400.0, 600.0),
+        // Near bottom of Fitz page (large y).
+        Rect::new(10.0, 730.0, PAGE_WIDTH - 10.0, PAGE_HEIGHT - 2.0),
+    ];
+
+    for (index, expected) in fitz_rects.into_iter().enumerate() {
+        annot
+            .set_rect(tester.doc_mut(), expected, Some(&inv_ctm))
+            .unwrap();
+        let actual = tester.link_annot().rect(Some(&page_ctm)).unwrap();
+        assert_eq!(actual, expected, "index: {index}");
+    }
+}
+
+#[test]
+fn test_parse_action_aa_fallback_order() {
+    // 1. /AA/D only
+    let mut tester = LinkAnnotTester::new(2);
+    let action = LinkAction::Action(PdfAction::GoTo(PdfDestination::Page {
+        page: 1,
+        kind: DestinationKind::Fit,
+    }));
+    let action_dict = tester.encode_action(&action);
+    tester.build_and_assert_annot_objects(AnnotSetup::new().with_aa_d(action_dict), &action);
+
+    // 2. /AA/U only (when /AA/D absent)
+    let mut tester = LinkAnnotTester::new(1);
+    let action = LinkAction::Action(PdfAction::Uri("https://example.com".into()));
+    let uri_dict = tester.encode_action(&action);
+    tester.build_and_assert_annot_objects(AnnotSetup::new().with_aa_u(uri_dict), &action);
+
+    // 3. /AA/D takes priority over /AA/U
+    let mut tester = LinkAnnotTester::new(2);
+    let d_action = LinkAction::Action(PdfAction::GoTo(PdfDestination::Page {
+        page: 1,
+        kind: DestinationKind::Fit,
+    }));
+    let d_dict = tester.encode_action(&d_action);
+    let u_dict = tester.encode_action(&LinkAction::Action(PdfAction::Uri(
+        "https://u-action.example.com".into(),
+    )));
+    tester.build_and_assert_annot_objects(
+        AnnotSetup::new().with_aa_d(d_dict).with_aa_u(u_dict),
+        &d_action,
+    );
+}
+
+#[test]
+fn test_parse_action_priority_dest_over_a_over_aa() {
+    let action = LinkAction::Action(PdfAction::Uri("https://a-entry.example.com".into()));
+
+    // 1. /Dest takes priority over /A
+    let mut tester = LinkAnnotTester::new(2);
+    let a_obj = tester.encode_action(&action);
+    let dest_action = LinkAction::Dest(PdfDestination::Page {
+        page: 1,
+        kind: DestinationKind::Fit,
+    });
+    let dest_obj = tester.encode_action(&dest_action);
+    tester.build_and_assert_annot_objects(
+        AnnotSetup::new().with_dest(dest_obj).with_action(a_obj),
+        &dest_action,
+    );
+
+    // 2. /A takes priority over /AA
+    let mut tester = LinkAnnotTester::new(2);
+    let a_obj = tester.encode_action(&action);
+    let aa_obj = tester.encode_action(&LinkAction::Action(PdfAction::GoTo(PdfDestination::Page {
+        page: 1,
+        kind: DestinationKind::Fit,
+    })));
+    tester.build_and_assert_annot_objects(
+        AnnotSetup::new().with_action(a_obj).with_aa_d(aa_obj),
+        &action,
+    );
+
+    // 3. No /Dest, /A, or /AA returns None
+    let mut tester = LinkAnnotTester::new(1);
+    let annot = tester.build_annotation_object(AnnotSetup::new());
+    let result = tester.parse_annotation_object(&annot);
+    assert!(result.is_none(), "No action should return None");
+}
+
+#[test]
+fn test_parse_named_actions_to_page_destinations() {
+    // (name, page_count, page_num, expected_page)
+    let cases: &[(&str, usize, Option<i32>, Option<u32>)] = &[
+        ("FirstPage", 5, Some(2), Some(0)),
+        ("LastPage", 5, Some(0), Some(4)),
+        ("PrevPage", 5, Some(3), Some(2)),
+        ("PrevPage", 5, Some(0), Some(0)), // clamps to 0
+        ("NextPage", 5, Some(2), Some(3)),
+        ("NextPage", 5, Some(4), Some(4)),   // clamps to last
+        ("PrevPage", 5, None, None),         // None page_num -> None
+        ("NextPage", 5, None, None),         // None page_num -> None
+        ("UnknownAction", 1, Some(0), None), // unknown -> None
+    ];
+
+    for (name, page_count, page_num, expected) in cases {
+        let mut tester = LinkAnnotTester::new(*page_count);
+        let action_dict = tester.make_named_action_dict(name);
+        if let Some(page) = page_num {
+            tester.on_page(*page);
+        }
+        let annot = tester.build_annotation_object(AnnotSetup::new().with_action(action_dict));
+        let result = tester.parse_annotation_object(&annot);
+
+        match expected {
+            Some(expected_page) => {
+                let expected_action = LinkAction::Action(PdfAction::GoTo(PdfDestination::Page {
+                    page: *expected_page,
+                    kind: DestinationKind::default(),
+                }));
+                assert_eq!(
+                    result,
+                    Some(expected_action),
+                    "{name} from page {page_num:?} should go to page {expected_page}"
+                );
+            }
+            None => assert!(
+                result.is_none(),
+                "{name} with page_num={page_num:?} should return None"
+            ),
+        }
+    }
+}
+
+#[test]
+fn test_parse_uri_action_with_catalog_base() {
+    // (base_uri, link_uri, expected_full_uri)
+    let cases: &[(Option<&str>, &str, &str)] = &[
+        (
+            Some("https://example.com/base/"),
+            "page.html",
+            "https://example.com/base/page.html",
+        ),
+        (None, "/absolute/path", "file:///absolute/path"),
+        (None, "relative/path", "file://relative/path"),
+        (
+            Some("https://base.example.com/"),
+            "https://other.example.com/page",
+            "https://other.example.com/page",
+        ),
+    ];
+
+    for (base, link_uri, expected) in cases {
+        let mut tester = LinkAnnotTester::new(1);
+        if let Some(base) = base {
+            tester.set_uri_base(base);
+        }
+
+        let action_dict =
+            tester.encode_action(&LinkAction::Action(PdfAction::Uri(link_uri.to_string())));
+
+        let expected_action = LinkAction::Action(PdfAction::Uri(expected.to_string()));
+        tester.build_and_assert_annot_objects(
+            AnnotSetup::new().with_action(action_dict),
+            &expected_action,
+        );
+    }
+}
+
+#[test]
+fn test_error_for_missing_or_incomplete_rect() {
+    let mut doc = PdfDocument::new();
+    doc.new_page(PAGE_SIZE).unwrap();
+
+    // 1. Missing /Rect
+    let mut annot_obj = doc.new_dict_with_capacity(2).unwrap();
+    annot_obj
+        .dict_put("Type", PdfObject::new_name("Annot").unwrap())
+        .unwrap();
+    annot_obj
+        .dict_put("Subtype", PdfObject::new_name("Link").unwrap())
+        .unwrap();
+    let annot = super::PdfLinkAnnot::new(annot_obj);
+    assert!(annot.rect(None).is_err());
+
+    // 2. Incomplete /Rect (only 2 elements)
+    let mut annot_obj = doc.new_dict_with_capacity(3).unwrap();
+    annot_obj
+        .dict_put("Type", PdfObject::new_name("Annot").unwrap())
+        .unwrap();
+    annot_obj
+        .dict_put("Subtype", PdfObject::new_name("Link").unwrap())
+        .unwrap();
+    let mut rect = doc.new_array_with_capacity(2).unwrap();
+    rect.array_push(PdfObject::new_real(10.0).unwrap()).unwrap();
+    rect.array_push(PdfObject::new_real(20.0).unwrap()).unwrap();
+    annot_obj.dict_put("Rect", rect).unwrap();
+    let annot = super::PdfLinkAnnot::new(annot_obj);
+    assert!(annot.rect(None).is_err());
+}
+
+#[test]
+fn test_parse_dest_entry_name_and_string_objects() {
+    // /Dest as a PDF name
+    let mut tester = LinkAnnotTester::new(1);
+    let expected = LinkAction::Dest(PdfDestination::Named("Chapter1".into()));
+    let dest = PdfObject::new_name("Chapter1").unwrap();
+    tester.build_and_assert_annot_objects(AnnotSetup::new().with_dest(dest), &expected);
+
+    // /Dest as a PDF string
+    let mut tester = LinkAnnotTester::new(1);
+    let expected = LinkAction::Dest(PdfDestination::Named("Section.2.3".into()));
+    let dest = PdfObject::new_string("Section.2.3").unwrap();
+    tester.build_and_assert_annot_objects(AnnotSetup::new().with_dest(dest), &expected);
+}
+
+#[test]
+fn test_parse_gotor_filespec_string() {
+    // 1. File spec as a raw string (not dict)
+    let mut tester = LinkAnnotTester::new(1);
+    let mut action_dict = tester.encode_action(&LinkAction::Action(PdfAction::GoToR {
+        file: FileSpec::Path("simple.pdf".into()),
+        dest: PdfDestination::default(),
+    }));
+    let path = PdfObject::new_string("other.pdf").unwrap();
+    action_dict.dict_put("F", path).unwrap();
+    let expected = LinkAction::Action(PdfAction::GoToR {
+        file: FileSpec::Path("other.pdf".into()),
+        dest: PdfDestination::default(),
+    });
+    tester.build_and_assert_annot_objects(AnnotSetup::new().with_action(action_dict), &expected);
+
+    // 2. Single filespec key variants
+    let single_key_cases: &[(&str, &str)] = &[
+        ("UF", "uf-only.pdf"),
+        ("F", "f-only.pdf"),
+        ("Unix", "/root/path/doc.pdf"),
+        ("DOS", "C:\\docs\\report.pdf"),
+        ("Mac", "Macintosh HD:docs:file.pdf"),
+    ];
+    for (key, path) in single_key_cases {
+        let mut tester = LinkAnnotTester::new(1);
+        let action_dict = gotor_action_with_filespec_keys(&mut tester, &[(key, path)]);
+        let expected = gotor_path(path);
+        tester
+            .build_and_assert_annot_objects(AnnotSetup::new().with_action(action_dict), &expected);
+    }
+
+    // 3. Priority tests: first key in list wins
+    let priority_cases: &[(&[(&str, &str)], &str)] = &[
+        // UF > F > Unix > DOS > Mac
+        (
+            &[
+                ("UF", "uf-wins.pdf"),
+                ("F", "f-loses.pdf"),
+                ("Unix", "unix-loses.pdf"),
+                ("DOS", "dos-loses.pdf"),
+                ("Mac", "mac-loses.pdf"),
+            ],
+            "uf-wins.pdf",
+        ),
+        // F > Unix > DOS > Mac (no UF)
+        (
+            &[
+                ("F", "f-wins.pdf"),
+                ("Unix", "unix-loses.pdf"),
+                ("DOS", "dos-loses.pdf"),
+            ],
+            "f-wins.pdf",
+        ),
+        // Unix > DOS > Mac (no UF/F)
+        (
+            &[
+                ("Unix", "unix-wins.pdf"),
+                ("DOS", "dos-loses.pdf"),
+                ("Mac", "mac-loses.pdf"),
+            ],
+            "unix-wins.pdf",
+        ),
+        // DOS > Mac (no UF/F/Unix)
+        (
+            &[("DOS", "C:\\dos-wins.pdf"), ("Mac", "mac-loses.pdf")],
+            "C:\\dos-wins.pdf",
+        ),
+    ];
+    for (keys, expected_path) in priority_cases {
+        let mut tester = LinkAnnotTester::new(1);
+        let action_dict = gotor_action_with_filespec_keys(&mut tester, keys);
+        let expected = gotor_path(expected_path);
+        tester
+            .build_and_assert_annot_objects(AnnotSetup::new().with_action(action_dict), &expected);
+    }
+
+    // 4. FS=URL with /F entry returns FileSpec::Url
+    let mut tester = LinkAnnotTester::new(1);
+    let action_dict = tester.encode_action(&LinkAction::Action(PdfAction::GoToR {
+        file: FileSpec::Url("https://example.com/remote.pdf".into()),
+        dest: PdfDestination::Named("chapter1".into()),
+    }));
+    let expected = LinkAction::Action(PdfAction::GoToR {
+        file: FileSpec::Url("https://example.com/remote.pdf".into()),
+        dest: PdfDestination::Named("chapter1".into()),
+    });
+    tester.build_and_assert_annot_objects(AnnotSetup::new().with_action(action_dict), &expected);
+
+    // 4. Empty dict (no recognized keys) returns error
+    let mut tester = LinkAnnotTester::new(1);
+    let action_dict = gotor_action_with_filespec_keys(&mut tester, &[]);
+    let annot = tester.build_annotation_object(AnnotSetup::new().with_action(action_dict));
+    let result = parse_link_action_from_annot_dict(&annot, &tester.doc, None);
+    assert!(result.is_err(), "Empty filespec should return an error");
+
+    // 5. Launch action with each filespec key
+    for (key, path) in [
+        ("UF", "launched-uf.txt"),
+        ("F", "launched-f.txt"),
+        ("Unix", "/usr/local/launched.txt"),
+        ("DOS", "C:\\launched.txt"),
+        ("Mac", "HD:launched.txt"),
+    ] {
+        let mut tester = LinkAnnotTester::new(1);
+        let action_dict = tester.encode_action(&LinkAction::Action(PdfAction::Launch(
+            FileSpec::Path("placeholder.txt".into()),
+        )));
+        let mut fspec = action_dict.get_dict("F").unwrap().unwrap();
+        fspec.dict_delete("F").unwrap();
+        fspec.dict_delete("UF").unwrap();
+        let path_obj = PdfObject::new_string(path).unwrap();
+        fspec.dict_put(key, path_obj).unwrap();
+
+        let expected = LinkAction::Action(PdfAction::Launch(FileSpec::Path(path.into())));
+        let annot = tester.build_annotation_object(AnnotSetup::new().with_action(action_dict));
+        let parsed = tester.parse_annotation_object(&annot);
+        assert_eq!(parsed, Some(expected), "Launch with /{key} key");
+    }
+}
+
+/// Helper: creates a GoToR action dict with specific filespec keys, removing defaults.
+fn gotor_action_with_filespec_keys(
+    tester: &mut LinkAnnotTester,
+    keys: &[(&str, &str)],
+) -> PdfObject {
+    let action_dict = tester.encode_action(&LinkAction::Action(PdfAction::GoToR {
+        file: FileSpec::Path("placeholder.pdf".into()),
+        dest: PdfDestination::default(),
+    }));
+    let mut fspec = action_dict.get_dict("F").unwrap().unwrap();
+    fspec.dict_delete("F").unwrap();
+    fspec.dict_delete("UF").unwrap();
+    for (key, value) in keys {
+        let path = PdfObject::new_string(value).unwrap();
+        fspec.dict_put(*key, path).unwrap();
+    }
+    action_dict
+}
+
+fn gotor_path(path: &str) -> LinkAction {
+    LinkAction::Action(PdfAction::GoToR {
+        file: FileSpec::Path(path.into()),
+        dest: PdfDestination::default(),
+    })
+}
+
+#[test]
+fn test_parse_filespec_url_requires_f_entry_regression() {
+    let dest = PdfDestination::Page {
+        page: 0,
+        kind: DestinationKind::default(),
+    };
+
+    // FS=URL marks URL-based filespecs, but URL payload must be in /F.
+    // When /F is absent, the parser must fall back to standard filename keys
+    // and return FileSpec::Path, not FileSpec::Url.
+    for key in ["UF", "Unix", "DOS", "Mac"] {
+        let mut tester = LinkAnnotTester::new(1);
+        let url = "https://example.com/only-fallback.pdf";
+        let action_dict = tester.encode_action(&LinkAction::Action(PdfAction::GoToR {
+            file: FileSpec::Url(url.into()),
+            dest: dest.clone(),
+        }));
+
+        let mut fspec = action_dict.get_dict("F").unwrap().unwrap();
+        fspec.dict_delete("F").unwrap();
+        let path = PdfObject::new_string(url).unwrap();
+        fspec.dict_put(key, path).unwrap();
+
+        let annot = tester.build_annotation_object(AnnotSetup::new().with_action(action_dict));
+        let parsed = tester.parse_annotation_object(&annot);
+
+        // Without /F, the parser treats the fallback value as a filename path, not a URL.
+        assert_eq!(parsed, Some(gotor_path(url)), "FS=URL with /{key} fallback");
+    }
+}
+
+#[test]
+fn test_decode_destination_kind_edge_cases() {
+    let doc = PdfDocument::new();
+
+    let make_array = |name, values: &[Option<f32>]| -> Result<PdfObject, Error> {
+        let mut array = doc.new_array_with_capacity(6)?;
+        // Index 0 is the page reference
+        array.array_push(PdfObject::new_int(0)?)?;
+        array.array_push(PdfObject::new_name(name)?)?;
+        for val in values {
+            match *val {
+                Some(val) => array.array_push(PdfObject::new_real(val)?)?,
+                None => array.array_push(PdfObject::new_null())?,
+            }
+        }
+        Ok(array)
+    };
+
+    // Unknown dest type defaults to XYZ (match MuPDF)
+    let arr = make_array("UnknownType", &[Some(10.0), Some(20.0), Some(1.5)]).unwrap();
+    assert_eq!(
+        DestinationKind::decode_from(&arr).unwrap(),
+        xyz_dest(Some(10.0), Some(20.0), Some(150.0)) // 1.5 == 150%
+    );
+
+    // Zero zoom maps to 100%
+    let arr = make_array("XYZ", &[None, None, Some(0.0)]).unwrap();
+    assert_eq!(
+        DestinationKind::decode_from(&arr).unwrap(),
+        xyz_dest(None, None, Some(100.0)) // 0.0 -> 100%
+    );
+
+    // Negative zoom maps to 100%
+    let arr = make_array("XYZ", &[None, None, Some(-1.0)]).unwrap();
+    assert_eq!(
+        DestinationKind::decode_from(&arr).unwrap(),
+        xyz_dest(None, None, Some(100.0)) // z <= 0.0 -> 100%
+    );
+
+    // All-null XYZ coordinates -> default
+    let arr = make_array("XYZ", &[None, None, None]).unwrap();
+    assert_eq!(
+        DestinationKind::decode_from(&arr).unwrap(),
+        DestinationKind::default()
+    );
+}
+
+#[test]
+fn test_cached_resolver_reuses_cached_entries() {
+    use std::cell::Cell;
+    use std::collections::HashMap;
+
+    let mut doc = PdfDocument::new();
+    for _ in 0..3 {
+        doc.new_page(PAGE_SIZE).unwrap();
+    }
+
+    let call_count = Cell::new(0u32);
+    let mut cache: HashMap<u32, (PdfObject, Option<Matrix>)> = HashMap::new();
+
+    let mut resolver = CachedResolver::new(&mut cache, |page_obj: &PdfObject| {
+        call_count.set(call_count.get() + 1);
+        Ok(page_obj.page_ctm()?.invert())
+    });
+
+    // First resolve for page 1.
+    let _ = resolver.resolve(&doc, 1).unwrap();
+    assert_eq!(call_count.get(), 1);
+
+    // Second resolve for page 1 — should use cache.
+    let _ = resolver.resolve(&doc, 1).unwrap();
+    assert_eq!(call_count.get(), 1, "Should reuse cached entry");
+
+    // Resolve for page 2 — should call fn again.
+    let _ = resolver.resolve(&doc, 2).unwrap();
+    assert_eq!(call_count.get(), 2);
+
+    assert_eq!(cache.len(), 2,);
+}

--- a/src/pdf/links/tests_link_annot.rs
+++ b/src/pdf/links/tests_link_annot.rs
@@ -396,6 +396,33 @@ fn test_set_action_misc() {
 }
 
 #[test]
+fn test_parse_link_action_errors_on_out_of_range_page_index() {
+    let mut tester = LinkAnnotTester::new(3);
+
+    let mut dest_array = tester.doc.new_array_with_capacity(2).unwrap();
+    dest_array
+        .array_push(PdfObject::new_int(9999).unwrap())
+        .unwrap();
+    dest_array
+        .array_push(PdfObject::new_name("Fit").unwrap())
+        .unwrap();
+
+    let mut action_dict = tester.doc.new_dict_with_capacity(2).unwrap();
+    action_dict
+        .dict_put("S", PdfObject::new_name("GoTo").unwrap())
+        .unwrap();
+    action_dict.dict_put("D", dest_array).unwrap();
+
+    // Rust fails on out-of-range pages
+    let annot = tester.build_annotation_object(AnnotSetup::new().with_action(action_dict));
+
+    // MuPDF simply drops the invalid link
+    assert!(parse_link_action_from_annot_dict(&annot, &tester.doc, None).is_err());
+    let links = tester.doc.load_page(0).unwrap().links().unwrap();
+    assert_eq!(links.count(), 0);
+}
+
+#[test]
 fn test_switches_between_dest_and_action_entries() {
     let mut tester = LinkAnnotTester::new(2);
     let mut annot = tester.add_link_annot();
@@ -429,6 +456,34 @@ fn test_switches_between_dest_and_action_entries() {
         annot.get_dict("A").unwrap().is_none(),
         "/A should be absent after writing /Dest"
     );
+
+    let mut tester = LinkAnnotTester::new(2);
+    let aa_d = tester.encode_action(&LinkAction::Action(PdfAction::GoTo(
+        PdfDestination::default(),
+    )));
+    let aa_u = tester.encode_action(&LinkAction::Action(PdfAction::Uri(
+        "https://other_example.com".into(),
+    )));
+    let annot_obj =
+        tester.build_annotation_object(AnnotSetup::new().with_aa_d(aa_d).with_aa_u(aa_u));
+    let mut annot = PdfLinkAnnot::new(annot_obj);
+
+    annot.set_action(tester.doc_mut(), &as_action).unwrap();
+    assert!(
+        annot.get_dict("AA").unwrap().is_none(),
+        "/AA should be absent after replacing with /A"
+    );
+    assert_eq!(
+        annot.action(&tester.doc, None).unwrap(),
+        Some(as_action.clone())
+    );
+
+    annot.set_action(tester.doc_mut(), &as_dest).unwrap();
+    assert!(
+        annot.get_dict("AA").unwrap().is_none(),
+        "/AA should stay absent"
+    );
+    assert_eq!(annot.action(&tester.doc, None).unwrap(), Some(as_dest));
 }
 
 /// `set_rect` — with `None` CTM writes coordinates as-is.

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -18,6 +18,7 @@ pub use links::{
 pub use object::PdfObject;
 pub use page::PdfPage;
 
+#[must_use]
 pub struct DocOperation<'a> {
     doc: &'a mut PdfDocument,
     success: bool,
@@ -32,16 +33,16 @@ impl<'a> DocOperation<'a> {
         })
     }
 
-    fn commit(mut self) {
+    pub fn commit(mut self) -> Result<(), crate::Error> {
+        self.doc.end_operation()?;
         self.success = true;
+        Ok(())
     }
 }
 
 impl Drop for DocOperation<'_> {
     fn drop(&mut self) {
-        if self.success {
-            let _ = self.doc.end_operation();
-        } else {
+        if !self.success {
             let _ = self.doc.abandon_operation();
         }
     }

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -3,6 +3,7 @@ pub mod document;
 pub mod filter;
 pub mod graft_map;
 pub mod intent;
+pub mod links;
 pub mod object;
 pub mod page;
 
@@ -11,5 +12,37 @@ pub use document::{Encryption, PdfDocument, PdfWriteOptions, Permission};
 pub use filter::PdfFilterOptions;
 pub use graft_map::PdfGraftMap;
 pub use intent::Intent;
+pub use links::{
+    DestPageResolver, FileSpec, LinkAction, PdfAction, PdfDestination, PdfLink, PdfLinkAnnot,
+};
 pub use object::PdfObject;
 pub use page::PdfPage;
+
+pub struct DocOperation<'a> {
+    doc: &'a mut PdfDocument,
+    success: bool,
+}
+
+impl<'a> DocOperation<'a> {
+    fn begin(doc: &'a mut PdfDocument, name: &str) -> Result<Self, crate::Error> {
+        doc.begin_operation(name)?;
+        Ok(Self {
+            doc,
+            success: false,
+        })
+    }
+
+    fn commit(mut self) {
+        self.success = true;
+    }
+}
+
+impl Drop for DocOperation<'_> {
+    fn drop(&mut self) {
+        if self.success {
+            let _ = self.doc.end_operation();
+        } else {
+            let _ = self.doc.abandon_operation();
+        }
+    }
+}

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -285,6 +285,16 @@ impl PdfObject {
         unsafe { ffi_try!(mupdf_pdf_array_len(context(), self.inner)) }.map(|size| size as usize)
     }
 
+    /// Creates a shallow copy of this array, resolving any indirect reference.
+    ///
+    /// Wraps `pdf_copy_array`: resolves `self` if indirect, then copies each
+    /// element into a new direct array. Returns an error if `self` is not an
+    /// array.
+    pub fn copy_array(&self) -> Result<Self, Error> {
+        unsafe { ffi_try!(mupdf_pdf_copy_array(context(), self.inner)) }
+            .map(|inner| unsafe { Self::from_raw(inner) })
+    }
+
     pub fn array_put(&mut self, index: i32, value: Self) -> Result<(), Error> {
         unsafe {
             ffi_try!(mupdf_pdf_array_put(
@@ -300,11 +310,29 @@ impl PdfObject {
         unsafe { ffi_try!(mupdf_pdf_array_push(context(), self.inner, value.inner)) }
     }
 
+    pub(crate) fn array_push_ref(&mut self, value: &Self) -> Result<(), Error> {
+        // From MUPDF (https://ghostscript.com/~robin/mupdf_explored.pdf, p. 238)
+        // The array will take new references to the object passed in - that is, after the call,
+        // both the array and the caller will hold references to the object. In cases where the
+        // object to be inserted is a ‘borrowed’ reference, this is ideal.
+        unsafe { ffi_try!(mupdf_pdf_array_push(context(), self.inner, value.inner)) }
+    }
+
     pub fn array_delete(&mut self, index: i32) -> Result<(), Error> {
         unsafe { ffi_try!(mupdf_pdf_array_delete(context(), self.inner, index)) }
     }
 
     pub fn dict_put<K: IntoPdfDictKey>(&mut self, key: K, value: Self) -> Result<(), Error> {
+        self.dict_put_ref(key, &value)
+    }
+
+    pub(crate) fn dict_put_ref<K: IntoPdfDictKey>(
+        &mut self,
+        key: K,
+        value: &Self,
+    ) -> Result<(), Error> {
+        // The same as array_push_ref, look at
+        // https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-object.c#L2505
         let key_obj = key.into_pdf_dict_key()?;
         unsafe {
             ffi_try!(mupdf_pdf_dict_put(

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -1,4 +1,6 @@
+use std::collections::HashMap;
 use std::{
+    ffi::CStr,
     mem::ManuallyDrop,
     ops::{Deref, DerefMut},
     ptr::NonNull,
@@ -6,7 +8,14 @@ use std::{
 
 use mupdf_sys::*;
 
-use crate::pdf::{PdfAnnotation, PdfAnnotationType, PdfFilterOptions, PdfObject};
+use crate::link::LinkDestination;
+use crate::pdf::links::{
+    build_link_annotation, parse_external_link, CachedResolver, DestPageResolver,
+};
+use crate::pdf::{
+    DocOperation, LinkAction, PdfAction, PdfAnnotation, PdfAnnotationType, PdfDestination,
+    PdfDocument, PdfFilterOptions, PdfLink, PdfLinkAnnot, PdfObject,
+};
 use crate::{context, unsafe_impl_ffi_wrapper, Error, FFIWrapper, Matrix, Page, Rect};
 
 #[derive(Debug)]
@@ -145,6 +154,336 @@ impl PdfPage {
                 self.as_mut_ptr(),
                 &raw mut opt.inner
             ))
+        }
+    }
+
+    /// Returns an iterator over the link annotations on this page as [`PdfLink`] items.
+    ///
+    /// Each link's `bounds` are in MuPDF's Fitz coordinate space (origin at top-left,
+    /// Y increasing downward). The `action` field is a structured [`PdfAction`] variant.
+    ///
+    /// Named destinations are resolved to concrete page numbers. Links with
+    /// unresolvable named destinations are skipped.
+    ///
+    /// # Output mapping
+    ///
+    /// | Link pattern                                     | Resolved action                  |
+    /// |--------------------------------------------------|----------------------------------|
+    /// | Internal page link                               | `GoTo(Page { page, kind })`      |
+    /// | Named destination (resolvable)                   | `GoTo(Page { page, kind })`      |
+    /// | Named destination (unresolvable)                 | *(skipped)*                      |
+    /// | `file://<path>.pdf#<params>`                     | `GoToR { file: Path(..), dest }` |
+    /// | `file:<path>.pdf#<params>`                       | `GoToR { file: Path(..), dest }` |
+    /// | `<scheme>://<host>/<..>.pdf#<params>` (external) | `GoToR { file: Url(..),  dest }` |
+    /// | `<path>.pdf#<params>` (no scheme)                | `GoToR { file: Path(..), dest }` |
+    /// | `file:<path>` (non-PDF)                          | `Launch(Path(..))`               |
+    /// | `<local_path>` (non-external, non-PDF)           | `Launch(Path(..))`               |
+    /// | `<scheme>://<..>` (non-PDF, external)            | `Uri(uri)`                       |
+    pub fn resolved_links(&self) -> Result<PdfLinkIter, Error> {
+        let links_head =
+            unsafe { ffi_try!(mupdf_load_links(context(), self.inner.as_ptr().cast())) }?;
+
+        let doc_ptr =
+            NonNull::new(unsafe { (*self.inner.as_ptr()).doc }).ok_or(Error::UnexpectedNullPtr)?;
+
+        let doc = unsafe { PdfDocument::from_raw(pdf_keep_document(context(), doc_ptr.as_ptr())) };
+
+        Ok(PdfLinkIter {
+            links_head,
+            next: links_head,
+            doc,
+        })
+    }
+
+    /// Returns an iterator over the link annotation dictionaries on this page
+    /// as [`PdfLinkAnnot`] items.
+    ///
+    /// Iterates the page's `/Annots` array and yields entries whose `Subtype` is `Link`.
+    /// Non-link annotations are silently skipped.
+    ///
+    /// # Why not [`PdfPage::annotations`]?
+    ///
+    /// MuPDF's `pdf_sync_annots` ([`PdfPage::annotations`]) skips `Subtype=Link` entries, so
+    /// [`PdfAnnotation`] of type [`PdfAnnotationType::Link`] can never be produced from a
+    /// page via the annotation iterator. This method bypasses that by reading the `/Annots`
+    /// array directly.
+    pub fn link_annotations(&self) -> Result<PdfLinkAnnotIter, Error> {
+        let annots = self.object().get_dict("Annots")?;
+        let count = if let Some(a) = &annots { a.len()? } else { 0 };
+
+        Ok(PdfLinkAnnotIter {
+            annots,
+            count,
+            index: 0,
+        })
+    }
+
+    /// Extracts all links from this page by reading the `/Annots` array directly.
+    ///
+    /// This is the symmetric counterpart to [`add_links`](Self::add_links): it reads the
+    /// same annotation dictionaries that `add_links` writes, preserving:
+    ///
+    /// - The `/Dest` and `/A` destinations (as [`LinkAction::Dest`] and [`LinkAction::Action`])
+    /// - Named destinations as [`PdfDestination::Named`] (not resolved to page numbers)
+    /// - Preserves `Launch` actions exactly as specified in the PDF document
+    /// - Does not clamp local coordinates to the page bounds
+    ///
+    /// Links with no recognizable action are silently skipped.
+    pub fn links_from_annotations(&self) -> Result<Vec<PdfLink>, Error> {
+        let doc_ptr =
+            NonNull::new(unsafe { (*self.inner.as_ptr()).doc }).ok_or(Error::UnexpectedNullPtr)?;
+        let doc = unsafe { PdfDocument::from_raw(pdf_keep_document(context(), doc_ptr.as_ptr())) };
+        let page_no = doc.lookup_page_number(&self.object()).ok();
+        let page_ctm = self.ctm()?;
+
+        let mut result = Vec::new();
+        for annot in self.link_annotations()?.flatten() {
+            if let Ok(Some(link)) = annot.to_pdf_link(&doc, page_no, Some(&page_ctm)) {
+                result.push(link);
+            }
+        }
+        Ok(result)
+    }
+
+    /// Adds link annotations to this page using the page's own CTM for coordinate
+    /// transformation.
+    ///
+    /// Convenience wrapper around [`add_links_with_inv_ctm`](Self::add_links_with_inv_ctm)
+    /// that uses a cached resolver deriving inverse CTMs from
+    /// `page_obj.page_ctm().invert()`. This is correct when all link coordinates
+    /// (both annotation bounds and `GoTo` destinations) are in MuPDF's Fitz
+    /// coordinate space.
+    ///
+    /// # In-memory link list
+    ///
+    /// Like [`add_links_with_inv_ctm`](Self::add_links_with_inv_ctm), this updates
+    /// `/Annots` but does not refresh MuPDF's in-memory `fz_link` list. Use
+    /// [`links_from_annotations`](Self::links_from_annotations) for immediate reads,
+    /// or reload page before calling [`resolved_links`](Self::resolved_links).
+    pub fn add_links(&mut self, doc: &mut PdfDocument, links: &[PdfLink]) -> Result<(), Error> {
+        let mut cache = HashMap::new();
+        let mut resolver = CachedResolver::new(&mut cache, |page_obj: &PdfObject| {
+            Ok(page_obj.page_ctm()?.invert())
+        });
+        self.add_links_with_inv_ctm(
+            doc,
+            links,
+            |page_obj| Ok(page_obj.page_ctm()?.invert()),
+            &mut resolver,
+        )
+    }
+
+    /// Adds link annotations to this page, using caller-provided inverse CTM functions
+    /// for coordinate transformation.
+    ///
+    /// Each [`PdfLink`] is converted into a PDF link annotation dictionary and
+    /// appended to the page's `/Annots` array.
+    ///
+    /// # Coordinate transforms
+    ///
+    /// [`PdfLink`] coordinates are in Fitz space. PDF annotations need PDF default
+    /// user space. Two mechanisms provide the inverse CTM for each context:
+    ///
+    /// - `annot_inv_ctm(page_obj)` — for the annotation `/Rect` on *this* page.
+    /// - `resolver` — a [`DestPageResolver`] that provides the destination page
+    ///   object and its inverse CTM for `GoTo(Page { .. })` destinations.
+    ///   `GoToR` coordinates are written as-is.
+    ///
+    /// # PdfAction -> annotation dictionary mapping
+    ///
+    /// | `PdfAction` variant         | `/S` (type) | `D` entry (`URI` for `Uri`) | `/F` entry    |
+    /// |-----------------------------|-------------|-----------------------------|---------------|
+    /// | `GoTo(Page { .. })`         | `GoTo`      | `[page_ref, /Kind, ...]`    | —             |
+    /// | `GoTo(Named(..))`           | `GoTo`      | `(name)`                    | —             |
+    /// | `Uri(..)`                   | `URI`       | `(uri)`                     | —             |
+    /// | `GoToR { .. }` (explicit)   | `GoToR`     | `[page_int, /Kind, ...]`    | filespec dict |
+    /// | `GoToR { .. }` (named)      | `GoToR`     | `(name)`                    | filespec dict |
+    /// | `Launch(..)`                | `Launch`    | —                           | filespec dict |
+    ///
+    ///
+    /// where:
+    ///
+    /// - `page_ref` is an indirect reference to the destination page object (local document)
+    /// - `page_int` is the zero-based page number as an integer (remote document)
+    /// - `/Kind` is the PDF destination type name (e.g. `/Fit`, `/XYZ`) followed by its parameters
+    ///   (see [`crate::DestinationKind::encode_into`])
+    /// - `filespec dict` is a file specification dictionary
+    ///
+    /// # In-memory link list
+    ///
+    /// This method modifies the page's `/Annots` dictionary but does not update
+    /// MuPDF's in-memory `fz_link` list. As a result:
+    ///
+    /// - [`links_from_annotations`](Self::links_from_annotations) reflects the new
+    ///   links immediately (reads the dict directly).
+    /// - [`resolved_links`](Self::resolved_links) will **not** include the new links until
+    ///   the page is reloaded.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self` does not belong to `doc` (ownership mismatch).
+    pub fn add_links_with_inv_ctm(
+        &mut self,
+        doc: &mut PdfDocument,
+        links: &[PdfLink],
+        annot_inv_ctm: impl FnOnce(&PdfObject) -> Result<Option<Matrix>, Error>,
+        resolver: &mut impl DestPageResolver,
+    ) -> Result<(), Error> {
+        if links.is_empty() {
+            return Ok(());
+        }
+
+        assert_eq!(
+            doc.as_raw(),
+            unsafe { (*self.inner.as_ptr()).doc },
+            "PdfPage ownership mismatch: the page is not attached to the provided PdfDocument"
+        );
+
+        let operation = DocOperation::begin(doc, "Add links")?;
+
+        let mut page_obj = self.object();
+        let annot_inv_ctm = annot_inv_ctm(&page_obj)?;
+
+        let mut annots = match page_obj.get_dict("Annots")? {
+            Some(annots) if annots.is_array()? => {
+                if annots.is_indirect()? {
+                    annots.copy_array()?
+                } else {
+                    annots
+                }
+            }
+            _ => operation.doc.new_array()?,
+        };
+
+        for link in links {
+            let annot =
+                build_link_annotation(operation.doc, &page_obj, link, &annot_inv_ctm, resolver)?;
+            let annot_indirect = operation.doc.add_object(&annot)?;
+            annots.array_push(annot_indirect)?;
+        }
+
+        if annots.len()? > 0 {
+            page_obj.dict_put("Annots", annots)?;
+        }
+
+        operation.commit();
+        Ok(())
+    }
+}
+
+/// Iterator over link annotations on a PDF page, yielding [`PdfLink`] items.
+///
+/// Created by [`PdfPage::resolved_links`]. Links with unresolvable named destinations
+/// or empty URIs are silently skipped.
+///
+/// See [`PdfPage::resolved_links`] for the full output mapping table.
+#[derive(Debug)]
+pub struct PdfLinkIter {
+    links_head: *mut fz_link,
+    next: *mut fz_link,
+    doc: PdfDocument,
+}
+
+impl Drop for PdfLinkIter {
+    fn drop(&mut self) {
+        if !self.links_head.is_null() {
+            unsafe {
+                fz_drop_link(context(), self.links_head);
+            }
+        }
+    }
+}
+
+impl Iterator for PdfLinkIter {
+    type Item = Result<PdfLink, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.next.is_null() {
+                return None;
+            }
+
+            let node = self.next;
+            unsafe {
+                self.next = (*node).next;
+                let bounds = (*node).rect.into();
+                let uri = CStr::from_ptr((*node).uri);
+
+                let action = match LinkDestination::from_uri(&self.doc, uri) {
+                    Ok(Some(dest)) => {
+                        // In PDFs, `page_in_chapter` is equivalent to `page_number`. Using it directly
+                        // allows the compiler to elide the `fz_page_number_from_location` FFI call.
+                        LinkAction::Action(PdfAction::GoTo(PdfDestination::Page {
+                            page: dest.loc.page_in_chapter,
+                            kind: dest.kind,
+                        }))
+                    }
+                    Ok(None) => match parse_external_link(uri.to_string_lossy().as_ref()) {
+                        Some(action) => match action {
+                            PdfAction::GoTo(PdfDestination::Named(_)) => {
+                                // `LinkDestination::from_uri` already attempted to resolve named destinations.
+                                // Reaching this point means the destination remains unresolved, so ignore and skip.
+                                continue;
+                            }
+                            action => LinkAction::Action(action),
+                        },
+                        None => continue,
+                    },
+                    Err(e) => return Some(Err(e)),
+                };
+
+                return Some(Ok(PdfLink { bounds, action }));
+            }
+        }
+    }
+}
+
+/// Iterator over link annotation dictionaries on a PDF page, yielding [`PdfLinkAnnot`] items.
+///
+/// Created by [`PdfPage::link_annotations`]. Non-link annotations (those without `Subtype=Link`)
+/// are silently skipped. Each `Result::Err` stops iteration, callers should handle
+/// errors appropriately.
+///
+/// See [`PdfPage::link_annotations`] for details on why this iterator exists alongside
+/// [`PdfPage::annotations`].
+#[derive(Debug)]
+pub struct PdfLinkAnnotIter {
+    annots: Option<PdfObject>,
+    count: usize,
+    index: usize,
+}
+
+impl Iterator for PdfLinkAnnotIter {
+    type Item = Result<PdfLinkAnnot, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let annots = self.annots.as_ref()?;
+        loop {
+            if self.index >= self.count {
+                return None;
+            }
+            let index = self.index;
+            self.index += 1;
+            let entry = match annots.get_array(index as i32) {
+                Ok(Some(e)) => e,
+                Ok(None) => continue,
+                Err(e) => return Some(Err(e)),
+            };
+            let resolved = match entry.resolve() {
+                Ok(Some(r)) => r,
+                Ok(None) => continue,
+                Err(e) => return Some(Err(e)),
+            };
+            let subtype = match resolved.get_dict("Subtype") {
+                Ok(Some(s)) => s,
+                Ok(None) => continue,
+                Err(e) => return Some(Err(e)),
+            };
+            match subtype.as_name() {
+                Ok(name) if name == b"Link" => return Some(Ok(PdfLinkAnnot::new(resolved))),
+                Ok(_) => continue,
+                Err(e) => return Some(Err(e)),
+            }
         }
     }
 }

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -225,11 +225,13 @@ impl PdfPage {
     ///
     /// - The `/Dest` and `/A` destinations (as [`LinkAction::Dest`] and [`LinkAction::Action`])
     /// - Named destinations as [`PdfDestination::Named`] (not resolved to page numbers)
-    /// - Preserves `Launch` actions exactly as specified in the PDF document
+    /// - `Launch` actions exactly as specified in the PDF document
     /// - Does not clamp local coordinates to the page bounds
     ///
-    /// Links with no recognizable action are silently skipped.
-    pub fn links_from_annotations(&self) -> Result<Vec<PdfLink>, Error> {
+    /// Links with no recognizable action, as well as malformed or unparseable annotations,
+    /// are silently skipped. If you need error reporting, iterate over [`PdfLinkAnnotIter`]
+    /// manually and call [`PdfLinkAnnot::to_pdf_link`] on each item.
+    pub fn links_from_annotations_lossy(&self) -> Result<Vec<PdfLink>, Error> {
         let doc_ptr =
             NonNull::new(unsafe { (*self.inner.as_ptr()).doc }).ok_or(Error::UnexpectedNullPtr)?;
         let doc = unsafe { PdfDocument::from_raw(pdf_keep_document(context(), doc_ptr.as_ptr())) };
@@ -258,7 +260,7 @@ impl PdfPage {
     ///
     /// Like [`add_links_with_inv_ctm`](Self::add_links_with_inv_ctm), this updates
     /// `/Annots` but does not refresh MuPDF's in-memory `fz_link` list. Use
-    /// [`links_from_annotations`](Self::links_from_annotations) for immediate reads,
+    /// [`links_from_annotations_lossy`](Self::links_from_annotations_lossy) for immediate reads,
     /// or reload page before calling [`resolved_links`](Self::resolved_links).
     pub fn add_links(&mut self, doc: &mut PdfDocument, links: &[PdfLink]) -> Result<(), Error> {
         let mut cache = HashMap::new();
@@ -314,7 +316,7 @@ impl PdfPage {
     /// This method modifies the page's `/Annots` dictionary but does not update
     /// MuPDF's in-memory `fz_link` list. As a result:
     ///
-    /// - [`links_from_annotations`](Self::links_from_annotations) reflects the new
+    /// - [`links_from_annotations_lossy`](Self::links_from_annotations_lossy) reflects the new
     ///   links immediately (reads the dict directly).
     /// - [`resolved_links`](Self::resolved_links) will **not** include the new links until
     ///   the page is reloaded.
@@ -366,8 +368,7 @@ impl PdfPage {
             page_obj.dict_put("Annots", annots)?;
         }
 
-        operation.commit();
-        Ok(())
+        operation.commit()
     }
 }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use mupdf_sys::*;
 
+use crate::pdf::PdfObject;
 use crate::{context, Error, Matrix, Point, Quad, Size, StrokeState};
 
 const FZ_MIN_INF_RECT: i32 = 0x80000000u32 as i32;
@@ -210,6 +211,13 @@ impl Rect {
 
     pub fn translate(&self, xoff: f32, yoff: f32) -> Self {
         unsafe { fz_translate_rect((*self).into(), xoff, yoff) }.into()
+    }
+
+    pub fn encode_into(self, array: &mut PdfObject) -> Result<(), Error> {
+        array.array_push(PdfObject::new_real(self.x0)?)?;
+        array.array_push(PdfObject::new_real(self.y0)?)?;
+        array.array_push(PdfObject::new_real(self.x1)?)?;
+        array.array_push(PdfObject::new_real(self.y1)?)
     }
 }
 


### PR DESCRIPTION
This PR adds support for PDF link annotations: we can read links from a page, extract link annotation dictionaries from `/Annots`, create and update link annotations in-place, and serialize link actions to MuPDF-compatible URI strings, all built on top of MuPDF’s APIs (sometimes low-level). It extends and supersedes #199.

`PdfLinkAnnot` is introduced specifically to enable in-place link editing. MuPDF’s `pdf_sync_annots` / `PdfPage::annotations()` skips `Subtype=Link`, so the generic annotation iterator cannot yield link annotations. `PdfLinkAnnot` bypasses it by working directly with the raw link annotation dictionaries from the page’s `/Annots` array.

**New types (`pdf::links` module):**

```rust
/// Extracted link data from a source page.
pub struct PdfLink {
    /// Link rectangle in Fitz coordinate space.
    pub bounds: Rect,
    /// Link action or destination (see PDF 32000-1:2008, 12.5.6.5, Table 173).
    pub action: LinkAction,
}

/// A link annotation's action or destination entry (see PDF 32000-1:2008, 12.5.6.5, Table 173).
pub enum LinkAction {
    /// Action dictionary (`A` entry in the annotation dictionary)
    /// (see PDF 32000-1:2008, 12.6.4).
    Action(PdfAction),
    /// Direct destination (`Dest` entry in the annotation dictionary)
    /// (see PDF 32000-1:2008, 12.3.2).
    Dest(PdfDestination),
}

/// PDF link destination representing an action associated with a link annotation
/// (see PDF 32000-1:2008, 12.6.4).
pub enum PdfAction {
    /// Go-to action (`S`=`GoTo`): changes the view to a destination in the current document
    /// (see PDF 32000-1:2008, 12.6.4.2, Table 199).
    GoTo(PdfDestination),
    /// Remote go-to action (`S`=`GoToR`): jumps to a destination in another PDF file
    /// (see PDF 32000-1:2008, 12.6.4.3, Table 200).
    GoToR {
        file: FileSpec,
        dest: PdfDestination,
    },
    /// Launch action (`S`=`Launch`): launches an application or opens/prints a document
    /// (see PDF 32000-1:2008, 12.6.4.5, Table 203).
    Launch(FileSpec),
    /// URI action (`S`=`URI`): resolves a uniform resource identifier
    /// (see PDF 32000-1:2008, 12.6.4.7, Table 206).
    Uri(String),
}

/// PDF file specification (see PDF 32000-1:2008, 7.11).
pub enum FileSpec {
    /// Local filesystem path (e.g., `/Docs/path/file.pdf`).
    Path(String),
    /// URL-based file specification (e.g., `http://example.com/file.pdf`).
    Url(String),
}

/// Destination within a PDF document (see PDF 32000-1:2008, 12.3.2).
pub enum PdfDestination {
    /// Explicit destination: zero-based page number with view settings (e.g., page 0, Fit).
    Page { page: u32, kind: DestinationKind },
    /// Named destination string resolved in the document's name tree (e.g., `"Chapter1"`).
    Named(String),
}

/// A link annotation dictionary in a PDF document, identified by `Subtype=Link`.
pub struct PdfLinkAnnot { /* wraps PdfObject */ }
```

**`PdfLinkAnnot` API:**

```rust
impl PdfLinkAnnot {
    /// Read action preserving `/Dest` vs `/A` and named destinations as-is.
    pub fn action(&self, doc: &PdfDocument, page_no: Option<i32>) -> Result<Option<LinkAction>, Error>;
    /// Read `/Rect`, transforming from PDF user space to Fitz space.
    pub fn rect(&self, page_ctm: Option<&Matrix>) -> Result<Rect, Error>;
    /// Replace the link action (writes `/A` or `/Dest`, removes the other).
    pub fn set_action(&mut self, doc: &mut PdfDocument, action: &LinkAction) -> Result<(), Error>;
    /// Write rect in Fitz space, transformed to PDF user space.
    pub fn set_rect(&mut self, doc: &mut PdfDocument, rect: Rect, inv_ctm: Option<&Matrix>) -> Result<(), Error>;
    /// Combine rect + action into a PdfLink.
    pub fn to_pdf_link(&self, doc: &PdfDocument, page_no: Option<i32>, ctm: Option<&Matrix>) -> Result<Option<PdfLink>, Error>;
}
```

**`PdfPage` new API:**

```rust
impl PdfPage {
    /// Iterator over resolved links (named dests -> page numbers, unresolvable skipped).
    pub fn resolved_links(&self) -> Result<PdfLinkIter, Error>;
    /// Iterator over raw link annotation dicts from `/Annots` array.
    pub fn link_annotations(&self) -> Result<PdfLinkAnnotIter, Error>;
    /// Extract all links preserving `/Dest` vs `/A` and named dests as-is.
    pub fn links_from_annotations(&self) -> Result<Vec<PdfLink>, Error>;
    /// Add link annotations with automatic CTM handling.
    pub fn add_links(&mut self, doc: &mut PdfDocument, links: &[PdfLink]) -> Result<(), Error>;
    /// Add link annotations with caller-provided inverse CTM.
    pub fn add_links_with_inv_ctm(&mut self, doc: &mut PdfDocument, links: &[PdfLink], ...) -> Result<(), Error>;
}
```

**`DestinationKind` additions:**

```rust
impl DestinationKind {
    /// Encode into a PDF destination array (moved from `Destination`).
    pub fn encode_into(self, array: &mut PdfObject) -> Result<(), Error>;
    /// Decode a PDF destination array into `DestinationKind` (inverse of encode_into).
    pub fn decode_from(array: &PdfObject) -> Result<DestinationKind, Error>;
}
impl Default for DestinationKind { ... }
impl Display for DestinationKind { ... }
```

**URI serialization:**

All link-related types implement `Display` plus a `to_uri()` helper that serialize actions into MuPDF-compatible URI strings.

**Other additions:**

- `DocOperation` RAII guard for safe `begin/end/abandon_operation`
- Small `PdfDocument`/`PdfObject` helpers for `dict`/`array` manipulation
- A few thin FFI wrappers mirroring MuPDF functionality
- Dedicated `Error::InvalidDestination`
- `percent-encoding` crate dependency

**Testing:**

~3700 lines of tests (~60% of the PR) cover URI parsing and formatting, annotation dictionary construction and extraction, read/write symmetry, and full round-trip scenarios (construct -> write to PDF -> read back -> verify match).

**Although the PR is ~6300 lines changed, it's mostly tests and docs. The core logic is relatively small.**
