### PR TITLE
Add owned PdfString/PdfVec types to fix UB with `PdfObject` `as_string`, `as_name`, `as_bytes` methods

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -129,6 +129,27 @@ jobs:
           RUSTDOCFLAGS: -Zsanitizer=address
           LSAN_OPTIONS: report_objects=1:suppressions=lsan_suppressions.txt
 
+      - name: cargo test -p compact_cstr
+        run: cargo test -Zbuild-std --target x86_64-unknown-linux-gnu -p compact_cstr
+        env:
+          RUSTFLAGS: -Zsanitizer=address
+          LSAN_OPTIONS: report_objects=1:suppressions=lsan_suppressions.txt
+
+  miri:
+    name: Miri (compact_cstr)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+
+      - run: cargo miri setup
+      - name: cargo miri test -p compact_cstr
+        run: cargo miri test -p compact_cstr
+        env:
+          MIRIFLAGS: -Zmiri-strict-provenance
+
   valgrind:
     name: Valgrind
     runs-on: ubuntu-latest
@@ -146,6 +167,10 @@ jobs:
         run: curl -LO https://github.com/tesseract-ocr/tessdata/raw/main/eng.traineddata
 
       - run: cargo test --features serde
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "valgrind --error-exitcode=1 --track-origins=yes"
+
+      - run: cargo test -p compact_cstr
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "valgrind --error-exitcode=1 --track-origins=yes"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ bitflags = "2.0.2"
 percent-encoding = "2.3.1"
 serde = { version = "1.0.201", features = ["derive"], optional = true }
 zerocopy = { version = "0.8.17", features = ["derive"] }
+compact_cstr = { path = "compact_cstr" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 font-kit = { version = "0.14.1", optional = true }
@@ -85,7 +86,8 @@ font-kit = { version = "0.14.1", optional = true }
 [workspace]
 members = [
     ".",
-    "mupdf-sys"
+    "mupdf-sys",
+    "compact_cstr"
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ bitflags = "2.0.2"
 percent-encoding = "2.3.1"
 serde = { version = "1.0.201", features = ["derive"], optional = true }
 zerocopy = { version = "0.8.17", features = ["derive"] }
-compact_cstr = { path = "compact_cstr" }
+compact_cstr = { version = "0.7.0", path = "compact_cstr" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 font-kit = { version = "0.14.1", optional = true }

--- a/compact_cstr/Cargo.toml
+++ b/compact_cstr/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 description = "Compact, NUL-terminated owned byte/string types used by mupdf-rs"
 license = "AGPL-3.0"
 repository = "https://github.com/messense/mupdf-rs"
-publish = false
 
 [dependencies]
 ecow = "0.2"

--- a/compact_cstr/Cargo.toml
+++ b/compact_cstr/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "compact_cstr"
+version.workspace = true
+edition.workspace = true
+description = "Compact, NUL-terminated owned byte/string types used by mupdf-rs"
+license = "AGPL-3.0"
+repository = "https://github.com/messense/mupdf-rs"
+publish = false
+
+[dependencies]
+ecow = "0.2"
+memchr = "2"
+
+[dev-dependencies]
+proptest = "1"

--- a/compact_cstr/src/error.rs
+++ b/compact_cstr/src/error.rs
@@ -1,0 +1,78 @@
+//! Error types returned by fallible constructors.
+
+use core::error::Error;
+use core::fmt;
+use core::str::Utf8Error;
+
+/// The supplied bytes contained a NUL (`b'\0'`) byte.
+///
+/// [`CompactCBytes`](crate::CompactCBytes) and [`CompactCString`](crate::CompactCString)  are internally
+/// NUL-terminated, so payloads cannot contain NUL bytes.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct NulError {
+    /// Byte index of the first interior NUL.
+    pub position: usize,
+}
+
+impl NulError {
+    /// Returns the byte index of the first interior NUL byte found.
+    #[inline]
+    pub const fn position(&self) -> usize {
+        self.position
+    }
+
+    #[inline]
+    pub(crate) const fn at(position: usize) -> Self {
+        Self { position }
+    }
+}
+
+impl fmt::Display for NulError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "interior NUL byte at position {}", self.position)
+    }
+}
+
+impl Error for NulError {}
+
+/// Error returned when constructing a [`CompactCString`](crate::CompactCString) from raw
+/// bytes that may be neither NUL-free nor valid UTF-8.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FromBytesError {
+    /// The input contained an interior NUL byte.
+    InteriorNul(NulError),
+    /// The input was not valid UTF-8.
+    InvalidUtf8(Utf8Error),
+}
+
+impl fmt::Display for FromBytesError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InteriorNul(e) => write!(f, "{e}"),
+            Self::InvalidUtf8(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl Error for FromBytesError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InteriorNul(e) => Some(e),
+            Self::InvalidUtf8(e) => Some(e),
+        }
+    }
+}
+
+impl From<NulError> for FromBytesError {
+    #[inline]
+    fn from(e: NulError) -> Self {
+        Self::InteriorNul(e)
+    }
+}
+
+impl From<Utf8Error> for FromBytesError {
+    #[inline]
+    fn from(e: Utf8Error) -> Self {
+        Self::InvalidUtf8(e)
+    }
+}

--- a/compact_cstr/src/lib.rs
+++ b/compact_cstr/src/lib.rs
@@ -1,0 +1,58 @@
+//! Owned, NUL-terminated byte/string types for safe MuPDF FFI.
+//!
+//! [`CompactCBytes`] and [`CompactCString`] use a compact 24-byte representation: up to
+//! 23 payload bytes are stored inline, while larger payloads spill to a
+//! reference-counted [`ecow::EcoVec<u8>`].
+//!
+//! Both types maintain a trailing NUL for allocation-free `&CStr` access and
+//! reject payload NUL bytes during checked construction. [`CompactCString`] also
+//! guarantees valid UTF-8.
+//!
+//! Their layout supports niche optimization, so [`Option<CompactCBytes>`] and
+//! [`Option<CompactCString>`] have no extra size overhead.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(rustdoc::broken_intra_doc_links)]
+
+use core::mem::{align_of, size_of};
+
+mod error;
+mod repr;
+
+/// Generates `PartialEq` implementations.
+macro_rules! impl_partial_eq {
+    ($(impl PartialEq<$rhs:ty> for $lhs:ty { |$self_:ident, $other:ident| $body:expr })*) => {$(
+        impl PartialEq<$rhs> for $lhs {
+            #[inline]
+            fn eq(&$self_, $other: &$rhs) -> bool {
+                $body
+            }
+        }
+    )*};
+}
+
+pub mod string;
+pub mod vector;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::{FromBytesError, NulError};
+pub use repr::INLINE_TOTAL;
+pub use string::CompactCString;
+pub use vector::CompactCBytes;
+
+use repr::Repr;
+
+// Size guarantees
+const _: () = assert!(size_of::<CompactCString>() == INLINE_TOTAL);
+const _: () = assert!(size_of::<CompactCString>() == size_of::<CompactCBytes>());
+
+// Alignment guarantees
+const _: () = assert!(align_of::<CompactCString>() == align_of::<Repr>());
+const _: () = assert!(align_of::<CompactCString>() == align_of::<CompactCBytes>());
+
+// Niche optimization guarantees
+const _: () = assert!(size_of::<Option<CompactCString>>() == size_of::<CompactCString>());
+const _: () = assert!(size_of::<Result<CompactCString, ()>>() == size_of::<CompactCString>());
+const _: () = assert!(size_of::<Option<CompactCBytes>>() == size_of::<CompactCBytes>());
+const _: () = assert!(size_of::<Result<CompactCBytes, ()>>() == size_of::<CompactCBytes>());

--- a/compact_cstr/src/repr.rs
+++ b/compact_cstr/src/repr.rs
@@ -1,0 +1,552 @@
+//! Core 24-byte representation shared by [`CompactCBytes`](crate::CompactCBytes) and
+//! [`CompactCString`](crate::CompactCString).
+//!
+//! It compactly stores up to 23 bytes inline or spills to the heap. The
+//! 24th byte stores either the inline remainder tag or the heap discriminant.
+//! For a fully packed inline value it also serves as the trailing NUL byte.
+//!
+//! # Acknowledgements
+//!
+//! The "magic last byte as discriminant" trick is inspired by the `ecow::EcoString` implementation
+//! from the https://crates.io/crates/ecow crate. The niche optimization technique (making `Option<T>` zero-cost)
+//! and the **pointer-typed first field that preserves provenance** are inspired by the `compact_str::CompactString`
+//! implementation from the https://crates.io/crates/compact_str.
+
+use core::ffi::CStr;
+use core::mem::{align_of, size_of, ManuallyDrop};
+use core::slice;
+
+use ecow::EcoVec;
+
+use crate::NulError;
+
+/// Total byte footprint of `Repr` including the discriminant byte.
+pub const INLINE_TOTAL: usize = 24;
+
+/// Maximum payload bytes in inline mode (the 24th byte is the discriminant).
+const INLINE_CAPACITY: usize = INLINE_TOTAL - 1;
+
+/// Byte value that marks heap storage.
+const SPILLED_LAST_BYTE: u8 = INLINE_TOTAL as u8;
+
+/// Length of the trailing byte tail in `Repr`, after the two pointer-sized words and before the
+/// 1-byte discriminant. On 64-bit this is 7, on 32-bit it is 15.
+const TAIL_LENGTH: usize = INLINE_CAPACITY - 2 * size_of::<usize>();
+
+/// Padding between the `EcoVec` and the discriminant byte in `HeapRepr`.
+const PAD_LENGTH: usize = INLINE_TOTAL - size_of::<EcoVec<u8>>() - size_of::<HeapLastByte>();
+
+/// Canonical 24-byte storage type.
+///
+/// # Why the first field is pointer-typed
+///
+/// The first word is `*const u8` rather than `[u8; 8]` to preserve pointer
+/// provenance for the heap variant.
+///
+/// For inline values this slot is just payload bytes and is never read as a
+/// pointer. This follows the same layout idea as [`compact_str::CompactString`].
+///
+/// # The Magic 24th Byte
+///
+/// The entire memory layout revolves around the 24th byte (`last`), which
+/// serves four distinct purposes at once:
+///
+/// 1. Inline Length Tag: For inline strings, the last byte encodes the `remaining capacity`
+///    using the formula `rem = INLINE_TOTAL - (len + 1)`. If you store a 10-byte string,
+///    the last byte is `24 - 10 - 1 = 13`. For a 23-byte string, the last byte becomes
+///    `24 - 23 - 1 = 0`, meaning it also will serve as the NUL terminator.
+///
+/// 2. NUL Terminator: By storing the remainder rather than the length, a fully packed
+///    23-byte inline string results in `rem = 24 - (23 + 1) = 0`. Thus, the 24th byte
+///    becomes `0` (`\0`), acting as the C-string NUL terminator. For shorter strings,
+///    the unused bytes are zero-padded, ensuring a NUL is always present at `bytes[len]`.
+///
+/// 3. Heap Marker: If the slice exceeds 23 bytes, it spills to an `EcoVec`. The 24th byte
+///    is then set to `24` (`LastByte::Spilled`), which marks a heap allocation.
+///
+/// 4. Niche Optimization Room: Because `last` only ever takes on valid values from `0..=24`,
+///    the remaining bit patterns (25..=255) are unused by `LastByte`. The Rust compiler can
+///    use these for "niche" optimization, meaning `Option<Repr>` will be the same size as
+///    `Repr`. This is why we don't use a `union` for the `Repr` layout, since the compiler
+///    could not recognize the optimization room for unions (inspired by [`compact_str::CompactString`]).
+///
+/// [`compact_str::CompactString`]: https://docs.rs/compact_str/latest/compact_str/struct.CompactString.html
+#[cfg(target_pointer_width = "64")]
+#[repr(C, align(8))]
+pub(super) struct Repr {
+    /// Pointer-typed slot. Heap: `EcoVec`'s data pointer (with provenance). Inline: raw bytes.
+    ptr: *const u8,
+    /// Heap: `EcoVec`'s `len`. Inline: payload bytes 8..16.
+    len: usize,
+    /// Heap: padding before the discriminant. Inline: payload bytes 16..23.
+    tail: [u8; TAIL_LENGTH],
+    /// Discriminant: inline remainder, or `Spilled` for heap.
+    last: LastByte,
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(C, align(4))]
+pub(super) struct Repr {
+    ptr: *const u8,
+    len: usize,
+    tail: [u8; TAIL_LENGTH],
+    last: LastByte,
+}
+
+/// Byte-typed staging layout for the inline variant.
+///
+/// Has the same size and alignment as [`Repr`], so a `mem::transmute` between them is layout-
+/// correct. Inline values are constructed into an `InlineRepr` (where every byte is plain `u8`
+/// and we can write fields directly in `const fn`) and then transmuted into a `Repr`. The
+/// resulting `Repr.ptr` value has no provenance, which is fine because inline access never
+/// reads it as a pointer.
+#[cfg(target_pointer_width = "64")]
+#[repr(C, align(8))]
+#[derive(Copy, Clone)]
+struct InlineRepr {
+    bytes: [u8; INLINE_CAPACITY],
+    last: LastByte,
+}
+
+#[cfg(target_pointer_width = "32")]
+#[repr(C, align(4))]
+#[derive(Copy, Clone)]
+struct InlineRepr {
+    bytes: [u8; INLINE_CAPACITY],
+    last: LastByte,
+}
+
+/// Discriminant stored in the 24th byte (index 23) of every `Repr`.
+///
+/// For inline variants the value encodes "remaining capacity":
+/// `InlineRem23` (= 23) means the buffer is empty (0 content bytes + 1 NUL = 1 byte used),
+/// `InlineRem0` (= 0) means the buffer is fully packed (23 content bytes + 1 NUL = 24 bytes).
+///
+/// `Spilled` (= 24) is impossible for any inline variant because the remainder can never exceed 23.
+/// This unused value becomes the heap discriminant and provides a niche for `Option` optimization.
+#[allow(dead_code)] // variants are layout markers, not constructed directly, so we allow dead code
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+enum LastByte {
+    InlineRem0 = 0,
+    InlineRem1 = 1,
+    InlineRem2 = 2,
+    InlineRem3 = 3,
+    InlineRem4 = 4,
+    InlineRem5 = 5,
+    InlineRem6 = 6,
+    InlineRem7 = 7,
+    InlineRem8 = 8,
+    InlineRem9 = 9,
+    InlineRem10 = 10,
+    InlineRem11 = 11,
+    InlineRem12 = 12,
+    InlineRem13 = 13,
+    InlineRem14 = 14,
+    InlineRem15 = 15,
+    InlineRem16 = 16,
+    InlineRem17 = 17,
+    InlineRem18 = 18,
+    InlineRem19 = 19,
+    InlineRem20 = 20,
+    InlineRem21 = 21,
+    InlineRem22 = 22,
+    InlineRem23 = INLINE_CAPACITY as u8,
+    Spilled = SPILLED_LAST_BYTE,
+}
+
+impl LastByte {
+    /// Returns `true` if this discriminant indicates heap storage.
+    #[inline(always)]
+    const fn is_heap(self) -> bool {
+        // Use byte comparison because `PartialEq` is not stable in const functions.
+        self as u8 == Self::Spilled as u8
+    }
+
+    /// Constructs an inline discriminant from the number of unused bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `rem > 23`.
+    #[inline(always)]
+    const fn from_inline_rem(rem: usize) -> Self {
+        assert!(rem <= 23, "inline remainder must be in 0..=23");
+        // SAFETY: `rem <= 23`, and all values in `0..=23` are valid `LastByte` variants.
+        unsafe { core::mem::transmute(rem as u8) }
+    }
+}
+
+/// Heap-only last-byte tag. Guarantees that byte 23 of [`HeapRepr`] is always
+/// [`SPILLED_LAST_BYTE`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+enum HeapLastByte {
+    Spilled = SPILLED_LAST_BYTE,
+}
+
+/// Layout for the heap variant.
+///
+/// Whenever this is constructed, we make sure to push a trailing NUL byte to the
+/// end of the `EcoVec<u8>`. It is unsound to construct this without the trailing
+/// NUL.
+///
+/// Padding aligns the discriminant to byte 23, matching `Repr::last`.
+///
+/// `EcoVec<u8>` is `(NonNull<u8>, usize, PhantomData)`, so its first word is pointer-typed.
+/// That word lines up with [`Repr`]'s pointer-typed `ptr` field, so
+/// `mem::transmute<HeapRepr, Repr>` carries the data pointer's provenance through.
+#[repr(C)]
+pub(super) struct HeapRepr {
+    vector: ManuallyDrop<EcoVec<u8>>,
+    _pad: [u8; PAD_LENGTH],
+    last: HeapLastByte,
+}
+
+impl HeapRepr {
+    /// Wraps an `EcoVec` into a heap repr with `Spilled` discriminant.
+    ///
+    /// # Safety
+    ///
+    /// `vector` must end with one NUL byte and contain no interior NULs.
+    #[inline]
+    const unsafe fn new(vector: EcoVec<u8>) -> Self {
+        Self {
+            vector: ManuallyDrop::new(vector),
+            _pad: [0; PAD_LENGTH],
+            last: HeapLastByte::Spilled,
+        }
+    }
+
+    /// Borrows the underlying `EcoVec`.
+    #[inline]
+    fn vector(&self) -> &EcoVec<u8> {
+        &self.vector
+    }
+
+    /// Drops the `EcoVec` in place. Must be called exactly once.
+    ///
+    /// # Safety
+    ///
+    /// `self.vector` must be initialized and must not be used again after this call.
+    #[inline]
+    unsafe fn drop_vector(&mut self) {
+        // SAFETY: caller guarantees this is the first and final drop of `self.vector`
+        unsafe { ManuallyDrop::drop(&mut self.vector) };
+    }
+}
+
+impl Repr {
+    /// Creates a `Repr` from a `CStr`, going inline if possible.
+    #[inline]
+    pub(super) fn from_cstr(c_str: &CStr) -> Self {
+        let bytes_with_nul = c_str.to_bytes_with_nul();
+        // to_bytes_with_nul returns slice with length at least 1
+        let len = bytes_with_nul.len() - 1;
+
+        // SAFETY: `CStr` payload contains no interior NULs by definition.
+        unsafe {
+            if len < INLINE_TOTAL {
+                Self::inline_unchecked(&bytes_with_nul[..len])
+            } else {
+                Self::from_heap(HeapRepr::new(EcoVec::from(bytes_with_nul)))
+            }
+        }
+    }
+
+    /// Creates a `Repr` from a byte slice, appending a NUL terminator.
+    ///
+    /// Returns an error if `bytes` contains an interior NUL.
+    #[inline]
+    pub(super) fn from_slice(bytes: &[u8]) -> Result<Self, NulError> {
+        match memchr::memchr(0, bytes) {
+            Some(position) => Err(NulError::at(position)),
+            // SAFETY: `bytes` contains no NUL bytes.
+            None => Ok(unsafe { Self::from_slice_unchecked(bytes) }),
+        }
+    }
+
+    /// Creates a `Repr` from a byte slice, appending a NUL terminator,
+    /// without checking for interior NULs.
+    ///
+    /// # Safety
+    ///
+    /// `bytes` must not contain any `0` byte.
+    #[inline]
+    pub(super) unsafe fn from_slice_unchecked(bytes: &[u8]) -> Self {
+        if bytes.len() < INLINE_TOTAL {
+            // SAFETY: The caller guarantees that `bytes` contain no `0` byte.
+            unsafe { Self::inline_unchecked(bytes) }
+        } else {
+            let mut vector = EcoVec::with_capacity(bytes.len() + 1);
+            vector.extend_from_slice(bytes);
+            vector.push(0);
+            // SAFETY: The caller guarantees that `bytes` contain no `0` byte.
+            Self::from_heap(unsafe { HeapRepr::new(vector) })
+        }
+    }
+
+    #[inline(always)]
+    pub(super) const fn try_inline(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() > INLINE_CAPACITY {
+            return None;
+        }
+
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == 0 {
+                return None;
+            }
+            i += 1;
+        }
+
+        // SAFETY:
+        // - bytes.len() <= INLINE_CAPACITY;
+        // - bytes contains no NUL bytes.
+        Some(unsafe { Self::inline_unchecked(bytes) })
+    }
+
+    /// Packs raw bytes without a NUL terminator into the inline representation.
+    ///
+    /// # Safety
+    ///
+    /// `bytes.len()` must be at most [`INLINE_CAPACITY`], and `bytes` must not
+    /// contain any NUL byte.
+    #[inline(always)]
+    const unsafe fn inline_unchecked(bytes: &[u8]) -> Self {
+        let len = bytes.len();
+        debug_assert!(len < INLINE_TOTAL);
+
+        let mut data = [0_u8; INLINE_CAPACITY];
+
+        // SAFETY:
+        // - `data.as_mut_ptr()` is non-null and points to `INLINE_CAPACITY` initialized bytes.
+        // - Caller guarantees `len <= INLINE_CAPACITY`.
+        let dst = unsafe { slice::from_raw_parts_mut(data.as_mut_ptr(), len) };
+        dst.copy_from_slice(bytes);
+
+        // rem is the space left after the string + its logical NUL
+        let rem = INLINE_TOTAL - (len + 1);
+
+        // The `data` was initialized with zeros, so it automatically has a NUL terminator
+        // after copying from the slice for payloads under 23 bytes. For exactly 23 bytes,
+        // the calculated `rem` (0) in the 24th byte serves as the NUL.
+        Self::from_inline(InlineRepr {
+            bytes: data,
+            last: LastByte::from_inline_rem(rem),
+        })
+    }
+
+    #[inline(always)]
+    const fn from_inline(inline: InlineRepr) -> Self {
+        // SAFETY: `Repr` and `InlineRepr` have the same size and alignment, asserted below.
+        // `*const u8` accepts any bit pattern, so reinterpreting bytes as it is valid.
+        unsafe { core::mem::transmute(inline) }
+    }
+
+    /// Transmutes a [`HeapRepr`] into a `Repr`, preserving pointer provenance.
+    #[inline(always)]
+    const fn from_heap(spilled: HeapRepr) -> Self {
+        // SAFETY:
+        // - `Repr` and `HeapRepr` have the same size and alignment, asserted below.
+        // - The `EcoVec`'s pointer-typed first word lines up with `Repr.ptr` (also pointer-typed),
+        //   so provenance is preserved.
+        // - The final byte is at the same offset in both layouts, and `HeapLastByte::Spilled`
+        //   has the same byte value as `LastByte::Spilled`.
+        unsafe { core::mem::transmute(spilled) }
+    }
+
+    /// Returns `true` if the data is heap-allocated.
+    #[inline]
+    pub(super) const fn is_heap(&self) -> bool {
+        self.last.is_heap()
+    }
+
+    /// Returns the payload length in bytes (without the trailing NUL).
+    #[inline]
+    pub(super) fn len(&self) -> usize {
+        if self.is_heap() {
+            // SAFETY: data is heap-allocated, as checked above.
+            let heap = unsafe { self.as_heap() };
+            // HeapRepr invariant: vector always ends with a trailing NUL byte.
+            heap.vector().len() - 1
+        } else {
+            // SAFETY: data is stored inline, as checked above.
+            unsafe { self.inline_len() }
+        }
+    }
+
+    /// Returns the payload bytes without the trailing NUL.
+    #[inline]
+    pub(super) fn to_bytes(&self) -> &[u8] {
+        if self.is_heap() {
+            // SAFETY: data is heap-allocated, as checked above.
+            let heap = unsafe { self.as_heap() };
+            let slice = heap.vector().as_slice();
+            debug_assert!(!slice.is_empty());
+            debug_assert_eq!(slice[slice.len() - 1], 0);
+            &slice[..slice.len() - 1]
+        } else {
+            // SAFETY: data is stored inline, as checked above.
+            let len = unsafe { self.inline_len() };
+
+            // SAFETY:
+            // - inline data is stored in bytes 0..23 of `Repr`
+            // - `len <= INLINE_CAPACITY = 23`, so the slice stays within the struct
+            // - Repr.ptr and other bytes of structure are read as data, not as a pointer
+            unsafe { slice::from_raw_parts((self as *const Self).cast::<u8>(), len) }
+        }
+    }
+
+    /// Returns the content as a `&CStr` without allocation.
+    #[inline]
+    pub(super) fn as_cstr(&self) -> &CStr {
+        if self.is_heap() {
+            // SAFETY: data is heap-allocated, as checked above.
+            let spilled = unsafe { self.as_heap() };
+            // SAFETY: HeapRepr invariant guarantees exactly one trailing NUL and no interior NULs.
+            unsafe { CStr::from_bytes_with_nul_unchecked(spilled.vector().as_slice()) }
+        } else {
+            // SAFETY: data is stored inline, as checked above.
+            let bytes_with_nul = unsafe { self.inline_bytes_with_nul() };
+            // SAFETY: inline invariant guarantees exactly one trailing NUL and no interior NULs.
+            unsafe { CStr::from_bytes_with_nul_unchecked(bytes_with_nul) }
+        }
+    }
+
+    /// Returns the payload length for an inline variant.
+    ///
+    /// # Safety
+    ///
+    /// Must only be called when `!is_heap()`.
+    #[inline]
+    const unsafe fn inline_len(&self) -> usize {
+        debug_assert!(!self.is_heap());
+        INLINE_CAPACITY - self.last as u8 as usize
+    }
+
+    /// Reinterprets `&self` as `&HeapRepr`.
+    ///
+    /// # Safety
+    ///
+    /// Must only be called when `is_heap()`.
+    #[inline]
+    const unsafe fn as_heap(&self) -> &HeapRepr {
+        debug_assert!(self.is_heap());
+        // SAFETY: caller guarantees this is the heap variant. `Repr` and `HeapRepr` have the same
+        // size and alignment (asserted at the bottom), and `Repr.ptr` is pointer-
+        // typed so the `EcoVec` pointer's provenance is intact.
+        unsafe { &*(self as *const Self).cast::<HeapRepr>() }
+    }
+
+    /// Reinterprets `&mut self` as `&mut HeapRepr`.
+    ///
+    /// # Safety
+    ///
+    /// Must only be called when `is_heap()`. The returned reference must
+    /// preserve all `HeapRepr` invariants.
+    #[inline]
+    unsafe fn as_mut_heap(&mut self) -> &mut HeapRepr {
+        debug_assert!(self.is_heap());
+        // SAFETY: caller guarantees this is the heap variant. The layout
+        // compatibility is asserted below.
+        unsafe { &mut *(self as *mut Self).cast::<HeapRepr>() }
+    }
+
+    /// Returns a slice covering `payload + NUL` for the inline variant.
+    ///
+    /// # Safety
+    ///
+    /// Must only be called when `!is_heap()`.
+    #[inline]
+    const unsafe fn inline_bytes_with_nul(&self) -> &[u8] {
+        debug_assert!(!self.is_heap());
+
+        // SAFETY: caller guarantees this is the inline variant
+        let len_with_nul = unsafe { self.inline_len() } + 1;
+
+        // SAFETY:
+        // 1. `Repr` is `#[repr(C)]`, so its inline payload + discriminant byte form a contiguous
+        //    24-byte block in memory.
+        // 2. Since `self.inline_len() <= 23`, `len_with_nul <= 24`. We will never read past
+        //    the bounds of the struct.
+        unsafe { slice::from_raw_parts((self as *const Self).cast::<u8>(), len_with_nul) }
+    }
+}
+
+/// Default is an empty inline string (0 payload bytes, remainder = 23).
+impl Default for Repr {
+    #[inline]
+    fn default() -> Self {
+        Self::from_inline(InlineRepr {
+            bytes: [0u8; INLINE_CAPACITY],
+            last: LastByte::InlineRem23,
+        })
+    }
+}
+
+impl Clone for Repr {
+    /// Clones the representation. This is a fast, `O(1)` operation.
+    ///
+    /// - Inline: Performs a simple bitwise copy of the 24-byte struct.
+    /// - Heap: Cheaply increments the reference count of the underlying [`EcoVec`].
+    #[inline]
+    fn clone(&self) -> Self {
+        if self.is_heap() {
+            // SAFETY: data is heap-allocated, as checked above.
+            let spilled = unsafe { self.as_heap() };
+            let cloned = spilled.vector().clone();
+            // SAFETY: cloning preserves the heap invariant of the original `EcoVec`.
+            Repr::from_heap(unsafe { HeapRepr::new(cloned) })
+        } else {
+            // Inline values own no heap resource. Copy through `InlineRepr`
+            // rather than `Repr`, since `Repr` has a pointer field and `Drop`.
+            //
+            // SAFETY: inline variant, as checked above. `InlineRepr` has the
+            // same layout and is plain byte storage plus a valid `LastByte`.
+            let inline = unsafe { (self as *const Self).cast::<InlineRepr>().read() };
+            Self::from_inline(inline)
+        }
+    }
+}
+
+impl Drop for Repr {
+    #[inline]
+    fn drop(&mut self) {
+        if self.is_heap() {
+            // SAFETY: data is heap-allocated (checked above), and this is the first
+            // and final drop of `self`
+            unsafe { self.as_mut_heap().drop_vector() };
+        }
+    }
+}
+
+// SAFETY: `EcoVec<u8>` is `Send + Sync`, and the inline variant is plain bytes
+// (`Repr::ptr` is never dereferenced for inline values)
+unsafe impl Send for Repr {}
+unsafe impl Sync for Repr {}
+
+// Base type guarantees
+const _: () = assert!(size_of::<EcoVec<u8>>() == 2 * size_of::<usize>());
+const _: () = assert!(size_of::<LastByte>() == 1);
+const _: () = assert!(size_of::<HeapLastByte>() == size_of::<LastByte>());
+const _: () = assert!(align_of::<HeapLastByte>() == align_of::<LastByte>());
+const _: () = assert!(HeapLastByte::Spilled as u8 == LastByte::Spilled as u8);
+
+// Size guarantees
+const _: () = assert!(size_of::<Repr>() == INLINE_TOTAL);
+const _: () = assert!(size_of::<InlineRepr>() == INLINE_TOTAL);
+const _: () = assert!(size_of::<HeapRepr>() == INLINE_TOTAL);
+
+// Alignment guarantees
+const _: () = assert!(align_of::<Repr>() == align_of::<HeapRepr>());
+const _: () = assert!(align_of::<Repr>() == align_of::<InlineRepr>());
+const _: () = assert!(align_of::<HeapRepr>() == align_of::<EcoVec<u8>>());
+
+// Field offset guarantees: ensures `Repr.ptr` lines up with `EcoVec.ptr` (offset 0), `Repr.len`
+// lines up with `EcoVec.len`, and the discriminant sits at byte 23 in every layout.
+const _: () = assert!(core::mem::offset_of!(Repr, ptr) == 0);
+const _: () = assert!(core::mem::offset_of!(Repr, len) == size_of::<usize>());
+const _: () = assert!(core::mem::offset_of!(Repr, tail) == 2 * size_of::<usize>());
+const _: () = assert!(core::mem::offset_of!(Repr, last) == INLINE_TOTAL - 1);
+const _: () = assert!(core::mem::offset_of!(InlineRepr, last) == INLINE_TOTAL - 1);
+const _: () = assert!(core::mem::offset_of!(HeapRepr, last) == INLINE_TOTAL - 1);

--- a/compact_cstr/src/repr.rs
+++ b/compact_cstr/src/repr.rs
@@ -195,6 +195,12 @@ enum HeapLastByte {
 /// `EcoVec<u8>` is `(NonNull<u8>, usize, PhantomData)`, so its first word is pointer-typed.
 /// That word lines up with [`Repr`]'s pointer-typed `ptr` field, so
 /// `mem::transmute<HeapRepr, Repr>` carries the data pointer's provenance through.
+///
+/// KNOWN ISSUE: this representation depends on `ecow::EcoVec`'s private field order and layout.
+/// The size/alignment assertions below catch some incompatible changes, but cannot prove the
+/// `EcoVec` pointer remains at byte offset 0 or that its length remains the second word. If `ecow`
+/// changes that private layout, the transmute-based heap representation must be redesigned or the
+/// dependency pinned to a version whose layout has been audited.
 #[repr(C)]
 pub(super) struct HeapRepr {
     vector: ManuallyDrop<EcoVec<u8>>,

--- a/compact_cstr/src/string.rs
+++ b/compact_cstr/src/string.rs
@@ -1,0 +1,300 @@
+//! Owned, NUL-terminated, UTF-8 validated string for PDF text values.
+
+use core::ffi::{c_char, CStr};
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::ops::Deref;
+use core::str::{FromStr, Utf8Error};
+use std::borrow::{Borrow, Cow};
+use std::ffi::CString;
+
+use crate::error::{FromBytesError, NulError};
+use crate::vector::CompactCBytes;
+
+/// An owned, UTF-8 validated string with a compact 24-byte representation.
+///
+/// `CompactCString` is a wrapper around [`CompactCBytes`] that additionally guarantees
+/// that the payload is valid UTF-8.
+#[derive(Debug, Default, Clone, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct CompactCString(CompactCBytes);
+
+impl CompactCString {
+    /// Creates a `CompactCString` from a `CompactCBytes` without checking UTF-8 validity.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `vec` contains valid UTF-8.
+    #[inline]
+    pub unsafe fn from_utf8_unchecked(vec: CompactCBytes) -> Self {
+        Self(vec)
+    }
+
+    /// Constructs a `CompactCString` from a `CStr` without checking UTF-8 validity.
+    ///
+    /// # Safety
+    ///
+    /// The contents of `c_str` must be valid UTF-8.
+    #[inline]
+    pub unsafe fn from_utf8_cstr_unchecked(c_str: &CStr) -> Self {
+        Self(CompactCBytes::from(c_str))
+    }
+
+    /// Constructs a `CompactCString` from raw bytes without validating UTF-8 or NULs.
+    ///
+    /// # Safety
+    ///
+    /// `bytes` must be valid UTF-8 and must not contain any NUL (`0`) bytes.
+    #[inline]
+    pub unsafe fn from_bytes_unchecked(bytes: &[u8]) -> Self {
+        // SAFETY: the caller guarantees that `bytes` is valid UTF-8 and NUL-free.
+        Self(unsafe { CompactCBytes::from_bytes_unchecked(bytes) })
+    }
+
+    /// Creates an inline `CompactCString` from a NUL-free byte payload.
+    ///
+    /// Returns `None` if the payload length is greater than or equal to
+    /// [`INLINE_TOTAL`](super::INLINE_TOTAL), or if it contains a NUL byte.
+    #[inline(always)]
+    pub const fn try_inline(s: &str) -> Option<Self> {
+        match CompactCBytes::try_inline(s.as_bytes()) {
+            bytes @ Some(_) => return Some(Self(bytes.unwrap())),
+            // Avoid const-evaluating the destructor for `Option<CompactCBytes>`.
+            // This is `None`, so there is no initialized `CompactCBytes` to drop.
+            bytes @ None => core::mem::forget(bytes),
+        }
+        None
+    }
+
+    /// Creates an inline `CompactCString` from a NUL-free string payload.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the payload length is greater than or equal to
+    /// [`INLINE_TOTAL`](super::INLINE_TOTAL), or if it contains a NUL byte.
+    #[inline(always)]
+    pub const fn new_inline(s: &str) -> Self {
+        Self(CompactCBytes::new_inline(s.as_bytes()))
+    }
+
+    /// Returns `true` if the data is heap-allocated.
+    #[inline]
+    pub fn is_heap(&self) -> bool {
+        self.0.is_heap()
+    }
+
+    /// Returns `true` if the data is stored inline.
+    #[inline]
+    pub fn is_inline(&self) -> bool {
+        self.0.is_inline()
+    }
+
+    /// Returns the length in bytes (not chars).
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the string is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the raw UTF-8 bytes without the trailing NUL.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    /// Returns the content as a `&CStr` without any allocation.
+    #[inline]
+    pub fn as_cstr(&self) -> &CStr {
+        self.0.as_cstr()
+    }
+
+    /// Returns a raw pointer to the NUL-terminated C string.
+    #[inline]
+    pub fn as_ptr(&self) -> *const c_char {
+        self.as_cstr().as_ptr()
+    }
+
+    /// Returns the content as a `&str`.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        self
+    }
+
+    /// Converts `self` into a [`String`].
+    ///
+    /// This allocates a new `String` and copies the UTF-8 payload.
+    #[inline]
+    pub fn into_string(self) -> String {
+        self.as_str().to_owned()
+    }
+
+    /// Consumes `self` and returns the underlying [`CompactCBytes`].
+    #[inline]
+    pub fn into_bytes(self) -> CompactCBytes {
+        self.0
+    }
+}
+
+impl TryFrom<&str> for CompactCString {
+    type Error = NulError;
+
+    #[inline]
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        let vec = CompactCBytes::try_from(s.as_bytes())?;
+        // SAFETY: `s` is valid UTF-8, and `CompactCBytes::try_from` rejects any NUL bytes.
+        Ok(unsafe { Self::from_utf8_unchecked(vec) })
+    }
+}
+
+impl TryFrom<&String> for CompactCString {
+    type Error = NulError;
+
+    #[inline]
+    fn try_from(s: &String) -> Result<Self, Self::Error> {
+        Self::try_from(s.as_str())
+    }
+}
+
+impl FromStr for CompactCString {
+    type Err = NulError;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s)
+    }
+}
+
+impl TryFrom<&CStr> for CompactCString {
+    type Error = Utf8Error;
+
+    #[inline]
+    fn try_from(c_str: &CStr) -> Result<Self, Self::Error> {
+        c_str.to_str()?;
+        // SAFETY: `c_str` is a valid C string, and `to_str` verified its contents as UTF-8.
+        Ok(unsafe { Self::from_utf8_cstr_unchecked(c_str) })
+    }
+}
+
+impl TryFrom<&CString> for CompactCString {
+    type Error = Utf8Error;
+
+    #[inline]
+    fn try_from(s: &CString) -> Result<Self, Self::Error> {
+        Self::try_from(s.as_c_str())
+    }
+}
+
+impl TryFrom<&[u8]> for CompactCString {
+    type Error = FromBytesError;
+
+    #[inline]
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let vec = CompactCBytes::try_from(bytes)?;
+        Self::try_from(vec).map_err(FromBytesError::from)
+    }
+}
+
+impl TryFrom<CompactCBytes> for CompactCString {
+    type Error = Utf8Error;
+
+    #[inline]
+    fn try_from(value: CompactCBytes) -> Result<Self, Self::Error> {
+        str::from_utf8(&value)?;
+        Ok(CompactCString(value))
+    }
+}
+
+impl From<CompactCString> for String {
+    #[inline]
+    fn from(s: CompactCString) -> Self {
+        s.into_string()
+    }
+}
+
+impl<'a> From<&'a CompactCString> for &'a str {
+    #[inline]
+    fn from(s: &'a CompactCString) -> Self {
+        s.as_str()
+    }
+}
+
+impl fmt::Display for CompactCString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Deref for CompactCString {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: CompactCString is always constructed from validated UTF-8.
+        unsafe { str::from_utf8_unchecked(self.as_bytes()) }
+    }
+}
+
+impl Hash for CompactCString {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
+impl AsRef<[u8]> for CompactCString {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl AsRef<CStr> for CompactCString {
+    #[inline]
+    fn as_ref(&self) -> &CStr {
+        self.as_cstr()
+    }
+}
+
+impl AsRef<str> for CompactCString {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Borrow<str> for CompactCString {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self
+    }
+}
+
+impl<T: AsRef<str> + ?Sized> PartialEq<T> for CompactCString {
+    #[inline]
+    fn eq(&self, other: &T) -> bool {
+        self.as_str() == other.as_ref()
+    }
+}
+
+impl_partial_eq! {
+    impl PartialEq<CompactCString>     for &CompactCString    { |self, other| self.as_str() == other.as_str() }
+
+    impl PartialEq<CompactCString>     for String        { |self, other| self.as_str() == other.as_str() }
+    impl PartialEq<&CompactCString>    for String        { |self, other| self.as_str() == other.as_str() }
+    impl PartialEq<CompactCString>     for &String       { |self, other| self.as_str() == other.as_str() }
+    impl PartialEq<String>        for &CompactCString    { |self, other| self.as_str() == other.as_str() }
+
+    impl PartialEq<CompactCString>     for str           { |self, other| self   == other.as_str() }
+    impl PartialEq<&CompactCString>    for str           { |self, other| self   == other.as_str() }
+    impl PartialEq<CompactCString>     for &str          { |self, other| *self  == other.as_str() }
+    impl PartialEq<CompactCString>     for &&str         { |self, other| **self == other.as_str() }
+
+    impl PartialEq<CompactCString>     for Cow<'_, str>  { |self, other| self  == other.as_str() }
+    impl PartialEq<CompactCString>     for &Cow<'_, str> { |self, other| *self == other.as_str() }
+    impl PartialEq<Cow<'_, str>>  for &CompactCString    { |self, other| self.as_str() == other  }
+}

--- a/compact_cstr/src/tests.rs
+++ b/compact_cstr/src/tests.rs
@@ -1,0 +1,459 @@
+use super::*;
+use core::error::Error;
+use core::num::NonZero;
+use std::borrow::Cow;
+use std::ffi::{CStr, CString};
+
+#[test]
+fn compact_c_string_layout_boundaries() {
+    let default = CompactCString::default();
+    assert_eq!(default.len(), 0);
+    assert_eq!(default.as_str(), "");
+    assert_eq!(default.as_bytes(), b"");
+    let cstring = CString::new("").unwrap();
+    assert_eq!(
+        default.as_cstr().to_bytes_with_nul(),
+        cstring.to_bytes_with_nul()
+    );
+
+    for len in [0, 3, 23, 24, 100] {
+        let s = "x".repeat(len);
+        let cstring = CString::new(s.clone()).unwrap();
+        let value = CompactCString::try_from(cstring.as_c_str()).unwrap();
+
+        assert_eq!(value.len(), len);
+        assert_eq!(value.as_str(), s);
+        assert_eq!(value.as_bytes(), s.as_bytes());
+        assert_eq!(
+            value.as_cstr().to_bytes_with_nul(),
+            cstring.to_bytes_with_nul()
+        );
+
+        if len < 24 {
+            assert!(value.is_inline());
+        } else {
+            assert!(value.is_heap());
+        }
+    }
+}
+
+#[test]
+fn compact_bytes_layout_boundaries() {
+    let default = CompactCBytes::default();
+    assert_eq!(default.len(), 0);
+    assert_eq!(default, b"");
+    let cstring = CString::new("").unwrap();
+    assert_eq!(
+        default.as_cstr().to_bytes_with_nul(),
+        cstring.to_bytes_with_nul()
+    );
+
+    for len in [0, 1, 22, 23, 24, 25, 100] {
+        let bytes = vec![b'a'; len];
+        let value = CompactCBytes::try_from(bytes.as_slice()).unwrap();
+
+        assert_eq!(value.len(), len);
+        assert_eq!(value.as_slice(), bytes.as_slice());
+        assert_eq!(value.as_cstr().to_bytes(), bytes.as_slice());
+
+        if len < 24 {
+            assert!(value.is_inline());
+        } else {
+            assert!(value.is_heap());
+        }
+    }
+}
+
+#[test]
+fn compact_bytes_equality() {
+    let short = CompactCBytes::try_from("hello".as_bytes()).unwrap();
+    let long = CompactCBytes::try_from([b'x'; 30].as_slice()).unwrap();
+    let other = CompactCBytes::try_from("world".as_bytes()).unwrap();
+
+    assert!(short.is_inline());
+    assert!(long.is_heap());
+
+    assert_eq!(short, short.clone());
+    assert_eq!(long, long.clone());
+    assert_ne!(short, other);
+
+    assert_eq!(short, b"hello".as_slice());
+    assert_ne!(short, b"world".as_slice());
+
+    assert_eq!(short, b"hello".to_vec());
+    assert_ne!(short, b"world".to_vec());
+
+    // CompactCBytes == &str  (str: AsRef<[u8]>)
+    assert_eq!(short, "hello");
+    assert_ne!(short, "world");
+
+    assert_eq!(&short, short.clone());
+    assert_ne!(&short, other.clone());
+
+    assert_eq!(b"hello".to_vec(), short);
+    assert_ne!(b"world".to_vec(), short);
+
+    assert_eq!(b"hello".to_vec(), &short);
+    assert_ne!(b"world".to_vec(), &short);
+
+    let v = b"hello".to_vec();
+    assert_eq!(&v, short);
+
+    let hello_bytes: &[u8] = b"hello";
+    assert_eq!(*hello_bytes, short);
+
+    assert_eq!(*hello_bytes, &short);
+
+    assert_eq!(hello_bytes, short);
+    assert_ne!(b"world".as_slice(), short);
+
+    let s_u8: &&[u8] = &b"hello".as_slice();
+    assert_eq!(s_u8, short);
+    assert_eq!(short, s_u8);
+
+    let s_u8: &&&[u8] = &&b"hello".as_slice();
+    assert_eq!(short, s_u8);
+
+    let long_bytes = vec![b'x'; 30];
+    assert_eq!(long, long_bytes);
+    assert_eq!(long_bytes, long);
+    assert_eq!(&long, long.clone());
+    assert_eq!(long_bytes.as_slice(), long);
+}
+
+#[test]
+#[allow(clippy::needless_borrow)]
+fn compact_c_string_equality() {
+    let short = CompactCString::try_from("hello").unwrap();
+    let long = CompactCString::try_from(&"y".repeat(30)).unwrap();
+    let other = CompactCString::try_from("world").unwrap();
+
+    assert!(short.is_inline());
+    assert!(long.is_heap());
+
+    assert_eq!(short, short.clone());
+    assert_eq!(long, long.clone());
+    assert_ne!(short, other);
+
+    assert_eq!(short, "hello");
+    assert_ne!(short, "world");
+
+    assert_eq!(short, String::from("hello"));
+    assert_ne!(short, String::from("world"));
+
+    let cow_borrowed: Cow<str> = Cow::Borrowed("hello");
+    let cow_owned: Cow<str> = Cow::Owned(String::from("hello"));
+    assert_eq!(short, cow_borrowed);
+    assert_eq!(short, cow_owned);
+
+    assert_eq!(&short, short.clone());
+    assert_ne!(&short, other.clone());
+
+    assert_eq!(String::from("hello"), short);
+    assert_ne!(String::from("world"), short);
+
+    assert_eq!(String::from("hello"), &short);
+    assert_ne!(String::from("world"), &short);
+
+    let s = String::from("hello");
+    assert_eq!(&s, short);
+
+    assert_eq!(*"hello", short);
+
+    assert_eq!(*"hello", &short);
+
+    assert_eq!("hello", short);
+    assert_ne!("world", short);
+
+    let r: &&str = &&"hello";
+    assert_eq!(r, short);
+
+    assert_eq!(cow_borrowed, short);
+    assert_eq!(cow_owned, short);
+
+    assert_eq!(&cow_borrowed, short);
+
+    assert_eq!(&short, String::from("hello"));
+
+    assert_eq!(&short, cow_borrowed);
+
+    let long_str = "y".repeat(30);
+    assert_eq!(long, long_str.as_str());
+    assert_eq!(long_str, long);
+    assert_eq!(&long, long.clone());
+}
+
+#[test]
+fn rejects_interior_nul() {
+    assert!(CompactCBytes::try_from(b"a\0b".as_slice()).is_err());
+    assert!(CompactCString::try_from("a\0b").is_err());
+
+    // Position is reported.
+    let err = CompactCBytes::try_from(b"abc\0def".as_slice()).unwrap_err();
+    assert_eq!(err.position(), 3);
+}
+
+#[test]
+fn infallible_byte_conversions() {
+    let bytes: Vec<NonZero<u8>> = b"hello".iter().map(|&b| NonZero::new(b).unwrap()).collect();
+
+    let value = CompactCBytes::from(bytes.as_slice());
+    assert_eq!(value.as_slice(), b"hello");
+    assert_eq!(value.as_cstr().to_bytes(), b"hello");
+
+    let cstring = CString::new("world").unwrap();
+    let value = CompactCBytes::from(cstring.as_c_str());
+    assert_eq!(value.as_slice(), b"world");
+    assert_eq!(value.as_cstr().to_bytes(), b"world");
+}
+
+#[test]
+fn inline_constructors() {
+    assert!(CompactCBytes::try_inline(b"").is_some());
+    assert!(CompactCBytes::try_inline(&[b'x'; 22]).is_some());
+    assert!(CompactCBytes::try_inline(&[b'x'; 23]).is_some());
+    assert!(CompactCBytes::try_inline(&[b'x'; 24]).is_none());
+
+    assert!(CompactCBytes::try_inline(b"\0").is_none());
+    assert!(CompactCBytes::try_inline(b"abc\0def").is_none());
+    assert!(CompactCBytes::try_inline(b"abc\0").is_none());
+
+    let v = CompactCBytes::try_inline(b"hello").unwrap();
+    assert!(v.is_inline());
+    assert_eq!(v.as_slice(), b"hello");
+
+    assert_eq!(CompactCBytes::new_inline(b"hello").as_slice(), b"hello");
+    assert_eq!(CompactCString::new_inline("hello").as_str(), "hello");
+    assert_eq!(
+        CompactCString::try_inline("hello").unwrap().as_str(),
+        "hello"
+    );
+}
+
+#[test]
+fn owned_input_conversions() {
+    let vec = vec![1, 2, 3];
+    let bytes: CompactCBytes = (&vec).try_into().unwrap();
+    assert_eq!(bytes.as_slice(), &[1, 2, 3]);
+
+    let vec = vec![NonZero::new(1).unwrap(), NonZero::new(2).unwrap()];
+    let bytes: CompactCBytes = (&vec).into();
+    assert_eq!(bytes.as_slice(), &[1u8, 2]);
+
+    let string = String::from("hello");
+    let cs: CompactCString = (&string).try_into().unwrap();
+    assert_eq!(cs.as_str(), "hello");
+
+    let cstring = CString::new("hello").unwrap();
+    let cs: CompactCString = (&cstring).try_into().unwrap();
+    assert_eq!(cs.as_str(), "hello");
+}
+
+#[test]
+fn from_str_and_string_conversions() {
+    use core::str::FromStr;
+
+    let cs = CompactCString::from_str("world").unwrap();
+    assert_eq!(cs.as_str(), "world");
+
+    assert!(CompactCString::from_str("a\0b").is_err());
+
+    let cs = CompactCString::try_from("hello").unwrap();
+
+    let string: String = cs.clone().into();
+    assert_eq!(string, "hello");
+
+    let str: &str = (&cs).into();
+    assert_eq!(str, "hello");
+}
+
+#[test]
+fn into_and_as_ptr() {
+    let cs = CompactCString::new_inline("payload");
+
+    assert_eq!(cs.clone().into_string(), "payload");
+    assert_eq!(cs.clone().into_bytes().as_slice(), b"payload");
+
+    let read = unsafe { CStr::from_ptr(cs.as_ptr()) };
+    assert_eq!(read.to_bytes(), b"payload");
+
+    let string = "y".repeat(40);
+    let cs = CompactCString::try_from(string.as_str()).unwrap();
+    assert!(cs.is_heap());
+
+    let read = unsafe { CStr::from_ptr(cs.as_ptr()) };
+    assert_eq!(read.to_bytes(), string.as_bytes());
+}
+
+#[test]
+fn as_ref_and_borrow_views() {
+    use std::borrow::Borrow;
+
+    let cb = CompactCBytes::new_inline(b"hello");
+
+    assert_eq!(AsRef::<[u8]>::as_ref(&cb), b"hello");
+    assert_eq!(AsRef::<CStr>::as_ref(&cb).to_bytes(), b"hello");
+    assert_eq!(Borrow::<[u8]>::borrow(&cb), b"hello");
+
+    let cs = CompactCString::new_inline("hello");
+
+    assert_eq!(AsRef::<[u8]>::as_ref(&cs), b"hello");
+    assert_eq!(AsRef::<str>::as_ref(&cs), "hello");
+    assert_eq!(AsRef::<CStr>::as_ref(&cs).to_bytes(), b"hello");
+    assert_eq!(Borrow::<str>::borrow(&cs), "hello");
+}
+
+#[test]
+fn display_and_debug() {
+    let bytes = b"hello";
+    let cb = CompactCBytes::new_inline(bytes.as_slice());
+    let cs = CompactCString::new_inline("hello");
+
+    assert_eq!(format!("{cs}"), "hello");
+
+    let expected_cb = format!("CompactCBytes({bytes:?})");
+    let expected_cs = format!("CompactCString({expected_cb})");
+
+    assert_eq!(format!("{cb:?}"), expected_cb);
+    assert_eq!(format!("{cs:?}"), expected_cs);
+}
+
+#[test]
+fn error_variants_and_sources() {
+    use crate::NulError;
+
+    let nul_err = CompactCBytes::try_from(b"a\0b".as_slice()).unwrap_err();
+    assert_eq!(format!("{nul_err}"), "interior NUL byte at position 1");
+
+    let nul_via_bytes = CompactCString::try_from(b"a\0b".as_slice()).unwrap_err();
+    let err = NulError { position: 1 };
+    assert_eq!(nul_via_bytes, FromBytesError::InteriorNul(err));
+
+    let source = Error::source(&nul_via_bytes).unwrap();
+    let source = source.downcast_ref::<NulError>().unwrap();
+    assert_eq!(source.position(), 1);
+
+    let bad_utf8 = [0xffu8, 0xfe];
+    let utf8_err = CompactCString::try_from(bad_utf8.as_slice()).unwrap_err();
+    assert!(matches!(utf8_err, FromBytesError::InvalidUtf8(_)));
+    assert!(Error::source(&utf8_err).is_some());
+}
+
+#[test]
+fn unsafe_constructors() {
+    let cs_raw = CString::new("raw").unwrap();
+
+    let v = unsafe { CompactCBytes::from_raw_c_unchecked(cs_raw.as_ptr()) };
+    assert_eq!(v.as_slice(), b"raw");
+
+    let v = unsafe { CompactCBytes::from_bytes_unchecked(b"unchecked") };
+    assert_eq!(v.as_slice(), b"unchecked");
+
+    let s = unsafe { CompactCString::from_bytes_unchecked(b"utf8raw") };
+    assert_eq!(s.as_str(), "utf8raw");
+
+    let bytes = CompactCBytes::try_from(b"valid".as_slice()).unwrap();
+
+    let s = unsafe { CompactCString::from_utf8_unchecked(bytes) };
+    assert_eq!(s.as_str(), "valid");
+
+    let s = unsafe { CompactCString::from_utf8_cstr_unchecked(cs_raw.as_c_str()) };
+    assert_eq!(s.as_str(), "raw");
+}
+
+#[test]
+fn heap_clone_drop_order() {
+    let big = "x".repeat(40);
+    let v = CompactCBytes::try_from(big.as_bytes()).unwrap();
+
+    assert!(v.is_heap());
+
+    let c1 = v.clone();
+    let c2 = c1.clone();
+
+    drop(v);
+    assert_eq!(c1.as_slice(), big.as_bytes());
+    assert_eq!(c2.as_slice(), big.as_bytes());
+
+    drop(c1);
+    assert_eq!(c2.as_slice(), big.as_bytes());
+    drop(c2);
+}
+
+#[test]
+fn test_in_collections() {
+    use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
+    let bytes_inline: &[u8] = b"hello";
+    let bytes_heap = vec![b'x'; 30];
+
+    let mut map = HashMap::new();
+    map.insert(CompactCBytes::try_from(bytes_inline).unwrap(), 42);
+    map.insert(CompactCBytes::try_from(bytes_heap.as_slice()).unwrap(), 7);
+
+    assert_eq!(map.get(bytes_inline), Some(&42));
+    assert_eq!(map.get(bytes_heap.as_slice()), Some(&7));
+
+    let mut set = HashSet::new();
+    set.insert(CompactCBytes::try_from(bytes_inline).unwrap());
+    set.insert(CompactCBytes::try_from(bytes_heap.as_slice()).unwrap());
+
+    assert!(set.contains(bytes_inline));
+    assert!(set.contains(bytes_heap.as_slice()));
+
+    let mut tree_map = BTreeMap::new();
+    tree_map.insert(CompactCBytes::try_from(bytes_inline).unwrap(), 42);
+    tree_map.insert(CompactCBytes::try_from(bytes_heap.as_slice()).unwrap(), 7);
+
+    assert_eq!(tree_map.get(bytes_inline), Some(&42));
+    assert_eq!(tree_map.get(bytes_heap.as_slice()), Some(&7));
+
+    let mut tree_set: BTreeSet<CompactCBytes> = BTreeSet::new();
+    tree_set.insert(CompactCBytes::try_from(bytes_inline).unwrap());
+    tree_set.insert(CompactCBytes::try_from(bytes_heap.as_slice()).unwrap());
+
+    assert!(tree_set.contains(bytes_inline));
+    assert!(tree_set.contains(bytes_heap.as_slice()));
+
+    let str_inline = "hello";
+    let str_heap = "y".repeat(30);
+
+    let mut map = HashMap::new();
+    map.insert(CompactCString::try_from(str_inline).unwrap(), 42);
+    map.insert(CompactCString::try_from(str_heap.as_str()).unwrap(), 7);
+
+    assert_eq!(map.get(str_inline), Some(&42));
+    assert_eq!(map.get(str_heap.as_str()), Some(&7));
+
+    let mut set = HashSet::new();
+    set.insert(CompactCString::try_from(str_inline).unwrap());
+    set.insert(CompactCString::try_from(str_heap.as_str()).unwrap());
+
+    assert!(set.contains(str_inline));
+    assert!(set.contains(str_heap.as_str()));
+
+    let mut tree_map = BTreeMap::new();
+    tree_map.insert(CompactCString::try_from(str_inline).unwrap(), 42);
+    tree_map.insert(CompactCString::try_from(str_heap.as_str()).unwrap(), 7);
+
+    assert_eq!(tree_map.get(str_inline), Some(&42));
+    assert_eq!(tree_map.get(str_heap.as_str()), Some(&7));
+
+    let mut tree_set = BTreeSet::new();
+    tree_set.insert(CompactCString::try_from(str_inline).unwrap());
+    tree_set.insert(CompactCString::try_from(str_heap.as_str()).unwrap());
+
+    assert!(tree_set.contains(str_inline));
+    assert!(tree_set.contains(str_heap.as_str()));
+}
+
+#[test]
+fn new_inline_panics() {
+    use std::panic::catch_unwind;
+
+    assert!(catch_unwind(|| CompactCBytes::new_inline(&[b'x'; 24])).is_err());
+    assert!(catch_unwind(|| CompactCBytes::new_inline(b"abc\0def")).is_err());
+
+    assert!(catch_unwind(|| CompactCString::new_inline("xxxxxxxxxxxxxxxxxxxxxxxxxx")).is_err());
+    assert!(catch_unwind(|| CompactCString::new_inline("a\0b")).is_err());
+}

--- a/compact_cstr/src/vector.rs
+++ b/compact_cstr/src/vector.rs
@@ -1,0 +1,249 @@
+//! Owned, NUL-terminated byte vector for PDF name and binary data.
+
+use core::cmp::Ordering;
+use core::ffi::{c_char, CStr};
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::num::NonZero;
+use core::ops::Deref;
+use std::borrow::Borrow;
+
+use crate::error::NulError;
+use crate::repr::Repr;
+
+/// An owned, C-string-compatible byte buffer with a compact 24-byte representation.
+///
+/// `CompactCBytes` always maintains a trailing NUL terminator and rejects interior `\0`
+/// bytes, allowing its contents to be viewed as a [`CStr`] without allocation.
+///
+/// It is built with several memory and performance optimizations:
+///
+/// * Stores up to 23 payload bytes inline, avoiding heap allocation for small values,
+///   and spills longer payloads to a reference-counted [`ecow::EcoVec<u8>`].
+///
+/// * Maintains an invisible trailing NUL terminator, allowing instant,
+///   allocation-free conversion to `&CStr` via [`as_cstr`](Self::as_cstr).
+///
+/// * Allows fast cloning, performed either by copying the 24-byte inline
+///   representation or by incrementing the reference count of the spilled storage.
+///
+/// * Enables niche optimization, so `Option<CompactCBytes>` has the same size as `CompactCBytes`.
+#[derive(Default, Clone)]
+#[repr(transparent)]
+pub struct CompactCBytes(pub(super) Repr);
+
+impl CompactCBytes {
+    /// Creates a `CompactCBytes` from a raw C string pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be a valid, NUL-terminated pointer.
+    #[inline]
+    pub unsafe fn from_raw_c_unchecked(ptr: *const c_char) -> Self {
+        let c_str = unsafe { CStr::from_ptr(ptr) };
+        Self::from(c_str)
+    }
+
+    /// Constructs a `CompactCBytes` from raw bytes without checking for interior NULs.
+    ///
+    /// # Safety
+    ///
+    /// `bytes` must not contain any `0` byte.
+    #[inline]
+    pub unsafe fn from_bytes_unchecked(bytes: &[u8]) -> Self {
+        // SAFETY: forwarded from caller.
+        Self(unsafe { Repr::from_slice_unchecked(bytes) })
+    }
+
+    /// Creates an inline `CompactCBytes` from a NUL-free byte payload.
+    ///
+    /// Returns `None` if the payload length is greater than or equal to
+    /// [`INLINE_TOTAL`](super::INLINE_TOTAL), or if it contains a NUL byte.
+    #[inline(always)]
+    pub const fn try_inline(bytes: &[u8]) -> Option<Self> {
+        match Repr::try_inline(bytes) {
+            repr @ Some(_) => return Some(Self(repr.unwrap())),
+            // Avoid const-evaluating the destructor for `Option<Repr>`.
+            // This is `None`, so there is no initialized `Repr` to drop.
+            repr @ None => core::mem::forget(repr),
+        }
+        None
+    }
+
+    /// Creates a new inline `CompactCBytes` from a byte slice.
+    ///
+    /// This constructor is `const` and never allocates. Therefore, the input must
+    /// fit into the inline representation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the payload length is greater than or equal to
+    /// [`INLINE_TOTAL`](super::INLINE_TOTAL), or if it contains a NUL byte.
+    #[inline(always)]
+    pub const fn new_inline(bytes: &[u8]) -> Self {
+        Self::try_inline(bytes).expect("payload must be at most 23 bytes and contain no NUL bytes")
+    }
+
+    /// Returns `true` if the data is heap-allocated.
+    #[inline]
+    pub const fn is_heap(&self) -> bool {
+        self.0.is_heap()
+    }
+
+    /// Returns `true` if the data is stored inline.
+    #[inline]
+    pub const fn is_inline(&self) -> bool {
+        !self.is_heap()
+    }
+
+    /// Returns the payload length in bytes (without the NUL terminator).
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the payload is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the payload bytes without the trailing NUL.
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        self
+    }
+
+    /// Returns the content as a `&CStr` without allocation.
+    #[inline]
+    pub fn as_cstr(&self) -> &CStr {
+        self.0.as_cstr()
+    }
+}
+
+impl TryFrom<&[u8]> for CompactCBytes {
+    type Error = NulError;
+
+    /// Validates that `value` contains no NUL bytes, then copies it into
+    /// inline storage or spills it to heap storage.
+    #[inline]
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        Repr::from_slice(value).map(Self)
+    }
+}
+
+impl TryFrom<&Vec<u8>> for CompactCBytes {
+    type Error = NulError;
+    #[inline]
+    fn try_from(bytes: &Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(bytes.as_slice())
+    }
+}
+
+impl From<&CStr> for CompactCBytes {
+    #[inline]
+    fn from(c_str: &CStr) -> Self {
+        Self(Repr::from_cstr(c_str))
+    }
+}
+
+impl From<&[NonZero<u8>]> for CompactCBytes {
+    #[inline]
+    fn from(bytes: &[NonZero<u8>]) -> Self {
+        // SAFETY: `NonZero<u8>` has the same layout as `u8`, and all bytes are non-zero.
+        let raw: &[u8] =
+            unsafe { core::slice::from_raw_parts(bytes.as_ptr().cast::<u8>(), bytes.len()) };
+        // SAFETY: `raw` is guaranteed to be NUL-free.
+        Self(unsafe { Repr::from_slice_unchecked(raw) })
+    }
+}
+
+impl From<&Vec<NonZero<u8>>> for CompactCBytes {
+    #[inline]
+    fn from(bytes: &Vec<NonZero<u8>>) -> Self {
+        Self::from(bytes.as_slice())
+    }
+}
+
+impl Deref for CompactCBytes {
+    type Target = [u8];
+
+    /// Returns the payload bytes without the trailing NUL.
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.0.to_bytes()
+    }
+}
+
+impl AsRef<[u8]> for CompactCBytes {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self
+    }
+}
+
+impl AsRef<CStr> for CompactCBytes {
+    #[inline]
+    fn as_ref(&self) -> &CStr {
+        self.as_cstr()
+    }
+}
+
+impl Borrow<[u8]> for CompactCBytes {
+    #[inline]
+    fn borrow(&self) -> &[u8] {
+        self
+    }
+}
+
+impl<T: AsRef<[u8]> + ?Sized> PartialEq<T> for CompactCBytes {
+    #[inline]
+    fn eq(&self, other: &T) -> bool {
+        self.as_slice() == other.as_ref()
+    }
+}
+
+impl Eq for CompactCBytes {}
+
+impl_partial_eq! {
+    impl PartialEq<CompactCBytes>     for &CompactCBytes  { |self, other| self.as_slice() == other.as_slice() }
+
+    impl PartialEq<CompactCBytes>     for Vec<u8>  { |self, other| self.as_slice() == other.as_slice() }
+    impl PartialEq<&CompactCBytes>    for Vec<u8>  { |self, other| self.as_slice() == other.as_slice() }
+    impl PartialEq<CompactCBytes>     for &Vec<u8> { |self, other| self.as_slice() == other.as_slice() }
+    impl PartialEq<Vec<u8>>    for &CompactCBytes  { |self, other| self.as_slice() == other.as_slice() }
+
+    impl PartialEq<CompactCBytes>     for [u8]     { |self, other| self   == other.as_slice() }
+    impl PartialEq<&CompactCBytes>    for [u8]     { |self, other| self   == other.as_slice() }
+    impl PartialEq<CompactCBytes>     for &[u8]    { |self, other| *self  == other.as_slice() }
+    impl PartialEq<CompactCBytes>     for &&[u8]   { |self, other| **self == other.as_slice() }
+}
+
+impl PartialOrd for CompactCBytes {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CompactCBytes {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_slice().cmp(other.as_slice())
+    }
+}
+
+impl Hash for CompactCBytes {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state);
+    }
+}
+
+impl fmt::Debug for CompactCBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("CompactCBytes")
+            .field(&self.as_slice())
+            .finish()
+    }
+}

--- a/compact_cstr/tests/proptest.rs
+++ b/compact_cstr/tests/proptest.rs
@@ -1,0 +1,366 @@
+//! These tests exercise the byte-layout / transmute reasoning in `repr.rs`
+//! by constructing values from random inputs and asserting that what comes
+//! out of the various accessors matches what went in. They are designed to
+//! be fast and deterministic enough to run under Miri.
+
+use compact_cstr::{CompactCBytes, CompactCString, FromBytesError, NulError, INLINE_TOTAL};
+use core::num::NonZero;
+use proptest::prelude::*;
+use std::borrow::Cow;
+use std::collections::hash_map::DefaultHasher;
+use std::ffi::{CStr, CString};
+use std::hash::{Hash, Hasher};
+
+/// Strategy for `Vec<u8>` that may include zero bytes.
+fn arbitrary_bytes() -> impl Strategy<Value = Vec<u8>> {
+    proptest::collection::vec(any::<u8>(), 0..200)
+}
+
+/// Strategy for `Vec<u8>` guaranteed to contain no zero byte.
+fn nul_free_bytes() -> impl Strategy<Value = Vec<u8>> {
+    proptest::collection::vec(1u8..=255, 0..200)
+}
+
+/// Strategy for NUL-free `Vec<u8>` whose length always spills to heap.
+fn heap_sized_nul_free_bytes() -> impl Strategy<Value = Vec<u8>> {
+    proptest::collection::vec(1u8..=255, INLINE_TOTAL..200)
+}
+
+/// Strategy for valid UTF-8 strings (which may contain interior NULs).
+fn arbitrary_string() -> impl Strategy<Value = String> {
+    ".{0,200}".prop_map(String::from)
+}
+
+/// Strategy for valid UTF-8 strings guaranteed to contain no NUL byte.
+fn nul_free_string() -> impl Strategy<Value = String> {
+    r"[^\x00]{0,200}".prop_map(String::from)
+}
+
+fn hash_of<T: Hash + ?Sized>(value: &T) -> u64 {
+    let mut h = DefaultHasher::new();
+    value.hash(&mut h);
+    h.finish()
+}
+
+/// Number of proptest cases per test. Under Miri every operation is interpreted, so we drop the
+/// count drastically; the goal under Miri is to exercise each code path a few times for UB
+/// detection, not to do thorough property coverage (that's what the regular `cargo test` run is
+/// for).
+#[cfg(miri)]
+const CASES: u32 = 2;
+#[cfg(not(miri))]
+const CASES: u32 = 64;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: CASES,
+        failure_persistence: None,
+        ..ProptestConfig::default()
+    })]
+
+    /// `CompactCBytes::try_from(&[u8])` accepts NUL-free input unchanged.
+    #[test]
+    fn compact_c_bytes_nul_free(bytes in nul_free_bytes()) {
+        let v = CompactCBytes::try_from(bytes.as_slice()).unwrap();
+        prop_assert_eq!(v.as_slice(), bytes.as_slice());
+        prop_assert_eq!(v.as_cstr().to_bytes(), bytes.as_slice());
+        prop_assert_eq!(v.len(), bytes.len());
+        prop_assert_eq!(v.is_empty(), bytes.is_empty());
+        prop_assert_eq!(v.is_heap(), bytes.len() >= INLINE_TOTAL);
+        prop_assert_eq!(v.is_inline(), !v.is_heap());
+    }
+
+    /// Cloning is always a faithful copy (inline or heap).
+    #[test]
+    fn compact_c_bytes_clone(bytes in nul_free_bytes()) {
+        let v = CompactCBytes::try_from(bytes.as_slice()).unwrap();
+        let c = v.clone();
+        prop_assert_eq!(v.as_slice(), c.as_slice());
+        prop_assert_eq!(v.is_heap(), c.is_heap());
+        // Drop one then check the other still reads correctly.
+        drop(v);
+        prop_assert_eq!(c.as_slice(), bytes.as_slice());
+    }
+
+    /// Bytes containing an interior NUL are rejected, with the correct position.
+    #[test]
+    fn interior_nul_rejected(prefix in nul_free_bytes(), suffix in nul_free_bytes()) {
+        let mut bytes = prefix.clone();
+        bytes.push(0);
+        bytes.extend_from_slice(&suffix);
+
+        let err: NulError = CompactCBytes::try_from(bytes.as_slice()).unwrap_err();
+        prop_assert_eq!(err.position(), prefix.len());
+    }
+
+    /// Arbitrary byte input is accepted unchanged if it contains no NUL bytes;
+    /// otherwise it is rejected at the position of the first NUL byte.
+    #[test]
+    fn compact_c_bytes_total(bytes in arbitrary_bytes()) {
+        match CompactCBytes::try_from(bytes.as_slice()) {
+            Ok(v) => {
+                prop_assert!(!bytes.contains(&0));
+                prop_assert_eq!(v.as_slice(), bytes.as_slice());
+            }
+            Err(e) => {
+                let nul_pos = bytes
+                    .iter()
+                    .position(|&b| b == 0)
+                    .expect("error implies input contains a NUL byte");
+
+                prop_assert_eq!(e.position(), nul_pos);
+            }
+        }
+    }
+
+    /// `&[NonZero<u8>]` is the safe-by-construction path.
+    #[test]
+    fn nonzero_slice(bytes in nul_free_bytes()) {
+        let nz: Vec<NonZero<u8>> =
+            bytes.iter().map(|&b| NonZero::new(b).unwrap()).collect();
+        let v = CompactCBytes::from(nz.as_slice());
+        prop_assert_eq!(v.as_slice(), bytes.as_slice());
+        prop_assert_eq!(v.as_cstr().to_bytes(), bytes.as_slice());
+    }
+
+    /// NUL-free strings are accepted unchanged. Strings containing a NUL byte are rejected.
+    #[test]
+    fn compact_c_string(s in arbitrary_string()) {
+        let nul_pos = s.as_bytes().iter().position(|&b| b == 0);
+        match CompactCString::try_from(s.as_str()) {
+            Ok(p) => {
+                prop_assert_eq!(nul_pos, None);
+                prop_assert_eq!(p.as_str(), s.as_str());
+                prop_assert_eq!(p.as_bytes(), s.as_bytes());
+                prop_assert_eq!(p.as_cstr().to_bytes(), s.as_bytes());
+            }
+            Err(e) => prop_assert_eq!(Some(e.position()), nul_pos),
+        }
+    }
+
+    /// NUL-free bytes are converted to `CompactCString` only if they are valid UTF-8.
+    #[test]
+    fn compact_c_string_from_bytes(bytes in nul_free_bytes()) {
+        let v = CompactCBytes::try_from(bytes.as_slice()).unwrap();
+        let utf8_ok = core::str::from_utf8(&bytes).is_ok();
+        match CompactCString::try_from(v) {
+            Ok(p) => {
+                prop_assert!(utf8_ok);
+                prop_assert_eq!(p.as_bytes(), bytes.as_slice());
+            }
+            Err(_) => prop_assert!(!utf8_ok),
+        }
+    }
+
+    #[test]
+    fn try_inline_bytes(bytes in proptest::collection::vec(1u8..=255, 0..30)) {
+        match CompactCBytes::try_inline(bytes.as_slice()) {
+            Some(v) => {
+                prop_assert!(bytes.len() < INLINE_TOTAL);
+                prop_assert!(v.is_inline());
+                prop_assert_eq!(v.as_slice(), bytes.as_slice());
+                prop_assert_eq!(v.as_cstr().to_bytes(), bytes.as_slice());
+            }
+            None => prop_assert!(bytes.len() >= INLINE_TOTAL),
+        }
+    }
+
+    #[test]
+    fn try_inline_bytes_rejects_nul(
+        prefix in proptest::collection::vec(1u8..=255, 0..15),
+        suffix in proptest::collection::vec(1u8..=255, 0..15),
+    ) {
+        let mut bytes = prefix;
+        bytes.push(0);
+        bytes.extend_from_slice(&suffix);
+
+        prop_assert!(CompactCBytes::try_inline(bytes.as_slice()).is_none());
+    }
+
+    #[test]
+    fn try_inline_string(s in r"[^\x00]{0,30}") {
+        match CompactCString::try_inline(&s) {
+            Some(v) => {
+                prop_assert!(s.len() < INLINE_TOTAL);
+                prop_assert!(v.is_inline());
+                prop_assert_eq!(v.as_str(), s.as_str());
+                prop_assert_eq!(v.as_bytes(), s.as_bytes());
+            }
+            None => prop_assert!(s.len() >= INLINE_TOTAL),
+        }
+    }
+
+    #[test]
+    fn cbytes_from_cstr(bytes in nul_free_bytes()) {
+        let cstring = CString::new(bytes.clone()).unwrap();
+        let v = CompactCBytes::from(cstring.as_c_str());
+
+        prop_assert_eq!(v.as_slice(), bytes.as_slice());
+        prop_assert_eq!(v.as_cstr().to_bytes_with_nul(), cstring.as_bytes_with_nul());
+        prop_assert_eq!(v.is_heap(), bytes.len() >= INLINE_TOTAL);
+    }
+
+    #[test]
+    fn cstring_from_cstr(s in nul_free_string()) {
+        let cstring = CString::new(s.clone()).unwrap();
+        let v = CompactCString::try_from(cstring.as_c_str()).unwrap();
+
+        prop_assert_eq!(v.as_str(), s.as_str());
+        prop_assert_eq!(v.as_cstr().to_bytes_with_nul(), cstring.as_bytes_with_nul());
+    }
+
+    #[test]
+    fn cstring_from_cstring(s in nul_free_string()) {
+        let cstring = CString::new(s.clone()).unwrap();
+        let v = CompactCString::try_from(&cstring).unwrap();
+
+        prop_assert_eq!(v.as_str(), s.as_str());
+    }
+
+    #[test]
+    fn from_str_matches_try_from(s in arbitrary_string()) {
+        use core::str::FromStr;
+
+        match (
+            CompactCString::try_from(s.as_str()),
+            CompactCString::from_str(s.as_str()),
+        ) {
+            (Ok(a), Ok(b)) => prop_assert_eq!(a.as_str(), b.as_str()),
+            (Err(a), Err(b)) => prop_assert_eq!(a.position(), b.position()),
+            _ => prop_assert!(false, "FromStr and TryFrom<&str> disagreed"),
+        }
+    }
+
+    #[test]
+    fn ord_matches_payload(a in nul_free_bytes(), b in nul_free_bytes()) {
+        let ca = CompactCBytes::try_from(a.as_slice()).unwrap();
+        let cb = CompactCBytes::try_from(b.as_slice()).unwrap();
+
+        prop_assert_eq!(ca.cmp(&cb), a.as_slice().cmp(b.as_slice()));
+        prop_assert_eq!(ca.partial_cmp(&cb), a.as_slice().partial_cmp(b.as_slice()));
+    }
+
+    #[test]
+    fn string_ord_matches_payload(a in nul_free_string(), b in nul_free_string()) {
+        let ca = CompactCString::try_from(a.as_str()).unwrap();
+        let cb = CompactCString::try_from(b.as_str()).unwrap();
+
+        prop_assert_eq!(ca.cmp(&cb), a.as_str().cmp(b.as_str()));
+        prop_assert_eq!(ca.partial_cmp(&cb), a.as_str().partial_cmp(b.as_str()));
+    }
+
+    #[test]
+    fn hash_bytes_matches_slice(bytes in nul_free_bytes()) {
+        let v = CompactCBytes::try_from(bytes.as_slice()).unwrap();
+
+        prop_assert_eq!(hash_of(&v), hash_of(bytes.as_slice()));
+    }
+
+    #[test]
+    fn hash_string_is_deterministic(s in nul_free_string()) {
+        let a = CompactCString::try_from(s.as_str()).unwrap();
+        let b = CompactCString::try_from(s.as_str()).unwrap();
+
+        prop_assert_eq!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn bytes_partial_eq_matrix(a in nul_free_bytes(), b in nul_free_bytes()) {
+        let ca = CompactCBytes::try_from(a.as_slice()).unwrap();
+        let expected = a == b;
+
+        prop_assert_eq!(ca == b, expected);
+        prop_assert_eq!(b == ca, expected);
+        prop_assert_eq!(ca == b.as_slice(), expected);
+        prop_assert_eq!(b.as_slice() == ca, expected);
+        prop_assert_eq!(&ca == &b, expected);
+    }
+
+    #[test]
+    fn string_partial_eq_matrix(a in nul_free_string(), b in nul_free_string()) {
+        let ca = CompactCString::try_from(a.as_str()).unwrap();
+        let cow: Cow<'_, str> = Cow::Borrowed(b.as_str());
+        let expected = a == b;
+
+        prop_assert_eq!(ca == b, expected);
+        prop_assert_eq!(b == ca, expected);
+        prop_assert_eq!(ca == b.as_str(), expected);
+        prop_assert_eq!(b.as_str() == ca, expected);
+        prop_assert_eq!(ca == cow, expected);
+        prop_assert_eq!(Cow::Borrowed(b.as_str()) == ca, expected);
+    }
+
+    #[test]
+    fn into_bytes_preserves_payload(s in nul_free_string()) {
+        let cs = CompactCString::try_from(s.as_str()).unwrap();
+        let bytes = cs.into_bytes();
+
+        prop_assert_eq!(bytes.as_slice(), s.as_bytes());
+    }
+
+    #[test]
+    fn into_string_preserves_payload(s in nul_free_string()) {
+        let cs = CompactCString::try_from(s.as_str()).unwrap();
+
+        prop_assert_eq!(cs.into_string(), s);
+    }
+
+    #[test]
+    fn as_ptr_is_nul_terminated(s in nul_free_string()) {
+        let cs = CompactCString::try_from(s.as_str()).unwrap();
+
+        // SAFETY: `cs` is alive, and `CompactCString` guarantees a valid NUL-terminated buffer.
+        let read = unsafe { CStr::from_ptr(cs.as_ptr()) };
+
+        prop_assert_eq!(read.to_bytes(), s.as_bytes());
+    }
+
+    #[test]
+    fn cstring_try_from_bytes_total(bytes in arbitrary_bytes()) {
+        let nul_pos = bytes.iter().position(|&b| b == 0);
+        let utf8_err = core::str::from_utf8(&bytes).err();
+
+        match CompactCString::try_from(bytes.as_slice()) {
+            Ok(cs) => {
+                prop_assert_eq!(nul_pos, None);
+                prop_assert!(utf8_err.is_none());
+                prop_assert_eq!(cs.as_bytes(), bytes.as_slice());
+            }
+            Err(FromBytesError::InteriorNul(e)) => {
+                prop_assert_eq!(Some(e.position()), nul_pos);
+            }
+            Err(FromBytesError::InvalidUtf8(e)) => {
+                prop_assert_eq!(nul_pos, None);
+                prop_assert_eq!(Some(e), utf8_err);
+            }
+        }
+    }
+
+    #[test]
+    fn heap_clone_outlives_original(bytes in heap_sized_nul_free_bytes()) {
+        let v = CompactCBytes::try_from(bytes.as_slice()).unwrap();
+        prop_assert!(v.is_heap());
+
+        let c = v.clone();
+        prop_assert!(c.is_heap());
+
+        drop(v);
+
+        prop_assert_eq!(c.as_slice(), bytes.as_slice());
+        prop_assert_eq!(c.as_cstr().to_bytes(), bytes.as_slice());
+    }
+
+    #[test]
+    fn cstring_rejects_injected_nul(
+        prefix in nul_free_string(),
+        suffix in nul_free_string(),
+    ) {
+        let mut s = prefix.clone();
+        s.push('\0');
+        s.push_str(&suffix);
+
+        let err = CompactCString::try_from(s.as_str()).unwrap_err();
+
+        prop_assert_eq!(err.position(), prefix.len());
+    }
+}

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -395,7 +395,7 @@ impl DestinationKind {
                 .as_float()
         }
 
-        let destination_kind = match kind_name {
+        let destination_kind = match kind_name.as_slice() {
             b"Fit" => DestinationKind::Fit,
             b"FitB" => DestinationKind::FitB,
             b"FitH" => DestinationKind::FitH {

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,6 +80,7 @@ pub enum Error {
     InvalidArgument(String),
     NotYetImplemented(String),
     NonInvertibleMatrix,
+    InteriorNul { position: usize },
 }
 
 impl fmt::Display for Error {
@@ -101,6 +102,10 @@ impl fmt::Display for Error {
             Error::InvalidArgument(msg) => write!(f, "invalid argument: {msg}"),
             Error::NotYetImplemented(msg) => write!(f, "not yet implemented: {msg}"),
             Error::NonInvertibleMatrix => write!(f, "matrix is not invertible"),
+            Error::InteriorNul { position } => write!(
+                f,
+                "string contained an interior NUL byte at position {position}"
+            ),
         }
     }
 }
@@ -122,6 +127,29 @@ impl From<MuPdfError> for Error {
 impl From<NulError> for Error {
     fn from(err: NulError) -> Self {
         Self::Nul(err)
+    }
+}
+
+impl From<compact_cstr::NulError> for Error {
+    fn from(err: compact_cstr::NulError) -> Self {
+        Self::InteriorNul {
+            position: err.position(),
+        }
+    }
+}
+
+impl From<compact_cstr::FromBytesError> for Error {
+    fn from(err: compact_cstr::FromBytesError) -> Self {
+        match err {
+            compact_cstr::FromBytesError::InteriorNul(e) => Self::from(e),
+            compact_cstr::FromBytesError::InvalidUtf8(_) => Self::InvalidUtf8,
+        }
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(_: std::str::Utf8Error) -> Self {
+        Self::InvalidUtf8
     }
 }
 

--- a/src/pdf/annotation.rs
+++ b/src/pdf/annotation.rs
@@ -6,6 +6,7 @@ use std::{
 
 use mupdf_sys::*;
 
+use crate::pdf::object::TryAsCStr;
 use crate::{color::AnnotationColor, pdf::Intent};
 use crate::{context, from_enum, Error};
 use crate::{pdf::PdfFilterOptions, pdf::PdfObject, Matrix, Point, Quad, Rect};
@@ -629,9 +630,9 @@ impl PdfAnnotation {
         Ok(Some(c_str.to_str().map_err(|_| Error::InvalidUtf8)?))
     }
 
-    pub fn set_author(&mut self, author: &str) -> Result<(), Error> {
+    pub fn set_author(&mut self, author: impl TryAsCStr) -> Result<(), Error> {
         self.ensure_attached()?;
-        let c_author = CString::new(author)?;
+        let c_author = author.try_as_c_str()?;
         unsafe {
             ffi_try!(mupdf_pdf_set_annot_author(
                 context(),

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -10,6 +10,7 @@ use bitflags::bitflags;
 
 use mupdf_sys::*;
 
+use crate::pdf::object::TryAsCStr;
 use crate::pdf::{FontInfo, PdfGraftMap, PdfObject, PdfPage};
 use crate::{
     context, from_enum, Buffer, CjkFontOrdering, Destination, Document, Error, FilePath, Font,
@@ -297,11 +298,11 @@ impl PdfDocument {
         PdfObject::new_real(f)
     }
 
-    pub fn new_string(&self, s: &str) -> Result<PdfObject, Error> {
+    pub fn new_string(&self, s: impl TryAsCStr) -> Result<PdfObject, Error> {
         PdfObject::new_string(s)
     }
 
-    pub fn new_name(&self, name: &str) -> Result<PdfObject, Error> {
+    pub fn new_name(&self, name: impl TryAsCStr) -> Result<PdfObject, Error> {
         PdfObject::new_name(name)
     }
 
@@ -335,8 +336,8 @@ impl PdfDocument {
             .map(|inner| unsafe { PdfGraftMap::from_raw(inner) })
     }
 
-    pub fn new_object_from_str(&self, src: &str) -> Result<PdfObject, Error> {
-        let c_src = CString::new(src)?;
+    pub fn new_object_from_str(&self, src: impl TryAsCStr) -> Result<PdfObject, Error> {
+        let c_src = src.try_as_c_str()?;
         unsafe {
             ffi_try!(mupdf_pdf_obj_from_str(
                 context(),
@@ -606,8 +607,8 @@ impl PdfDocument {
         unsafe { ffi_try!(mupdf_pdf_delete_page(context(), self.inner, page_no)) }
     }
 
-    pub fn begin_operation(&self, op: &str) -> Result<(), Error> {
-        let c_op = CString::new(op).map_err(|_| Error::InvalidUtf8)?;
+    pub fn begin_operation(&self, op: impl TryAsCStr) -> Result<(), Error> {
+        let c_op = op.try_as_c_str()?;
         unsafe {
             ffi_try!(mupdf_pdf_begin_operation(
                 context(),
@@ -784,7 +785,7 @@ mod test {
     use crate::document::test_document;
     use crate::Buffer;
 
-    use super::{PdfDocument, PdfWriteOptions, Permission};
+    use super::{PdfDocument, PdfObject, PdfWriteOptions, Permission};
 
     #[test]
     fn test_pdf_write_options_passwords() {
@@ -998,5 +999,76 @@ mod test {
         assert_eq!(sentinel.as_string().unwrap(), "foo");
         assert_eq!(sentinel.to_string(), "(foo)");
         assert_eq!(obj.read_stream().unwrap(), b"dict payload");
+    }
+
+    #[test]
+    fn test_as_string_indirect_delete() {
+        let mut pdf = PdfDocument::new();
+
+        let original = "A".repeat(1000);
+
+        // 1. Create a direct string object (refcount=1)
+        let string_obj = PdfObject::new_string(&original).unwrap();
+
+        // 2. Add to document xref — returns an indirect reference.
+        //    Internally: pdf_update_object keeps the direct obj (refcount=2),
+        //    and returns a new indirect ref.
+        let indirect = pdf.add_object(&string_obj).unwrap();
+        assert!(indirect.is_indirect().unwrap());
+        let obj_num = indirect.as_indirect().unwrap();
+
+        // 3. Get string from the indirect ref.
+        let prd_str = indirect.as_string().unwrap();
+        assert_eq!(prd_str, original);
+
+        // 4. Drop the original direct PdfObject (refcount drops to 1)
+        //    (only the xref entry still holds a reference)
+        drop(string_obj);
+
+        // 5. Delete the xref entry (refcount drops to 0),
+        //    object and its text buffer are freed.
+        pdf.delete_object(obj_num).unwrap();
+
+        assert_eq!(prd_str, original);
+    }
+
+    #[test]
+    fn test_as_bytes_owned_indirect_delete() {
+        let mut pdf = PdfDocument::new();
+
+        let original = "A".repeat(1000);
+
+        let string_obj = PdfObject::new_string(&original).unwrap();
+        let indirect = pdf.add_object(&string_obj).unwrap();
+        let obj_num = indirect.as_indirect().unwrap();
+
+        // as_bytes() returns an owned CompactCBytes — safe even after deletion
+        let bytes = indirect.as_bytes().unwrap();
+        assert_eq!(bytes, original);
+
+        drop(string_obj);
+        pdf.delete_object(obj_num).unwrap();
+
+        // bytes is an owned copy — still valid
+        assert_eq!(bytes, original.as_bytes());
+    }
+
+    #[test]
+    fn test_as_name_indirect_delete() {
+        let mut pdf = PdfDocument::new();
+
+        let original = "A".repeat(100); // max == 127
+
+        let name_obj = PdfObject::new_name(&original).unwrap();
+        let indirect = pdf.add_object(&name_obj).unwrap();
+        let obj_num = indirect.as_indirect().unwrap();
+
+        let name = indirect.as_name().unwrap();
+        assert_eq!(name, original.as_bytes());
+
+        drop(name_obj);
+        pdf.delete_object(obj_num).unwrap();
+
+        assert_eq!(name, original.as_bytes());
     }
 }

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -1054,6 +1054,15 @@ mod test {
     }
 
     #[test]
+    fn test_as_bytes_preserves_nul_bytes() {
+        let pdf = PdfDocument::new();
+        let obj = pdf.new_object_from_str(r"(a\000b)").unwrap();
+
+        assert!(obj.is_string().unwrap());
+        assert_eq!(obj.as_bytes().unwrap().as_slice(), b"a\0b");
+    }
+
+    #[test]
     fn test_as_name_indirect_delete() {
         let mut pdf = PdfDocument::new();
 

--- a/src/pdf/links/extraction.rs
+++ b/src/pdf/links/extraction.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 
 use super::{FileSpec, LinkAction, PdfAction, PdfDestination};
 use crate::destination::not_nan;
-use crate::pdf::{PdfDocument, PdfObject};
+use crate::pdf::{CompactCString, PdfDocument, PdfObject};
 use crate::{DestinationKind, Error, Rect};
 
 /// Parses a [MuPDF-compatible] link URI string into a structured [`PdfAction`] based on the Adobe
@@ -563,10 +563,10 @@ fn parse_dest_value(dest: &PdfObject, doc: &PdfDocument) -> Result<Option<PdfDes
     if dest.is_array()? && dest.len()? > 0 {
         parse_dest_array(dest, doc).map(Some)
     } else if dest.is_name()? {
-        let name = std::str::from_utf8(dest.as_name()?).map_err(|_| Error::InvalidUtf8)?;
-        Ok(Some(PdfDestination::Named(name.to_owned())))
+        let name = CompactCString::try_from(dest.as_name()?)?.to_string();
+        Ok(Some(PdfDestination::Named(name)))
     } else if dest.is_string()? {
-        Ok(Some(PdfDestination::Named(dest.as_string()?.to_owned())))
+        Ok(Some(PdfDestination::Named(dest.as_string()?.to_string())))
     } else {
         Ok(None)
     }
@@ -695,7 +695,7 @@ fn parse_action_dict(
         return Ok(None);
     };
 
-    match type_obj.as_name()? {
+    match type_obj.as_name()?.as_slice() {
         b"GoTo" => {
             let Some(dest_obj) = action.get_dict("D")? else {
                 return Ok(None);
@@ -707,18 +707,18 @@ fn parse_action_dict(
             let Some(uri_obj) = action.get_dict("URI")? else {
                 return Ok(None);
             };
-            let uri = uri_obj.as_string()?.to_owned();
+            let uri = uri_obj.as_string()?;
             // MuPDF prepends the document URI base for non-external URIs.
             // pdf-link.c:536-543
             if is_external_link(&uri) {
-                Ok(Some(PdfAction::Uri(uri)))
+                Ok(Some(PdfAction::Uri(uri.to_string())))
             } else {
                 let base = doc
                     .trailer()?
                     .get_dict("Root")?
                     .and_then(|root| root.get_dict("URI").ok().flatten())
                     .and_then(|uri_dict| uri_dict.get_dict("Base").ok().flatten())
-                    .and_then(|base_obj| base_obj.as_string().ok().map(|s| s.to_owned()));
+                    .and_then(|base_obj| base_obj.as_string().ok().map(String::from));
                 let mut full_uri = base.unwrap_or_else(|| "file://".to_owned());
                 full_uri.reserve(uri.len());
                 full_uri.push_str(&uri);
@@ -741,11 +741,11 @@ fn parse_action_dict(
                         let kind = DestinationKind::decode_from(&dest)?;
                         PdfDestination::Page { page, kind }
                     } else if dest.is_name()? {
-                        let name =
-                            std::str::from_utf8(dest.as_name()?).map_err(|_| Error::InvalidUtf8)?;
-                        PdfDestination::Named(name.to_owned())
+                        PdfDestination::Named(
+                            CompactCString::try_from(dest.as_name()?)?.to_string(),
+                        )
                     } else if dest.is_string()? {
-                        PdfDestination::Named(dest.as_string()?.to_owned())
+                        PdfDestination::Named(dest.as_string()?.to_string())
                     } else {
                         PdfDestination::default()
                     }
@@ -766,7 +766,7 @@ fn parse_action_dict(
                 return Ok(None);
             };
             let total = doc.page_count()?;
-            let target = match dest_obj.as_name()? {
+            let target = match dest_obj.as_name()?.as_slice() {
                 b"FirstPage" => Some(0),
                 b"LastPage" => Some((total - 1).max(0)),
                 b"PrevPage" => page_no.map(|p| (p - 1).max(0)),
@@ -818,7 +818,7 @@ fn parse_action_dict(
 /// [`afterward`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L304
 fn parse_filespec(obj: &PdfObject) -> Result<FileSpec, Error> {
     if obj.is_string()? {
-        return Ok(FileSpec::Path(obj.as_string()?.to_owned()));
+        return Ok(FileSpec::Path(obj.as_string()?.to_string()));
     }
 
     if obj.is_dict()? {
@@ -829,14 +829,14 @@ fn parse_filespec(obj: &PdfObject) -> Result<FileSpec, Error> {
                 // `UF`, `Unix`, `DOS`, or `Mac` as URL text, as MuPDF does, since `F` should be
                 // only a 7-bit ASCII URL string, whereas `UF`, for example, is Unicode text.
                 if let Some(f) = obj.get_dict("F")? {
-                    return Ok(FileSpec::Url(f.as_string()?.to_owned()));
+                    return Ok(FileSpec::Url(f.as_string()?.to_string()));
                 }
             }
         }
 
         if let Some(name) = get_file_name(obj)? {
             if name.is_string()? {
-                return Ok(FileSpec::Path(name.as_string()?.to_owned()));
+                return Ok(FileSpec::Path(name.as_string()?.to_string()));
             }
         }
     }

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -10,6 +10,8 @@ pub mod page;
 #[cfg(test)]
 mod tests_annotation;
 
+pub use compact_cstr::{CompactCBytes, CompactCString};
+
 pub use annotation::{
     AnnotationArea, AnnotationBorderEffect, AnnotationBorderStyle, AnnotationDefaultAppearance,
     AnnotationFlags, AnnotationQuadPoints, AnnotationTextAlign, LineEndingStyle, PdfAnnotation,
@@ -23,7 +25,7 @@ pub use intent::Intent;
 pub use links::{
     DestPageResolver, FileSpec, LinkAction, PdfAction, PdfDestination, PdfLink, PdfLinkAnnot,
 };
-pub use object::PdfObject;
+pub use object::{IntoPdfDictKey, PdfObject, TryAsCStr};
 pub use page::{FontInfo, InsertFontOptions, PdfPage};
 
 #[must_use]

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
 use std::fmt;
@@ -5,6 +6,7 @@ use std::io::{self, BufReader, Read, Write};
 use std::slice;
 use std::str::FromStr;
 
+use compact_cstr::{CompactCBytes, CompactCString};
 use mupdf_sys::*;
 
 use crate::pdf::PdfDocument;
@@ -26,9 +28,81 @@ impl IntoPdfDictKey for String {
     }
 }
 
+impl IntoPdfDictKey for &CStr {
+    fn into_pdf_dict_key(self) -> Result<PdfObject, Error> {
+        PdfObject::new_name(self)
+    }
+}
+
+impl IntoPdfDictKey for CString {
+    fn into_pdf_dict_key(self) -> Result<PdfObject, Error> {
+        PdfObject::new_name(&self)
+    }
+}
+
 impl IntoPdfDictKey for PdfObject {
     fn into_pdf_dict_key(self) -> Result<PdfObject, Error> {
         Ok(self)
+    }
+}
+
+impl IntoPdfDictKey for CompactCString {
+    #[inline]
+    fn into_pdf_dict_key(self) -> Result<PdfObject, Error> {
+        PdfObject::new_name(self)
+    }
+}
+
+impl IntoPdfDictKey for &CompactCString {
+    #[inline]
+    fn into_pdf_dict_key(self) -> Result<PdfObject, Error> {
+        PdfObject::new_name(self)
+    }
+}
+
+pub trait TryAsCStr {
+    fn try_as_c_str(&self) -> Result<Cow<'_, CStr>, Error>;
+}
+
+impl TryAsCStr for str {
+    #[inline]
+    fn try_as_c_str(&self) -> Result<Cow<'_, CStr>, Error> {
+        Ok(Cow::Owned(CString::new(self)?))
+    }
+}
+
+impl TryAsCStr for String {
+    #[inline]
+    fn try_as_c_str(&self) -> Result<Cow<'_, CStr>, Error> {
+        Ok(Cow::Owned(CString::new(self.as_str())?))
+    }
+}
+
+impl TryAsCStr for CStr {
+    #[inline]
+    fn try_as_c_str(&self) -> Result<Cow<'_, CStr>, Error> {
+        Ok(Cow::Borrowed(self))
+    }
+}
+
+impl TryAsCStr for CString {
+    #[inline]
+    fn try_as_c_str(&self) -> Result<Cow<'_, CStr>, Error> {
+        Ok(Cow::Borrowed(self))
+    }
+}
+
+impl TryAsCStr for CompactCString {
+    #[inline]
+    fn try_as_c_str(&self) -> Result<Cow<'_, CStr>, Error> {
+        Ok(Cow::Borrowed(self.as_cstr()))
+    }
+}
+
+impl<T: TryAsCStr + ?Sized> TryAsCStr for &T {
+    #[inline]
+    fn try_as_c_str(&self) -> Result<Cow<'_, CStr>, Error> {
+        (**self).try_as_c_str()
     }
 }
 
@@ -75,14 +149,14 @@ impl PdfObject {
             .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
-    pub fn new_string(s: &str) -> Result<PdfObject, Error> {
-        let c_str = CString::new(s)?;
+    pub fn new_string(s: impl TryAsCStr) -> Result<PdfObject, Error> {
+        let c_str = s.try_as_c_str()?;
         unsafe { ffi_try!(mupdf_pdf_new_string(context(), c_str.as_ptr())) }
             .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
 
-    pub fn new_name(name: &str) -> Result<PdfObject, Error> {
-        let c_name = CString::new(name)?;
+    pub fn new_name(name: impl TryAsCStr) -> Result<PdfObject, Error> {
+        let c_name = name.try_as_c_str()?;
         unsafe { ffi_try!(mupdf_pdf_new_name(context(), c_name.as_ptr())) }
             .map(|inner| unsafe { PdfObject::from_raw(inner) })
     }
@@ -147,22 +221,27 @@ impl PdfObject {
         unsafe { ffi_try!(mupdf_pdf_to_indirect(context(), self.inner)) }
     }
 
-    pub fn as_name(&self) -> Result<&[u8], Error> {
+    pub fn as_name(&self) -> Result<CompactCBytes, Error> {
         let name_ptr = unsafe { ffi_try!(mupdf_pdf_to_name(context(), self.inner)) }?;
-        let c_name = unsafe { CStr::from_ptr(name_ptr) };
-        Ok(c_name.to_bytes())
+        Ok(CompactCBytes::from(unsafe { CStr::from_ptr(name_ptr) }))
     }
 
-    pub fn as_string(&self) -> Result<&str, Error> {
+    /// Compare this name object to a string.
+    /// Returns `false` if this object is not a name or does not match.
+    pub fn name_eq(&self, name: impl AsRef<[u8]>) -> bool {
+        self.as_name().is_ok_and(|bytes| bytes == name.as_ref())
+    }
+
+    pub fn as_string(&self) -> Result<CompactCString, Error> {
         let str_ptr = unsafe { ffi_try!(mupdf_pdf_to_string(context(), self.inner)) }?;
-        let c_str = unsafe { CStr::from_ptr(str_ptr) };
-        c_str.to_str().map_err(|_| Error::InvalidUtf8)
+        CompactCString::try_from(unsafe { CStr::from_ptr(str_ptr) }).map_err(Into::into)
     }
 
-    pub fn as_bytes(&self) -> Result<&[u8], Error> {
+    pub fn as_bytes(&self) -> Result<CompactCBytes, Error> {
         let mut len = 0;
         let ptr = unsafe { ffi_try!(mupdf_pdf_to_bytes(context(), self.inner, &mut len)) }?;
-        Ok(unsafe { slice::from_raw_parts(ptr, len) })
+        let bytes = unsafe { slice::from_raw_parts(ptr, len) };
+        CompactCBytes::try_from(bytes).map_err(Into::into)
     }
 
     pub fn resolve(&self) -> Result<Option<Self>, Error> {

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -229,7 +229,7 @@ impl PdfObject {
     /// Compare this name object to a string.
     /// Returns `false` if this object is not a name or does not match.
     pub fn name_eq(&self, name: impl AsRef<[u8]>) -> bool {
-        self.as_name().is_ok_and(|bytes| bytes == name.as_ref())
+        self.is_name().unwrap_or(false) && self.as_name().is_ok_and(|bytes| bytes == name.as_ref())
     }
 
     pub fn as_string(&self) -> Result<CompactCString, Error> {

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -660,7 +660,8 @@ impl PdfPage {
             let Some(key) = ext_gstates.get_dict_key(idx as i32)? else {
                 continue;
             };
-            let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+            let key_bytes = key.as_name()?;
+            let Ok(key_name) = str::from_utf8(&key_bytes) else {
                 continue;
             };
             let Some(value) = ext_gstates.get_dict_val(idx as i32)? else {
@@ -682,7 +683,8 @@ impl PdfPage {
                 let Some(key) = ext_gstates.get_dict_key(idx as i32)? else {
                     continue;
                 };
-                let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+                let key_bytes = key.as_name()?;
+                let Ok(key_name) = str::from_utf8(&key_bytes) else {
                     continue;
                 };
                 let Some(index) = key_name
@@ -730,7 +732,8 @@ impl PdfPage {
             )));
         }
 
-        match type_obj.as_name()? {
+        let type_name = type_obj.as_name()?;
+        match type_name.as_slice() {
             b"OCG" | b"OCMD" => Ok(()),
             _ => Err(Error::InvalidArgument(format!(
                 "optional content xref {oc_xref} must have /Type /OCG or /OCMD"
@@ -848,7 +851,8 @@ impl PdfPage {
             let Some(key) = properties.get_dict_key(idx as i32)? else {
                 continue;
             };
-            let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+            let key_bytes = key.as_name()?;
+            let Ok(key_name) = str::from_utf8(&key_bytes) else {
                 continue;
             };
             let Some(value) = properties.get_dict_val(idx as i32)? else {
@@ -872,7 +876,8 @@ impl PdfPage {
                 let Some(key) = properties.get_dict_key(idx as i32)? else {
                     continue;
                 };
-                let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+                let key_bytes = key.as_name()?;
+                let Ok(key_name) = str::from_utf8(&key_bytes) else {
                     continue;
                 };
                 let Some(index) = key_name
@@ -1029,7 +1034,8 @@ impl PdfPage {
 
     fn resource_font_base_name(font_obj: &PdfObject) -> Result<Option<String>, Error> {
         if let Some(base_font) = font_obj.get_dict("BaseFont")? {
-            let base_font = str::from_utf8(base_font.as_name()?)
+            let base_font_bytes = base_font.as_name()?;
+            let base_font = str::from_utf8(&base_font_bytes)
                 .map(Self::normalized_base_font_name)
                 .map(str::to_owned)
                 .ok();
@@ -1048,7 +1054,8 @@ impl PdfPage {
             return Ok(None);
         };
 
-        Ok(str::from_utf8(base_font.as_name()?)
+        let base_font_bytes = base_font.as_name()?;
+        Ok(str::from_utf8(&base_font_bytes)
             .map(Self::normalized_base_font_name)
             .map(str::to_owned)
             .ok())
@@ -1065,7 +1072,7 @@ impl PdfPage {
             let Ok(encoding_name) = encoding.as_name() else {
                 return Ok(None);
             };
-            let Ok(encoding_name) = str::from_utf8(encoding_name) else {
+            let Ok(encoding_name) = str::from_utf8(&encoding_name) else {
                 return Ok(None);
             };
             return match encoding_name {
@@ -1085,7 +1092,7 @@ impl PdfPage {
             let Ok(name) = item.as_name() else {
                 continue;
             };
-            let Ok(name) = str::from_utf8(name) else {
+            let Ok(name) = str::from_utf8(&name) else {
                 continue;
             };
             if name.contains("cyrillic") || name.starts_with("afii10") {
@@ -1159,7 +1166,8 @@ impl PdfPage {
             let Some(key) = font_dict.get_dict_key(idx as i32)? else {
                 continue;
             };
-            let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+            let key_bytes = key.as_name()?;
+            let Ok(key_name) = str::from_utf8(&key_bytes) else {
                 continue;
             };
             let Some(value) = font_dict.get_dict_val(idx as i32)? else {
@@ -1209,7 +1217,8 @@ impl PdfPage {
                 let Some(key) = font_dict.get_dict_key(idx as i32)? else {
                     continue;
                 };
-                let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+                let key_bytes = key.as_name()?;
+                let Ok(key_name) = str::from_utf8(&key_bytes) else {
                     continue;
                 };
                 let Some(index) = key_name

--- a/src/shape/finish.rs
+++ b/src/shape/finish.rs
@@ -337,7 +337,7 @@ mod tests {
         (0..properties.dict_len().unwrap())
             .map(|index| {
                 let key = properties.get_dict_key(index as i32).unwrap().unwrap();
-                let key = str::from_utf8(key.as_name().unwrap()).unwrap().to_owned();
+                let key = str::from_utf8(&key.as_name().unwrap()).unwrap().to_owned();
                 let value = properties.get_dict_val(index as i32).unwrap().unwrap();
                 (key, value)
             })
@@ -349,7 +349,7 @@ mod tests {
         (0..ext_gstates.dict_len().unwrap())
             .map(|index| {
                 let key = ext_gstates.get_dict_key(index as i32).unwrap().unwrap();
-                let key = str::from_utf8(key.as_name().unwrap()).unwrap().to_owned();
+                let key = str::from_utf8(&key.as_name().unwrap()).unwrap().to_owned();
                 let value = ext_gstates.get_dict_val(index as i32).unwrap().unwrap();
                 (key, value)
             })


### PR DESCRIPTION
Closes #207. Return owned types instead of borrowed references:

| Before                | After                      |
|-----------------------|----------------------------|
| `as_string() -> &str` | `as_string() -> PdfString` |
| `as_name() -> &[u8]`  | `as_name() -> PdfVec`      |
| `as_bytes() -> &[u8]` | `as_bytes() -> PdfVec`     |

I decided to use custom `PdfString` / `PdfVec` types instead of `String` / `Vec<u8>` because these custom structures allow the following:

- Inline storage (up to 23 bytes) with no heap allocation, which covers 99% of standard PDF names (`Type`, `Subtype`, `Font`, `Rect`, ...) and most short string values.
- Heap allocation uses `ecow::EcoVec<u8>` which is a **reference-counted**, copy-on-write vector. Since we do not need to mutate the returned strings, I think that cheap cloning is preferable.

I didn't use existing Rust crates, since most compact string crates (e.g. `compact_str`, `ecow::EcoString`, etc.) are designed for Rust strings and cannot provide all of the following at the same time:

- Inline storage;
- Cheap `&CStr` conversion without allocation;
- Niche optimization.

`PdfString` / `PdfVec` are NUL-terminated, so `.as_cstr()` is just a pointer cast. Additionally, they support niche optimization, so `Option<PdfString>` / `Option<PdfVec>` have the same size as the structures themselves.

I also added a helper `TryAsCStr` trait so functions like `get_dict`, `new_name`, and `new_string` accept not only `&str`, but also `&CStr` or `PdfString` directly. This allows avoiding runtime `CString` allocations when the caller already has a NUL-terminated value (e.g. passing `c"Subtype"` instead of `"Subtype"`).