### PR TITLE
Tolerate unset FEATURE env var

### DIFF
--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -336,8 +336,10 @@ impl Target {
             os: env::var("CARGO_CFG_TARGET_OS")?,
             env: env::var("CARGO_CFG_TARGET_ENV")?,
 
-            features: env::var("CARGO_CFG_TARGET_FEATURE")?
+            features: env::var("CARGO_CFG_TARGET_FEATURE")
+                .unwrap_or_default()
                 .split(',')
+                .filter(|feature| !feature.is_empty())
                 .map(str::to_owned)
                 .collect(),
         })


### PR DESCRIPTION
When building for armeabi v7 (armv7), there are no features on the target (arm64 has `neon`, for example), so the build fails.