### PR TITLE
Fix `PdfAnnotation` soundness by keeping parent page alive

### DIFF
--- a/src/pdf/annotation.rs
+++ b/src/pdf/annotation.rs
@@ -1,6 +1,7 @@
 use std::{
     convert::TryFrom,
     ffi::{c_int, c_uint, CStr, CString},
+    ptr::NonNull,
 };
 
 use mupdf_sys::*;
@@ -62,17 +63,46 @@ from_enum! { pdf_line_ending => c_uint,
 
 #[derive(Debug)]
 pub struct PdfAnnotation {
-    pub(crate) inner: *mut pdf_annot,
+    pub(crate) inner: NonNull<pdf_annot>,
+    /// Ref-counted page pointer that keeps the parent page (and transitively
+    /// the document) alive for as long as this annotation exists.
+    page: NonNull<pdf_page>,
 }
 
 impl PdfAnnotation {
+    /// Create a `PdfAnnotation` from pointer.
+    ///
+    /// # Safety
+    ///
+    /// * `ptr` must be non-null and point to a valid `pdf_annot`.
+    /// * The caller must own one reference to `ptr` (e.g. from a create call)
+    ///   and must not drop it afterwards — this wrapper assumes ownership.
+    /// * The parent page must be alive at the time of this call.
     pub(crate) unsafe fn from_raw(ptr: *mut pdf_annot) -> Self {
-        Self { inner: ptr }
+        let page = pdf_annot_page(context(), ptr);
+        pdf_keep_page(context(), page);
+        Self {
+            inner: NonNull::new_unchecked(ptr),
+            page: NonNull::new_unchecked(page),
+        }
+    }
+
+    /// Create a `PdfAnnotation` from a borrowed pointer.
+    ///
+    /// Increments the annotation's reference count before taking ownership.
+    ///
+    /// # Safety
+    ///
+    /// * `ptr` must be non-null and point to a valid `pdf_annot`.
+    /// * The parent page must be alive at the time of this call.
+    pub(crate) unsafe fn from_raw_keep_ref(ptr: *mut pdf_annot) -> Self {
+        pdf_keep_annot(context(), ptr);
+        Self::from_raw(ptr)
     }
 
     /// Get the [`PdfAnnotationType`] of this annotation
     pub fn r#type(&self) -> Result<PdfAnnotationType, Error> {
-        unsafe { ffi_try!(mupdf_pdf_annot_type(context(), self.inner)) }.map(|subtype| {
+        unsafe { ffi_try!(mupdf_pdf_annot_type(context(), self.inner.as_ptr())) }.map(|subtype| {
             PdfAnnotationType::try_from(subtype).unwrap_or(PdfAnnotationType::Unknown)
         })
     }
@@ -80,24 +110,24 @@ impl PdfAnnotation {
     /// Check if the annotation is hot (i.e. that the pointing device's cursor is hovering over the
     /// annotation)
     pub fn is_hot(&self) -> bool {
-        unsafe { pdf_annot_hot(context(), self.inner) != 0 }
+        unsafe { pdf_annot_hot(context(), self.inner.as_ptr()) != 0 }
     }
 
     /// Make this "hot" (see [`Self::is_hot()`])
     pub fn set_hot(&mut self, hot: bool) {
         // Just kinda trusting it would be insane of them to throw here
-        unsafe { pdf_set_annot_hot(context(), self.inner, i32::from(hot)) }
+        unsafe { pdf_set_annot_hot(context(), self.inner.as_ptr(), i32::from(hot)) }
     }
 
     pub fn is_active(&self) -> bool {
-        unsafe { pdf_annot_active(context(), self.inner) != 0 }
+        unsafe { pdf_annot_active(context(), self.inner.as_ptr()) != 0 }
     }
 
     pub fn set_line(&mut self, start: Point, end: Point) -> Result<(), Error> {
         unsafe {
             ffi_try!(mupdf_pdf_set_annot_line(
                 context(),
-                self.inner,
+                self.inner.as_ptr(),
                 start.into(),
                 end.into()
             ))
@@ -109,13 +139,13 @@ impl PdfAnnotation {
             match color {
                 AnnotationColor::Gray(g) => ffi_try!(mupdf_pdf_set_annot_color(
                     context(),
-                    self.inner,
+                    self.inner.as_ptr(),
                     1,
                     [g].as_ptr()
                 )),
                 AnnotationColor::Rgb { red, green, blue } => ffi_try!(mupdf_pdf_set_annot_color(
                     context(),
-                    self.inner,
+                    self.inner.as_ptr(),
                     3,
                     [red, green, blue].as_ptr()
                 )),
@@ -126,7 +156,7 @@ impl PdfAnnotation {
                     key,
                 } => ffi_try!(mupdf_pdf_set_annot_color(
                     context(),
-                    self.inner,
+                    self.inner.as_ptr(),
                     4,
                     [cyan, magenta, yellow, key].as_ptr()
                 )),
@@ -138,7 +168,7 @@ impl PdfAnnotation {
         unsafe {
             ffi_try!(mupdf_pdf_set_annot_flags(
                 context(),
-                self.inner,
+                self.inner.as_ptr(),
                 flags.bits()
             ))
         }
@@ -146,11 +176,17 @@ impl PdfAnnotation {
 
     /// Set the bounding box of the annotation
     pub fn set_rect(&mut self, rect: Rect) -> Result<(), Error> {
-        unsafe { ffi_try!(mupdf_pdf_set_annot_rect(context(), self.inner, rect.into())) }
+        unsafe {
+            ffi_try!(mupdf_pdf_set_annot_rect(
+                context(),
+                self.inner.as_ptr(),
+                rect.into()
+            ))
+        }
     }
 
     pub fn author(&self) -> Result<Option<&str>, Error> {
-        let ptr = unsafe { ffi_try!(mupdf_pdf_annot_author(context(), self.inner)) }?;
+        let ptr = unsafe { ffi_try!(mupdf_pdf_annot_author(context(), self.inner.as_ptr())) }?;
         if ptr.is_null() {
             return Ok(None);
         }
@@ -163,7 +199,7 @@ impl PdfAnnotation {
         unsafe {
             ffi_try!(mupdf_pdf_set_annot_author(
                 context(),
-                self.inner,
+                self.inner.as_ptr(),
                 c_author.as_ptr()
             ))
         }
@@ -173,7 +209,7 @@ impl PdfAnnotation {
         unsafe {
             ffi_try!(mupdf_pdf_filter_annot_contents(
                 context(),
-                self.inner,
+                self.inner.as_ptr(),
                 &raw mut opt.inner
             ))
         }
@@ -183,7 +219,7 @@ impl PdfAnnotation {
         unsafe {
             ffi_try!(mupdf_pdf_set_annot_popup(
                 context(),
-                self.inner,
+                self.inner.as_ptr(),
                 fz_rect::from(rect)
             ))
         }
@@ -193,7 +229,7 @@ impl PdfAnnotation {
         unsafe {
             ffi_try!(mupdf_pdf_set_annot_active(
                 context(),
-                self.inner,
+                self.inner.as_ptr(),
                 c_int::from(active)
             ))
         }
@@ -203,7 +239,7 @@ impl PdfAnnotation {
         unsafe {
             ffi_try!(mupdf_pdf_set_annot_border_width(
                 context(),
-                self.inner,
+                self.inner.as_ptr(),
                 width
             ))
         }
@@ -213,7 +249,7 @@ impl PdfAnnotation {
         unsafe {
             ffi_try!(mupdf_pdf_set_annot_intent(
                 context(),
-                self.inner,
+                self.inner.as_ptr(),
                 pdf_intent::from(intent)
             ))
         }
@@ -222,10 +258,9 @@ impl PdfAnnotation {
 
 impl Drop for PdfAnnotation {
     fn drop(&mut self) {
-        if !self.inner.is_null() {
-            unsafe {
-                pdf_drop_annot(context(), self.inner);
-            }
+        unsafe {
+            pdf_drop_annot(context(), self.inner.as_ptr());
+            pdf_drop_page(context(), self.page.as_ptr());
         }
     }
 }

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -7,6 +7,9 @@ pub mod links;
 pub mod object;
 pub mod page;
 
+#[cfg(test)]
+mod tests_annotation;
+
 pub use annotation::{LineEndingStyle, PdfAnnotation, PdfAnnotationType};
 pub use document::{Encryption, PdfDocument, PdfWriteOptions, Permission};
 pub use filter::PdfFilterOptions;

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -61,7 +61,11 @@ impl PdfPage {
                 subtype as i32
             ))
         }
-        .map(|annot| unsafe { PdfAnnotation::from_raw(annot) })
+        .map(|annot| {
+            // SAFETY: `mupdf_pdf_create_annot` returns an owned pointer (refcount = 1)
+            // and `self` (the page) is alive.
+            unsafe { PdfAnnotation::from_raw(annot) }
+        })
     }
 
     pub fn delete_annotation(&mut self, annot: &PdfAnnotation) -> Result<(), Error> {
@@ -69,14 +73,21 @@ impl PdfPage {
             ffi_try!(mupdf_pdf_delete_annot(
                 context(),
                 self.as_mut_ptr(),
-                annot.inner
+                annot.inner.as_ptr()
             ))
         }
     }
 
     pub fn annotations(&self) -> AnnotationIter {
-        let next = unsafe { pdf_first_annot(context(), self.as_ptr().cast_mut()) };
-        AnnotationIter { next }
+        let page = self.as_ptr().cast_mut();
+        let next = unsafe { pdf_first_annot(context(), page) };
+        // SAFETY: `self` is alive so `page` is valid. We keep the page so
+        // the iterator (and any annotations it yields) can outlive `self`.
+        unsafe { pdf_keep_page(context(), page) };
+        AnnotationIter {
+            next: NonNull::new(next),
+            page: unsafe { NonNull::new_unchecked(page) },
+        }
     }
 
     pub fn update(&mut self) -> Result<bool, Error> {
@@ -505,21 +516,27 @@ impl DerefMut for PdfPage {
 
 #[derive(Debug)]
 pub struct AnnotationIter {
-    next: *mut pdf_annot,
+    next: Option<NonNull<pdf_annot>>,
+    page: NonNull<pdf_page>,
 }
 
 impl Iterator for AnnotationIter {
     type Item = PdfAnnotation;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.next.is_null() {
-            return None;
-        }
-        let node = self.next;
+        let node = self.next?.as_ptr();
         unsafe {
-            self.next = pdf_next_annot(context(), node);
-            Some(PdfAnnotation::from_raw(node))
+            self.next = NonNull::new(pdf_next_annot(context(), node));
+            // SAFETY: `node` is a borrowed pointer from the page's annotation
+            // list, and `self.page` keeps the page alive.
+            Some(PdfAnnotation::from_raw_keep_ref(node))
         }
+    }
+}
+
+impl Drop for AnnotationIter {
+    fn drop(&mut self) {
+        unsafe { pdf_drop_page(context(), self.page.as_ptr()) };
     }
 }
 

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::marker::PhantomData;
 use std::{
     ffi::CStr,
     mem::ManuallyDrop,
@@ -68,7 +69,7 @@ impl PdfPage {
         })
     }
 
-    pub fn delete_annotation(&mut self, annot: &PdfAnnotation) -> Result<(), Error> {
+    pub fn delete_annotation(&mut self, annot: PdfAnnotation) -> Result<(), Error> {
         unsafe {
             ffi_try!(mupdf_pdf_delete_annot(
                 context(),
@@ -78,15 +79,11 @@ impl PdfPage {
         }
     }
 
-    pub fn annotations(&self) -> AnnotationIter {
-        let page = self.as_ptr().cast_mut();
-        let next = unsafe { pdf_first_annot(context(), page) };
-        // SAFETY: `self` is alive so `page` is valid. We keep the page so
-        // the iterator (and any annotations it yields) can outlive `self`.
-        unsafe { pdf_keep_page(context(), page) };
+    pub fn annotations(&self) -> AnnotationIter<'_> {
+        let next = unsafe { pdf_first_annot(context(), self.as_ptr().cast_mut()) };
         AnnotationIter {
             next: NonNull::new(next),
-            page: unsafe { NonNull::new_unchecked(page) },
+            marker: PhantomData,
         }
     }
 
@@ -515,12 +512,12 @@ impl DerefMut for PdfPage {
 }
 
 #[derive(Debug)]
-pub struct AnnotationIter {
+pub struct AnnotationIter<'a> {
     next: Option<NonNull<pdf_annot>>,
-    page: NonNull<pdf_page>,
+    marker: PhantomData<&'a PdfPage>,
 }
 
-impl Iterator for AnnotationIter {
+impl Iterator for AnnotationIter<'_> {
     type Item = PdfAnnotation;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -528,15 +525,10 @@ impl Iterator for AnnotationIter {
         unsafe {
             self.next = NonNull::new(pdf_next_annot(context(), node));
             // SAFETY: `node` is a borrowed pointer from the page's annotation
-            // list, and `self.page` keeps the page alive.
+            // list. The PhantomData borrow guarantees the page outlives this
+            // iterator. The yielded PdfAnnotation holds its own page refcount.
             Some(PdfAnnotation::from_raw_keep_ref(node))
         }
-    }
-}
-
-impl Drop for AnnotationIter {
-    fn drop(&mut self) {
-        unsafe { pdf_drop_page(context(), self.page.as_ptr()) };
     }
 }
 

--- a/src/pdf/tests_annotation.rs
+++ b/src/pdf/tests_annotation.rs
@@ -78,43 +78,67 @@ fn annotation_properties_and_soundness() {
     line_annot.set_intent(Intent::LineArrow).unwrap();
 }
 
+const TYPES: [PdfAnnotationType; 3] = [
+    PdfAnnotationType::Text,
+    PdfAnnotationType::Highlight,
+    PdfAnnotationType::Square,
+];
+
 #[test]
 fn annotation_iteration_and_deletion() {
     let tester = AnnotTester::new();
 
     assert_eq!(tester.page().annotations().count(), 0);
 
-    tester.create(PdfAnnotationType::Text);
-    tester.create(PdfAnnotationType::Highlight);
-    tester.create(PdfAnnotationType::Square);
+    for ty in TYPES {
+        tester.create(ty);
+    }
 
-    let first_annot = {
-        let page = tester.page();
-        let mut iter = page.annotations();
+    let page = tester.page();
+    let annots: Vec<_> = page.annotations().collect();
+    assert_eq!(annots.len(), TYPES.len());
+    for (annot, expected) in annots.iter().zip(TYPES) {
+        assert_eq!(annot.r#type().unwrap(), expected);
+    }
 
-        drop(page);
+    // Annotations remain valid after the page is dropped
+    drop(page);
+    for (annot, expected) in annots.iter().zip(TYPES) {
+        assert_eq!(annot.r#type().unwrap(), expected);
+    }
 
-        let first = iter.next().unwrap();
-        assert_eq!(first.r#type().unwrap(), PdfAnnotationType::Text);
+    let tester = AnnotTester::new();
 
-        let remaining: Vec<_> = iter.collect();
-        assert_eq!(remaining.len(), 2);
-        assert_eq!(remaining[0].r#type().unwrap(), PdfAnnotationType::Highlight);
+    for ty in TYPES {
+        tester.create(ty);
+    }
 
-        first
-    };
-
-    assert_eq!(first_annot.r#type().unwrap(), PdfAnnotationType::Text);
-
+    // Collect annotations, then delete the first one
     let mut page = tester.page();
-    page.delete_annotation(&first_annot).unwrap();
+    let mut annots: Vec<_> = page.annotations().collect();
+    let first = annots.remove(0);
+    page.delete_annotation(first).unwrap();
 
-    let final_annots: Vec<_> = page.annotations().collect();
-    assert_eq!(final_annots.len(), 2);
-    assert_eq!(
-        final_annots[0].r#type().unwrap(),
-        PdfAnnotationType::Highlight
-    );
+    let remaining: Vec<_> = page.annotations().collect();
+    assert_eq!(remaining.len(), TYPES.len() - 1);
+    for (annot, expected) in remaining.iter().zip(&TYPES[1..]) {
+        assert_eq!(annot.r#type().unwrap(), *expected);
+    }
+
+    let tester = AnnotTester::new();
+
+    for ty in TYPES {
+        tester.create(ty);
+    }
+
+    // Collect then delete all annotations
+    let mut page = tester.page();
+    let annots: Vec<_> = page.annotations().collect();
+    for annot in annots {
+        page.delete_annotation(annot).unwrap();
+    }
+
+    assert_eq!(page.annotations().count(), 0);
 }
 
 #[test]

--- a/src/pdf/tests_annotation.rs
+++ b/src/pdf/tests_annotation.rs
@@ -1,0 +1,138 @@
+use crate::pdf::{
+    annotation::AnnotationFlags, Intent, PdfAnnotationType, PdfDocument, PdfFilterOptions,
+};
+use crate::{color::AnnotationColor, Point, Rect, Size};
+
+const PAGE_SIZE: Size = Size::A4;
+
+struct AnnotTester {
+    doc: PdfDocument,
+}
+
+impl AnnotTester {
+    fn new() -> Self {
+        let mut doc = PdfDocument::new();
+        doc.new_page(PAGE_SIZE).unwrap();
+        Self { doc }
+    }
+
+    fn page(&self) -> crate::pdf::PdfPage {
+        self.doc.load_pdf_page(0).unwrap()
+    }
+
+    fn create(&self, ty: PdfAnnotationType) -> crate::pdf::PdfAnnotation {
+        self.page().create_annotation(ty).unwrap()
+    }
+}
+
+#[test]
+fn annotation_properties_and_soundness() {
+    let tester = AnnotTester::new();
+
+    let mut text_annot = tester.create(PdfAnnotationType::Text);
+    let mut square_annot = tester.create(PdfAnnotationType::Square);
+    let mut line_annot = tester.create(PdfAnnotationType::Line);
+
+    assert_eq!(text_annot.r#type().unwrap(), PdfAnnotationType::Text);
+    assert_eq!(square_annot.r#type().unwrap(), PdfAnnotationType::Square);
+    assert_eq!(line_annot.r#type().unwrap(), PdfAnnotationType::Line);
+
+    assert!(!text_annot.is_hot());
+    text_annot.set_hot(true);
+    assert!(text_annot.is_hot());
+
+    assert!(!text_annot.is_active());
+    text_annot.set_active(true).unwrap();
+    assert!(text_annot.is_active());
+
+    let author = text_annot.author().unwrap();
+    assert!(author.is_none() || author == Some(""));
+    text_annot.set_author("Tester").unwrap();
+    assert_eq!(text_annot.author().unwrap(), Some("Tester"));
+
+    text_annot
+        .set_popup(Rect::new(100.0, 100.0, 300.0, 200.0))
+        .unwrap();
+    text_annot
+        .set_flags(AnnotationFlags::IS_PRINT | AnnotationFlags::IS_LOCKED)
+        .unwrap();
+
+    square_annot
+        .set_rect(Rect::new(10.0, 20.0, 100.0, 80.0))
+        .unwrap();
+    square_annot
+        .set_color(AnnotationColor::Rgb {
+            red: 1.0,
+            green: 0.0,
+            blue: 0.0,
+        })
+        .unwrap();
+    square_annot.set_border_width(2.5).unwrap();
+
+    let mut freetext_annot = tester.create(PdfAnnotationType::FreeText);
+    freetext_annot.filter(PdfFilterOptions::default()).unwrap();
+
+    line_annot
+        .set_line(Point { x: 10.0, y: 20.0 }, Point { x: 200.0, y: 300.0 })
+        .unwrap();
+    line_annot.set_intent(Intent::LineArrow).unwrap();
+}
+
+#[test]
+fn annotation_iteration_and_deletion() {
+    let tester = AnnotTester::new();
+
+    assert_eq!(tester.page().annotations().count(), 0);
+
+    tester.create(PdfAnnotationType::Text);
+    tester.create(PdfAnnotationType::Highlight);
+    tester.create(PdfAnnotationType::Square);
+
+    let first_annot = {
+        let page = tester.page();
+        let mut iter = page.annotations();
+
+        drop(page);
+
+        let first = iter.next().unwrap();
+        assert_eq!(first.r#type().unwrap(), PdfAnnotationType::Text);
+
+        let remaining: Vec<_> = iter.collect();
+        assert_eq!(remaining.len(), 2);
+        assert_eq!(remaining[0].r#type().unwrap(), PdfAnnotationType::Highlight);
+
+        first
+    };
+
+    assert_eq!(first_annot.r#type().unwrap(), PdfAnnotationType::Text);
+
+    let mut page = tester.page();
+    page.delete_annotation(&first_annot).unwrap();
+
+    let final_annots: Vec<_> = page.annotations().collect();
+    assert_eq!(final_annots.len(), 2);
+    assert_eq!(
+        final_annots[0].r#type().unwrap(),
+        PdfAnnotationType::Highlight
+    );
+}
+
+#[test]
+fn annotations_from_different_pages() {
+    let mut doc = PdfDocument::new();
+    doc.new_page(PAGE_SIZE).unwrap();
+    doc.new_page(PAGE_SIZE).unwrap();
+
+    let (annot0, annot1) = {
+        let mut page0 = doc.load_pdf_page(0).unwrap();
+        let mut page1 = doc.load_pdf_page(1).unwrap();
+        let a0 = page0.create_annotation(PdfAnnotationType::Text).unwrap();
+        let a1 = page1
+            .create_annotation(PdfAnnotationType::Highlight)
+            .unwrap();
+        (a0, a1)
+    };
+
+    assert_eq!(annot0.r#type().unwrap(), PdfAnnotationType::Text);
+    assert_eq!(annot1.r#type().unwrap(), PdfAnnotationType::Highlight);
+}


### PR DESCRIPTION
Closes #205

`PdfAnnotation` held a raw `*mut pdf_annot` without preventing the parent page from being freed. Since MuPDF's returns `pdf_annot->page` that is a borrowed (non-ref-counted) back-pointer, dropping the `PdfPage` while annotations were still alive caused use-after-free.

**Changes:**

- `PdfAnnotation` now stores a ref-counted `NonNull<pdf_page>` that keeps the parent page alive
- Added `from_raw_keep_ref` for borrowed annotation pointers (used by the iterator)
- `AnnotationIter` keeps the page alive and uses correct refcounting

Added 3 soundness tests
