### PR TITLE
Add PdfDocument binding for MuPDF’s `pdf_bake_document`

### DIFF
--- a/mupdf-sys/wrapper/pdf_document.c
+++ b/mupdf-sys/wrapper/pdf_document.c
@@ -113,6 +113,11 @@ void mupdf_pdf_calculate_form(fz_context *ctx, pdf_document *pdf, mupdf_error_t 
     TRY_CATCH_VOID(pdf_calculate_form(ctx, pdf));
 }
 
+void mupdf_pdf_bake_document(fz_context *ctx, pdf_document *pdf, bool bake_annots, bool bake_widgets, mupdf_error_t **errptr)
+{
+    TRY_CATCH_VOID(pdf_bake_document(ctx, pdf, bake_annots, bake_widgets));
+}
+
 pdf_obj *mupdf_pdf_trailer(fz_context *ctx, pdf_document *pdf, mupdf_error_t **errptr)
 {
     pdf_obj *obj = NULL;

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -472,7 +472,7 @@ impl PdfDocument {
         unsafe { ffi_try!(mupdf_pdf_calculate_form(context(), self.inner)) }
     }
 
-    pub fn bake_document(&mut self, bake_annots: bool, bake_widgets: bool) -> Result<(), Error> {
+    pub fn bake(&mut self, bake_annots: bool, bake_widgets: bool) -> Result<(), Error> {
         unsafe {
             ffi_try!(mupdf_pdf_bake_document(
                 context(),
@@ -847,7 +847,7 @@ mod test {
     #[test]
     fn test_pdf_document_bake_document() {
         let mut doc = test_document!("../..", "files/dummy.pdf" as PdfDocument).unwrap();
-        doc.bake_document(false, false).unwrap();
+        doc.bake(false, false).unwrap();
     }
 
     #[test]

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -472,6 +472,17 @@ impl PdfDocument {
         unsafe { ffi_try!(mupdf_pdf_calculate_form(context(), self.inner)) }
     }
 
+    pub fn bake_document(&mut self, bake_annots: bool, bake_widgets: bool) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(mupdf_pdf_bake_document(
+                context(),
+                self.inner,
+                bake_annots,
+                bake_widgets
+            ))
+        }
+    }
+
     pub fn trailer(&self) -> Result<PdfObject, Error> {
         unsafe { ffi_try!(mupdf_pdf_trailer(context(), self.inner)) }
             .map(|inner| unsafe { PdfObject::from_raw(inner) })
@@ -831,6 +842,12 @@ mod test {
         let bytes = include_bytes!("../../tests/files/dummy.pdf");
         let doc = PdfDocument::from_bytes(bytes).unwrap();
         assert!(!doc.needs_password().unwrap());
+    }
+
+    #[test]
+    fn test_pdf_document_bake_document() {
+        let mut doc = test_document!("../..", "files/dummy.pdf" as PdfDocument).unwrap();
+        doc.bake_document(false, false).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Adds `PdfDocument::bake_document` binding for MuPDF’s `pdf_bake_document`.

I really need this API exposed for downstream PDF processing workflows.
