### PR TITLE
Allow disabling base14 fonts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/messense/mupdf-rs"
 
 [features]
-default = ["js", "xps", "svg", "cbz", "img", "html", "epub", "system-fonts", "tesseract"]
+default = ["js", "xps", "svg", "cbz", "img", "html", "epub", "system-fonts", "tesseract", "base14-fonts"]
 
 # Use system libs for all thirdparty libs
 sys-lib = ["mupdf-sys/sys-lib"]
@@ -41,6 +41,7 @@ sys-lib-zxingcpp = ["mupdf-sys/sys-lib-zxingcpp"]
 sys-lib-brotli = ["mupdf-sys/sys-lib-brotli"]
 
 all-fonts = ["mupdf-sys/all-fonts"]
+base14-fonts = ["mupdf-sys/base14-fonts"]
 system-fonts = ["font-kit"]
 
 js = ["mupdf-sys/js"]

--- a/mupdf-sys/Cargo.toml
+++ b/mupdf-sys/Cargo.toml
@@ -216,6 +216,7 @@ sys-lib-zxingcpp = []
 sys-lib-brotli = []
 
 all-fonts = []
+base14-fonts = []
 
 js = []
 xps = []

--- a/mupdf-sys/androidfonts.c
+++ b/mupdf-sys/androidfonts.c
@@ -46,6 +46,17 @@ static fz_font *load_noto_try(fz_context *ctx, const char *stem)
 	return font;
 }
 
+static const char *android_style_suffix(int bold, int italic)
+{
+	if (bold && italic)
+		return "-BoldItalic";
+	if (bold)
+		return "-Bold";
+	if (italic)
+		return "-Italic";
+	return "-Regular";
+}
+
 enum { JP, KR, SC, TC };
 
 fz_font *load_droid_fallback_font(fz_context *ctx, int script, int language, int serif, int bold, int italic)
@@ -237,5 +248,50 @@ fz_font *load_droid_cjk_font(fz_context *ctx, const char *name, int ros, int ser
 
 fz_font *load_droid_font(fz_context *ctx, const char *name, int bold, int italic, int needs_exact_metrics)
 {
+	fz_font *font = NULL;
+	const char *style = android_style_suffix(bold, italic);
+
+	(void)needs_exact_metrics;
+
+	if (!name)
+		return NULL;
+
+	if (!fz_strcasecmp(name, "Helvetica") || !fz_strcasecmp(name, "Arial") || strstr(name, "Helvetica") || strstr(name, "Arial"))
+	{
+		font = load_noto(ctx, "Roboto", "", style, 0);
+		if (!font) font = load_noto(ctx, "NotoSans", "", style, 0);
+		if (!font) font = load_noto(ctx, "DroidSans", "", style, 0);
+		return font;
+	}
+
+	if (!fz_strcasecmp(name, "Times") || !fz_strcasecmp(name, "Times-Roman") || strstr(name, "Times"))
+	{
+		font = load_noto(ctx, "NotoSerif", "", style, 0);
+		if (!font) font = load_noto(ctx, "RobotoSerif", "", style, 0);
+		if (!font) font = load_noto(ctx, "DroidSerif", "", style, 0);
+		return font;
+	}
+
+	if (!fz_strcasecmp(name, "Courier") || strstr(name, "Courier"))
+	{
+		font = load_noto(ctx, "DroidSans", "Mono", "", 0);
+		if (!font) font = load_noto(ctx, "NotoSans", "Mono", "-Regular", 0);
+		return font;
+	}
+
+	if (!fz_strcasecmp(name, "Symbol") || strstr(name, "Symbol"))
+	{
+		font = load_noto(ctx, "NotoSans", "Symbols", "-Regular", 0);
+		if (!font) font = load_noto(ctx, "NotoSans", "Symbols2", "-Regular", 0);
+		return font;
+	}
+
+	if (!fz_strcasecmp(name, "ZapfDingbats") || strstr(name, "Dingbats"))
+	{
+		font = load_noto(ctx, "NotoSans", "Symbols", "-Regular", 0);
+		if (!font) font = load_noto(ctx, "NotoSans", "Symbols2", "-Regular", 0);
+		return font;
+	}
+
 	return NULL;
 }

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -26,6 +26,8 @@ fn main() {
 }
 
 fn run() -> Result<()> {
+    println!("cargo:rerun-if-changed=androidfonts.c");
+
     if fs::read_dir("mupdf").map_or(true, |d| d.count() == 0) {
         Err(
             "The `mupdf` directory is empty, did you forget to pull the submodules?\n\
@@ -130,7 +132,10 @@ fn build_wrapper(target: &Target) -> Result<()> {
             build.file(&path);
         }
     }
-    build.include("mupdf/include").include("wrapper");
+    build
+        .include("mupdf/include")
+        .include("wrapper")
+        .include(".");
     if target.os == "android" {
         build.define("HAVE_ANDROID", None);
     }
@@ -264,6 +269,8 @@ const FONTS: [&str; 6] = [
     "TOFU_SIL",
 ];
 
+const BASE14_FONT_PRUNE_FLAG: &str = "TOFU_BASE14";
+
 enum Build {
     Make(Make),
     Msbuild(Msbuild),
@@ -285,6 +292,13 @@ impl Build {
         };
     }
 
+    fn define_flag(&mut self, var: &str) {
+        match self {
+            Self::Make(m) => m.define_flag(var),
+            Self::Msbuild(m) => m.define_flag(var),
+        };
+    }
+
     fn define_bool(&mut self, var: &str, val: bool) {
         self.define(var, if val { "1" } else { "0" });
     }
@@ -301,11 +315,14 @@ impl Build {
         self.fz_enable("HTML", cfg!(feature = "html"));
         self.fz_enable("EPUB", cfg!(feature = "epub"));
         self.fz_enable("JS", cfg!(feature = "js"));
+        if !cfg!(feature = "all-fonts") {
+            for font in &FONTS {
+                self.define_flag(font);
+            }
 
-        for font in &FONTS {
-            // TOFU flags skip fonts when set to 1
-            // So we invert: all-fonts=true means TOFU=0 (include fonts)
-            self.define_bool(font, !cfg!(feature = "all-fonts"));
+            if !cfg!(feature = "base14-fonts") {
+                self.define_flag(BASE14_FONT_PRUNE_FLAG);
+            }
         }
 
         match self {

--- a/mupdf-sys/make.rs
+++ b/mupdf-sys/make.rs
@@ -25,6 +25,10 @@ impl Make {
         self.build.define(var, val);
     }
 
+    pub fn define_flag(&mut self, var: &str) {
+        self.build.define(var, None);
+    }
+
     fn make_var(&mut self, var: &str, val: impl AsRef<OsStr>) {
         let mut flag = OsString::from(var);
         flag.push("=");

--- a/mupdf-sys/msbuild.rs
+++ b/mupdf-sys/msbuild.rs
@@ -14,6 +14,10 @@ impl Msbuild {
         self.cl.push(format!("/D{var}#{val}"));
     }
 
+    pub fn define_flag(&mut self, var: &str) {
+        self.cl.push(format!("/D{var}"));
+    }
+
     fn patch_nan(&self, build_dir: &str) -> Result<()> {
         let file_path = Path::new(build_dir).join("source/fitz/geometry.c");
         let content = fs::read_to_string(&file_path)


### PR DESCRIPTION
Implement a fallback font loader for Android

This is related to #217 -- without the patch, mupdf-rs (/mupdf-sys) requires bunding ~600KB worth of fonts