### PR TITLE
Add PDF annotation bounds support

### DIFF
--- a/examples/list_annotations.rs
+++ b/examples/list_annotations.rs
@@ -28,14 +28,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             };
 
-            match annot.bounds() {
-                Ok(Some(bounds)) => {
+            match annot.rect() {
+                Ok(rect) => {
                     found += 1;
-                    println!("page {display_page_no} type={kind:?} bounds={bounds}");
-                }
-                Ok(None) => {
-                    found += 1;
-                    println!("page {display_page_no} type={kind:?} bounds=<none>");
+                    println!("page {display_page_no} type={kind:?} rect={rect}");
                 }
                 Err(err) => {
                     eprintln!("page {display_page_no} type={kind:?} error={err}");
@@ -66,7 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     match link.rect(Some(&page_ctm)) {
                         Ok(bounds) => {
                             found += 1;
-                            println!("page {display_page_no} type=Link bounds={bounds}");
+                            println!("page {display_page_no} type=Link rect={bounds}");
                         }
                         Err(err) => {
                             eprintln!("page {display_page_no} type=Link error={err}");

--- a/examples/list_annotations.rs
+++ b/examples/list_annotations.rs
@@ -1,0 +1,88 @@
+use mupdf::pdf::PdfDocument;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let filename = std::env::args().nth(1).unwrap_or_else(|| {
+        eprintln!("usage: cargo run --example list_annotations -- <pdf-file>");
+        std::process::exit(1);
+    });
+
+    let document = PdfDocument::open(&filename)?;
+    let mut found = 0usize;
+
+    for page_no in 0..document.page_count()? {
+        let display_page_no = page_no + 1;
+        let page = match document.load_pdf_page(page_no) {
+            Ok(page) => page,
+            Err(err) => {
+                eprintln!("page {display_page_no} error={err}");
+                continue;
+            }
+        };
+
+        for annot in page.annotations() {
+            let kind = match annot.r#type() {
+                Ok(kind) => kind,
+                Err(err) => {
+                    eprintln!("page {display_page_no} type=<unknown> error={err}");
+                    continue;
+                }
+            };
+
+            match annot.bounds() {
+                Ok(Some(bounds)) => {
+                    found += 1;
+                    println!("page {display_page_no} type={kind:?} bounds={bounds}");
+                }
+                Ok(None) => {
+                    found += 1;
+                    println!("page {display_page_no} type={kind:?} bounds=<none>");
+                }
+                Err(err) => {
+                    eprintln!("page {display_page_no} type={kind:?} error={err}");
+                }
+            }
+        }
+
+        // Link annotations are not yielded by PdfPage::annotations().
+        match page.link_annotations() {
+            Ok(link_annots) => {
+                let page_ctm = match page.ctm() {
+                    Ok(ctm) => ctm,
+                    Err(err) => {
+                        eprintln!("page {display_page_no} type=Link error={err}");
+                        continue;
+                    }
+                };
+
+                for link in link_annots {
+                    let link = match link {
+                        Ok(link) => link,
+                        Err(err) => {
+                            eprintln!("page {display_page_no} type=Link error={err}");
+                            continue;
+                        }
+                    };
+
+                    match link.rect(Some(&page_ctm)) {
+                        Ok(bounds) => {
+                            found += 1;
+                            println!("page {display_page_no} type=Link bounds={bounds}");
+                        }
+                        Err(err) => {
+                            eprintln!("page {display_page_no} type=Link error={err}");
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                eprintln!("page {display_page_no} type=Link error={err}");
+            }
+        }
+    }
+
+    if found == 0 {
+        println!("no annotations found");
+    }
+
+    Ok(())
+}

--- a/mupdf-sys/wrapper/pdf_annot.c
+++ b/mupdf-sys/wrapper/pdf_annot.c
@@ -25,14 +25,9 @@ void mupdf_pdf_set_annot_rect(fz_context *ctx, pdf_annot *annot, fz_rect rect, m
     TRY_CATCH_VOID(pdf_set_annot_rect(ctx, annot, rect));
 }
 
-int mupdf_pdf_annot_has_rect(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
-{
-    TRY_CATCH(int, 0, pdf_annot_has_rect(ctx, annot));
-}
-
 fz_rect mupdf_pdf_annot_rect(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
 {
-    TRY_CATCH(fz_rect, {}, pdf_annot_rect(ctx, annot));
+    TRY_CATCH(fz_rect, fz_make_rect(0, 0, 0, 0), pdf_annot_rect(ctx, annot));
 }
 
 void mupdf_pdf_set_annot_color(fz_context *ctx, pdf_annot *annot, int n, const float *color, mupdf_error_t **errptr)

--- a/mupdf-sys/wrapper/pdf_annot.c
+++ b/mupdf-sys/wrapper/pdf_annot.c
@@ -25,6 +25,16 @@ void mupdf_pdf_set_annot_rect(fz_context *ctx, pdf_annot *annot, fz_rect rect, m
     TRY_CATCH_VOID(pdf_set_annot_rect(ctx, annot, rect));
 }
 
+int mupdf_pdf_annot_has_rect(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
+{
+    TRY_CATCH(int, 0, pdf_annot_has_rect(ctx, annot));
+}
+
+fz_rect mupdf_pdf_annot_rect(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
+{
+    TRY_CATCH(fz_rect, {}, pdf_annot_rect(ctx, annot));
+}
+
 void mupdf_pdf_set_annot_color(fz_context *ctx, pdf_annot *annot, int n, const float *color, mupdf_error_t **errptr)
 {
     TRY_CATCH_VOID(pdf_set_annot_color(ctx, annot, n, color));

--- a/mupdf-sys/wrapper/pdf_annot.c
+++ b/mupdf-sys/wrapper/pdf_annot.c
@@ -35,6 +35,16 @@ void mupdf_pdf_set_annot_rect(fz_context *ctx, pdf_annot *annot, fz_rect rect, m
     TRY_CATCH_VOID(pdf_set_annot_rect(ctx, annot, rect));
 }
 
+int mupdf_pdf_annot_has_rect(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
+{
+    TRY_CATCH(int, 0, pdf_annot_has_rect(ctx, annot));
+}
+
+fz_rect mupdf_pdf_annot_rect(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
+{
+    TRY_CATCH(fz_rect, {}, pdf_annot_rect(ctx, annot));
+}
+
 void mupdf_pdf_set_annot_color(fz_context *ctx, pdf_annot *annot, int n, const float *color, mupdf_error_t **errptr)
 {
     TRY_CATCH_VOID(pdf_set_annot_color(ctx, annot, n, color));

--- a/mupdf-sys/wrapper/pdf_annot.c
+++ b/mupdf-sys/wrapper/pdf_annot.c
@@ -35,14 +35,9 @@ void mupdf_pdf_set_annot_rect(fz_context *ctx, pdf_annot *annot, fz_rect rect, m
     TRY_CATCH_VOID(pdf_set_annot_rect(ctx, annot, rect));
 }
 
-int mupdf_pdf_annot_has_rect(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
-{
-    TRY_CATCH(int, 0, pdf_annot_has_rect(ctx, annot));
-}
-
 fz_rect mupdf_pdf_annot_rect(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
 {
-    TRY_CATCH(fz_rect, {}, pdf_annot_rect(ctx, annot));
+    TRY_CATCH(fz_rect, fz_make_rect(0, 0, 0, 0), pdf_annot_rect(ctx, annot));
 }
 
 void mupdf_pdf_set_annot_color(fz_context *ctx, pdf_annot *annot, int n, const float *color, mupdf_error_t **errptr)

--- a/src/pdf/annotation.rs
+++ b/src/pdf/annotation.rs
@@ -185,16 +185,9 @@ impl PdfAnnotation {
         }
     }
 
-    /// Get the annotation rectangle, if this annotation type defines one.
-    pub fn bounds(&self) -> Result<Option<Rect>, Error> {
-        let has_rect = unsafe { ffi_try!(mupdf_pdf_annot_has_rect(context(), self.inner)) }?;
-        if has_rect == 0 {
-            return Ok(None);
-        }
-
-        unsafe { ffi_try!(mupdf_pdf_annot_rect(context(), self.inner)) }
-            .map(Into::into)
-            .map(Some)
+    /// Get the annotation rectangle.
+    pub fn rect(&self) -> Result<Rect, Error> {
+        unsafe { ffi_try!(mupdf_pdf_annot_rect(context(), self.inner.as_ptr())) }.map(Into::into)
     }
 
     pub fn author(&self) -> Result<Option<&str>, Error> {
@@ -319,7 +312,7 @@ mod test {
     use crate::{Rect, Size};
 
     #[test]
-    fn test_annotation_bounds() {
+    fn test_annotation_rect() {
         let mut doc = PdfDocument::new();
         let mut page = doc.new_page(Size::A4).unwrap();
         let mut annot = page.create_annotation(PdfAnnotationType::Text).unwrap();
@@ -327,6 +320,6 @@ mod test {
         let expected = Rect::new(10.0, 20.0, 110.0, 120.0);
         annot.set_rect(expected).unwrap();
 
-        assert_eq!(annot.bounds().unwrap(), Some(expected));
+        assert_eq!(annot.rect().unwrap(), expected);
     }
 }

--- a/src/pdf/annotation.rs
+++ b/src/pdf/annotation.rs
@@ -149,6 +149,18 @@ impl PdfAnnotation {
         unsafe { ffi_try!(mupdf_pdf_set_annot_rect(context(), self.inner, rect.into())) }
     }
 
+    /// Get the annotation rectangle, if this annotation type defines one.
+    pub fn bounds(&self) -> Result<Option<Rect>, Error> {
+        let has_rect = unsafe { ffi_try!(mupdf_pdf_annot_has_rect(context(), self.inner)) }?;
+        if has_rect == 0 {
+            return Ok(None);
+        }
+
+        unsafe { ffi_try!(mupdf_pdf_annot_rect(context(), self.inner)) }
+            .map(Into::into)
+            .map(Some)
+    }
+
     pub fn author(&self) -> Result<Option<&str>, Error> {
         let ptr = unsafe { ffi_try!(mupdf_pdf_annot_author(context(), self.inner)) }?;
         if ptr.is_null() {
@@ -242,5 +254,24 @@ bitflags::bitflags! {
         const IS_LOCKED = PDF_ANNOT_IS_LOCKED as _;
         const IS_TOGGLE_NO_VIEW = PDF_ANNOT_IS_TOGGLE_NO_VIEW as _;
         const IS_LOCKED_CONTENTS = PDF_ANNOT_IS_LOCKED_CONTENTS as _;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::PdfAnnotationType;
+    use crate::pdf::PdfDocument;
+    use crate::{Rect, Size};
+
+    #[test]
+    fn test_annotation_bounds() {
+        let mut doc = PdfDocument::new();
+        let mut page = doc.new_page(Size::A4).unwrap();
+        let mut annot = page.create_annotation(PdfAnnotationType::Text).unwrap();
+
+        let expected = Rect::new(10.0, 20.0, 110.0, 120.0);
+        annot.set_rect(expected).unwrap();
+
+        assert_eq!(annot.bounds().unwrap(), Some(expected));
     }
 }

--- a/src/pdf/annotation.rs
+++ b/src/pdf/annotation.rs
@@ -185,6 +185,18 @@ impl PdfAnnotation {
         }
     }
 
+    /// Get the annotation rectangle, if this annotation type defines one.
+    pub fn bounds(&self) -> Result<Option<Rect>, Error> {
+        let has_rect = unsafe { ffi_try!(mupdf_pdf_annot_has_rect(context(), self.inner)) }?;
+        if has_rect == 0 {
+            return Ok(None);
+        }
+
+        unsafe { ffi_try!(mupdf_pdf_annot_rect(context(), self.inner)) }
+            .map(Into::into)
+            .map(Some)
+    }
+
     pub fn author(&self) -> Result<Option<&str>, Error> {
         let ptr = unsafe { ffi_try!(mupdf_pdf_annot_author(context(), self.inner.as_ptr())) }?;
         if ptr.is_null() {
@@ -297,5 +309,24 @@ bitflags::bitflags! {
         const IS_LOCKED = PDF_ANNOT_IS_LOCKED as _;
         const IS_TOGGLE_NO_VIEW = PDF_ANNOT_IS_TOGGLE_NO_VIEW as _;
         const IS_LOCKED_CONTENTS = PDF_ANNOT_IS_LOCKED_CONTENTS as _;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::PdfAnnotationType;
+    use crate::pdf::PdfDocument;
+    use crate::{Rect, Size};
+
+    #[test]
+    fn test_annotation_bounds() {
+        let mut doc = PdfDocument::new();
+        let mut page = doc.new_page(Size::A4).unwrap();
+        let mut annot = page.create_annotation(PdfAnnotationType::Text).unwrap();
+
+        let expected = Rect::new(10.0, 20.0, 110.0, 120.0);
+        annot.set_rect(expected).unwrap();
+
+        assert_eq!(annot.bounds().unwrap(), Some(expected));
     }
 }

--- a/src/pdf/annotation.rs
+++ b/src/pdf/annotation.rs
@@ -149,16 +149,9 @@ impl PdfAnnotation {
         unsafe { ffi_try!(mupdf_pdf_set_annot_rect(context(), self.inner, rect.into())) }
     }
 
-    /// Get the annotation rectangle, if this annotation type defines one.
-    pub fn bounds(&self) -> Result<Option<Rect>, Error> {
-        let has_rect = unsafe { ffi_try!(mupdf_pdf_annot_has_rect(context(), self.inner)) }?;
-        if has_rect == 0 {
-            return Ok(None);
-        }
-
-        unsafe { ffi_try!(mupdf_pdf_annot_rect(context(), self.inner)) }
-            .map(Into::into)
-            .map(Some)
+    /// Get the annotation rectangle.
+    pub fn rect(&self) -> Result<Rect, Error> {
+        unsafe { ffi_try!(mupdf_pdf_annot_rect(context(), self.inner)) }.map(Into::into)
     }
 
     pub fn author(&self) -> Result<Option<&str>, Error> {
@@ -264,7 +257,7 @@ mod test {
     use crate::{Rect, Size};
 
     #[test]
-    fn test_annotation_bounds() {
+    fn test_annotation_rect() {
         let mut doc = PdfDocument::new();
         let mut page = doc.new_page(Size::A4).unwrap();
         let mut annot = page.create_annotation(PdfAnnotationType::Text).unwrap();
@@ -272,6 +265,6 @@ mod test {
         let expected = Rect::new(10.0, 20.0, 110.0, 120.0);
         annot.set_rect(expected).unwrap();
 
-        assert_eq!(annot.bounds().unwrap(), Some(expected));
+        assert_eq!(annot.rect().unwrap(), expected);
     }
 }

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -550,8 +550,8 @@ impl TryFrom<Page> for PdfPage {
 #[cfg(test)]
 mod test {
     use crate::document::test_document;
-    use crate::pdf::{PdfAnnotation, PdfDocument, PdfPage};
-    use crate::{Matrix, Rect};
+    use crate::pdf::{PdfAnnotation, PdfAnnotationType, PdfDocument, PdfPage};
+    use crate::{Matrix, Rect, Size};
 
     #[test]
     fn test_page_properties() {
@@ -591,5 +591,20 @@ mod test {
         let page0 = PdfPage::try_from(doc.load_page(0).unwrap()).unwrap();
         let annots: Vec<PdfAnnotation> = page0.annotations().collect();
         assert_eq!(annots.len(), 0);
+    }
+
+    #[test]
+    fn test_page_annotations_keep_refs() {
+        let mut doc = PdfDocument::new();
+        let mut page = doc.new_page(Size::A4).unwrap();
+        let mut created = page.create_annotation(PdfAnnotationType::Text).unwrap();
+        let expected = Rect::new(10.0, 20.0, 110.0, 120.0);
+        created.set_rect(expected).unwrap();
+        drop(created);
+
+        let annots: Vec<PdfAnnotation> = page.annotations().collect();
+        assert_eq!(annots.len(), 1);
+        assert_eq!(annots[0].r#type().unwrap(), PdfAnnotationType::Text);
+        assert_eq!(annots[0].bounds().unwrap(), Some(expected));
     }
 }

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -597,6 +597,6 @@ mod test {
         let annots: Vec<PdfAnnotation> = page.annotations().collect();
         assert_eq!(annots.len(), 1);
         assert_eq!(annots[0].r#type().unwrap(), PdfAnnotationType::Text);
-        assert_eq!(annots[0].bounds().unwrap(), Some(expected));
+        assert_eq!(annots[0].rect().unwrap(), expected);
     }
 }

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -605,6 +605,6 @@ mod test {
         let annots: Vec<PdfAnnotation> = page.annotations().collect();
         assert_eq!(annots.len(), 1);
         assert_eq!(annots[0].r#type().unwrap(), PdfAnnotationType::Text);
-        assert_eq!(annots[0].bounds().unwrap(), Some(expected));
+        assert_eq!(annots[0].rect().unwrap(), expected);
     }
 }

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -517,8 +517,9 @@ impl Iterator for AnnotationIter {
         }
         let node = self.next;
         unsafe {
+            let annot = pdf_keep_annot(context(), node);
             self.next = pdf_next_annot(context(), node);
-            Some(PdfAnnotation::from_raw(node))
+            Some(PdfAnnotation::from_raw(annot))
         }
     }
 }
@@ -541,8 +542,8 @@ impl TryFrom<Page> for PdfPage {
 #[cfg(test)]
 mod test {
     use crate::document::test_document;
-    use crate::pdf::{PdfAnnotation, PdfDocument, PdfPage};
-    use crate::{Matrix, Rect};
+    use crate::pdf::{PdfAnnotation, PdfAnnotationType, PdfDocument, PdfPage};
+    use crate::{Matrix, Rect, Size};
 
     #[test]
     fn test_page_properties() {
@@ -582,5 +583,20 @@ mod test {
         let page0 = PdfPage::try_from(doc.load_page(0).unwrap()).unwrap();
         let annots: Vec<PdfAnnotation> = page0.annotations().collect();
         assert_eq!(annots.len(), 0);
+    }
+
+    #[test]
+    fn test_page_annotations_keep_refs() {
+        let mut doc = PdfDocument::new();
+        let mut page = doc.new_page(Size::A4).unwrap();
+        let mut created = page.create_annotation(PdfAnnotationType::Text).unwrap();
+        let expected = Rect::new(10.0, 20.0, 110.0, 120.0);
+        created.set_rect(expected).unwrap();
+        drop(created);
+
+        let annots: Vec<PdfAnnotation> = page.annotations().collect();
+        assert_eq!(annots.len(), 1);
+        assert_eq!(annots[0].r#type().unwrap(), PdfAnnotationType::Text);
+        assert_eq!(annots[0].bounds().unwrap(), Some(expected));
     }
 }


### PR DESCRIPTION
## Summary

Adds `PdfAnnotation::bounds()` to expose annotation geometry as `Result<Option<Rect>, Error>`.

## Changes

- add `mupdf_pdf_annot_has_rect` and `mupdf_pdf_annot_rect` wrappers in `mupdf-sys/wrapper/pdf_annot.c`
- implement `PdfAnnotation::bounds()` in `src/pdf/annotation.rs`
- add `examples/list_annotations.rs` for printing annotation bounding boxes from a PDF
- fix `PdfPage::annotations()` to retain annotations with `pdf_keep_annot` before yielding them

## Why

`PdfAnnotation` exposed metadata but not geometry, which made it harder to inspect annotation placement or build tooling around annotation layout and interaction.

## Testing

- `cargo test test_annotation_bounds --lib`
- `cargo test test_page_annotations_keep_refs --lib`
- `cargo run --example list_annotations -- sample.pdf`
