### PR TITLE
Expose contents and set_contents as methods in `PdfAnnotation`

### DIFF
--- a/mupdf-sys/wrapper/pdf_annot.c
+++ b/mupdf-sys/wrapper/pdf_annot.c
@@ -10,6 +10,16 @@ const char *mupdf_pdf_annot_author(fz_context *ctx, pdf_annot *annot, mupdf_erro
     TRY_CATCH(const char *, NULL, pdf_annot_author(ctx, annot));
 }
 
+const char *mupdf_pdf_annot_contents(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
+{
+    TRY_CATCH(const char *, NULL, pdf_annot_contents(ctx, annot));
+}
+
+void mupdf_pdf_set_annot_contents(fz_context *ctx, pdf_annot *annot, const char *text, mupdf_error_t **errptr)
+{
+    TRY_CATCH_VOID(pdf_set_annot_contents(ctx, annot, text));
+}
+
 void mupdf_pdf_set_annot_author(fz_context *ctx, pdf_annot *annot, const char *author, mupdf_error_t **errptr)
 {
     TRY_CATCH_VOID(pdf_set_annot_author(ctx, annot, author));

--- a/src/pdf/annotation.rs
+++ b/src/pdf/annotation.rs
@@ -205,6 +205,26 @@ impl PdfAnnotation {
         }
     }
 
+    pub fn contents(&self) -> Result<Option<&str>, Error> {
+        let ptr = unsafe { ffi_try!(mupdf_pdf_annot_contents(context(), self.inner.as_ptr())) }?;
+        if ptr.is_null() {
+            return Ok(None);
+        }
+        let c_str = unsafe { CStr::from_ptr(ptr) };
+        Ok(Some(c_str.to_str().unwrap()))
+    }
+
+    pub fn set_contents(&mut self, contents: &str) -> Result<(), Error> {
+        let c_contents = CString::new(contents)?;
+        unsafe {
+            ffi_try!(mupdf_pdf_set_annot_contents(
+                context(),
+                self.inner.as_ptr(),
+                c_contents.as_ptr()
+            ))
+        }
+    }
+
     pub fn filter(&mut self, mut opt: PdfFilterOptions) -> Result<(), Error> {
         unsafe {
             ffi_try!(mupdf_pdf_filter_annot_contents(


### PR DESCRIPTION
Quite minimal additions to the C-Rust interface that largely reflect to a tee the existing design behind set_author and author methods. Contributes to Issue https://github.com/messense/mupdf-rs/issues/7.