### PR TITLE
feat(pdf): add document page composition APIs

### DIFF
--- a/mupdf-sys/wrapper/image.c
+++ b/mupdf-sys/wrapper/image.c
@@ -11,6 +11,11 @@ fz_image *mupdf_new_image_from_file(fz_context *ctx, const char *filename, mupdf
     TRY_CATCH(fz_image*, NULL, fz_new_image_from_file(ctx, filename));
 }
 
+fz_image *mupdf_new_image_from_buffer(fz_context *ctx, fz_buffer *buffer, mupdf_error_t **errptr)
+{
+    TRY_CATCH(fz_image*, NULL, fz_new_image_from_buffer(ctx, buffer));
+}
+
 fz_image *mupdf_new_image_from_display_list(fz_context *ctx, fz_display_list *list, float w, float h, mupdf_error_t **errptr)
 {
     TRY_CATCH(fz_image*, NULL, fz_new_image_from_display_list(ctx, w, h, list));

--- a/mupdf-sys/wrapper/pdf_document.c
+++ b/mupdf-sys/wrapper/pdf_document.c
@@ -268,6 +268,52 @@ void mupdf_pdf_delete_page(fz_context *ctx, pdf_document *pdf, int page_no, mupd
     }
 }
 
+void mupdf_pdf_graft_page(fz_context *ctx, pdf_document *dst, int page_to, pdf_document *src, int page_from, mupdf_error_t **errptr)
+{
+    if (page_from < 0 || page_from >= pdf_count_pages(ctx, src))
+    {
+        *errptr = mupdf_new_error_from_str("source page index is not valid");
+        return;
+    }
+    if (page_to < 0 || page_to > pdf_count_pages(ctx, dst))
+    {
+        *errptr = mupdf_new_error_from_str("target page index is not valid");
+        return;
+    }
+    TRY_CATCH_VOID(pdf_graft_page(ctx, dst, page_to, src, page_from));
+}
+
+void mupdf_pdf_delete_page_range(fz_context *ctx, pdf_document *pdf, int start, int end, mupdf_error_t **errptr)
+{
+    int page_count = pdf_count_pages(ctx, pdf);
+    if (start < 0 || end < start || end > page_count)
+    {
+        *errptr = mupdf_new_error_from_str("page range is not valid");
+        return;
+    }
+    TRY_CATCH_VOID(pdf_delete_page_range(ctx, pdf, start, end));
+}
+
+void mupdf_pdf_page_label(fz_context *ctx, pdf_document *pdf, int page_no, char *buf, size_t size, mupdf_error_t **errptr)
+{
+    if (page_no < 0 || page_no >= pdf_count_pages(ctx, pdf))
+    {
+        *errptr = mupdf_new_error_from_str("page_no is not a valid page");
+        return;
+    }
+    TRY_CATCH_VOID(pdf_page_label(ctx, pdf, page_no, buf, size));
+}
+
+void mupdf_pdf_set_page_labels(fz_context *ctx, pdf_document *pdf, int index, pdf_page_label_style style, const char *prefix, int start, mupdf_error_t **errptr)
+{
+    if (index < 0 || index > pdf_count_pages(ctx, pdf))
+    {
+        *errptr = mupdf_new_error_from_str("page label index is not valid");
+        return;
+    }
+    TRY_CATCH_VOID(pdf_set_page_labels(ctx, pdf, index, style, prefix, start));
+}
+
 void mupdf_pdf_begin_operation(fz_context *ctx, pdf_document *doc, const char *operation, mupdf_error_t **errptr)
 {
     TRY_CATCH_VOID(pdf_begin_operation(ctx, doc, operation));

--- a/mupdf-sys/wrapper/pixmap.c
+++ b/mupdf-sys/wrapper/pixmap.c
@@ -32,9 +32,39 @@ void mupdf_clear_pixmap_with_value(fz_context *ctx, fz_pixmap *pixmap, int value
     TRY_CATCH_VOID(fz_clear_pixmap_with_value(ctx, pixmap, value));
 }
 
+void mupdf_clear_pixmap_rect_with_value(fz_context *ctx, fz_pixmap *pixmap, int value, fz_irect rect, mupdf_error_t **errptr)
+{
+    TRY_CATCH_VOID(fz_clear_pixmap_rect_with_value(ctx, pixmap, value, rect));
+}
+
 void mupdf_invert_pixmap(fz_context *ctx, fz_pixmap *pixmap, mupdf_error_t **errptr)
 {
     TRY_CATCH_VOID(fz_invert_pixmap(ctx, pixmap));
+}
+
+void mupdf_invert_pixmap_rect(fz_context *ctx, fz_pixmap *pixmap, fz_irect rect, mupdf_error_t **errptr)
+{
+    TRY_CATCH_VOID(fz_invert_pixmap_rect(ctx, pixmap, rect));
+}
+
+void mupdf_md5_pixmap(fz_context *ctx, fz_pixmap *pixmap, unsigned char digest[16], mupdf_error_t **errptr)
+{
+    TRY_CATCH_VOID(fz_md5_pixmap(ctx, pixmap, digest));
+}
+
+fz_pixmap *mupdf_warp_pixmap(fz_context *ctx, fz_pixmap *pixmap, fz_quad points, int width, int height, mupdf_error_t **errptr)
+{
+    TRY_CATCH(fz_pixmap*, NULL, fz_warp_pixmap(ctx, pixmap, points, width, height));
+}
+
+void mupdf_subsample_pixmap(fz_context *ctx, fz_pixmap *pixmap, int factor, mupdf_error_t **errptr)
+{
+    if (factor < 1)
+    {
+        *errptr = mupdf_new_error_from_str("subsample factor must be at least 1");
+        return;
+    }
+    TRY_CATCH_VOID(fz_subsample_pixmap(ctx, pixmap, factor));
 }
 
 void mupdf_gamma_pixmap(fz_context *ctx, fz_pixmap *pixmap, float gamma, mupdf_error_t **errptr)

--- a/src/image.rs
+++ b/src/image.rs
@@ -2,7 +2,7 @@ use std::ffi::CString;
 
 use mupdf_sys::*;
 
-use crate::{context, Colorspace, DisplayList, Error, Pixmap};
+use crate::{context, Buffer, Colorspace, DisplayList, Error, Pixmap};
 
 #[derive(Debug)]
 pub struct Image {
@@ -22,6 +22,12 @@ impl Image {
     pub fn from_file(filename: &str) -> Result<Self, Error> {
         let c_filename = CString::new(filename)?;
         unsafe { ffi_try!(mupdf_new_image_from_file(context(), c_filename.as_ptr())) }
+            .map(|inner| Self { inner })
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        let buffer = Buffer::from_bytes(bytes)?;
+        unsafe { ffi_try!(mupdf_new_image_from_buffer(context(), buffer.inner)) }
             .map(|inner| Self { inner })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,10 @@ pub use pdf::{
     InsertPdfOptions, InsertPdfResult, InsertPosition, PageLabelRule, PageLabelStyle, PageRange,
     PageSelection, PdfWidget, PdfWidgetIter, WidgetType,
 };
-pub use pdf::{ExtractedImage, ImagePlacement, InsertImageOptions, PageImageInfo, PageImageSource};
+pub use pdf::{
+    ExtractedImage, ImagePlacement, InsertImageOptions, OptionalContentGroup, OptionalContentRef,
+    PageImageInfo, PageImageSource,
+};
 pub use pixmap::{ColorUsage, ImageFormat, Pixel, Pixmap, PixmapDigest};
 pub use point::Point;
 pub use quad::Quad;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ pub use pdf::{
     InsertPdfOptions, InsertPdfResult, InsertPosition, PageLabelRule, PageLabelStyle, PageRange,
     PageSelection, PdfWidget, PdfWidgetIter, WidgetType,
 };
+pub use pdf::{ExtractedImage, ImagePlacement, InsertImageOptions, PageImageInfo, PageImageSource};
 pub use pixmap::{ColorUsage, ImageFormat, Pixel, Pixmap, PixmapDigest};
 pub use point::Point;
 pub use quad::Quad;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ pub use pdf::{
     InsertPdfOptions, InsertPdfResult, InsertPosition, PageLabelRule, PageLabelStyle, PageRange,
     PageSelection, PdfWidget, PdfWidgetIter, WidgetType,
 };
-pub use pixmap::{ImageFormat, Pixmap};
+pub use pixmap::{ColorUsage, ImageFormat, Pixel, Pixmap, PixmapDigest};
 pub use point::Point;
 pub use quad::Quad;
 pub use rect::{IRect, Rect};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,8 +111,9 @@ pub use outline::Outline;
 pub use page::Page;
 pub use path::{Path, PathWalker};
 pub use pdf::{
-    EmbeddedFileInfo, EmbeddedFileOptions, FieldFlags, FontInfo, InsertFontOptions, PdfWidget,
-    PdfWidgetIter, WidgetType,
+    EmbeddedFileInfo, EmbeddedFileOptions, FieldFlags, FontInfo, InsertFontOptions,
+    InsertPdfOptions, InsertPdfResult, InsertPosition, PageLabelRule, PageLabelStyle, PageRange,
+    PageSelection, PdfWidget, PdfWidgetIter, WidgetType,
 };
 pub use pixmap::{ImageFormat, Pixmap};
 pub use point::Point;

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -1,16 +1,16 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::convert::TryFrom;
-use std::ffi::{c_int, CStr, CString};
+use std::ffi::{c_char, c_int, CStr, CString};
 use std::io::{self, Read, Write};
-use std::ops::{Deref, DerefMut};
+use std::ops::{Deref, DerefMut, Range, RangeInclusive};
 use std::ptr::{self, NonNull};
 
 use bitflags::bitflags;
 
 use mupdf_sys::*;
 
-use crate::pdf::{FontInfo, PdfGraftMap, PdfObject, PdfPage};
+use crate::pdf::{DocOperation, FontInfo, PdfGraftMap, PdfObject, PdfPage};
 use crate::{
     context, from_enum, Buffer, CjkFontOrdering, Destination, Document, Error, FilePath, Font,
     Image, Outline, SimpleFontEncoding, Size, WriteMode,
@@ -268,6 +268,246 @@ pub struct EmbeddedFileInfo {
     pub size: usize,
     pub created: Option<i64>,
     pub modified: Option<i64>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PageRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl PageRange {
+    pub fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+
+    pub fn len(self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.start >= self.end
+    }
+}
+
+impl From<Range<usize>> for PageRange {
+    fn from(range: Range<usize>) -> Self {
+        Self::new(range.start, range.end)
+    }
+}
+
+impl From<RangeInclusive<usize>> for PageRange {
+    fn from(range: RangeInclusive<usize>) -> Self {
+        let (start, end) = range.into_inner();
+        Self::new(start, end.saturating_add(1))
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum PageSelection {
+    #[default]
+    All,
+    Range(PageRange),
+    Pages(Vec<usize>),
+}
+
+impl PageSelection {
+    fn validated_indices(&self, page_count: usize) -> Result<Vec<usize>, Error> {
+        let indices = match self {
+            Self::All => (0..page_count).collect(),
+            Self::Range(range) => {
+                if range.is_empty() {
+                    return Err(Error::InvalidArgument(
+                        "page selection range must not be empty".to_owned(),
+                    ));
+                }
+                if range.end > page_count {
+                    return Err(Error::InvalidArgument(format!(
+                        "page selection range {}..{} exceeds page count {page_count}",
+                        range.start, range.end
+                    )));
+                }
+                (range.start..range.end).collect()
+            }
+            Self::Pages(pages) => {
+                if pages.is_empty() {
+                    return Err(Error::InvalidArgument(
+                        "page selection must not be empty".to_owned(),
+                    ));
+                }
+                for page in pages {
+                    if *page >= page_count {
+                        return Err(Error::InvalidArgument(format!(
+                            "page index {page} exceeds page count {page_count}"
+                        )));
+                    }
+                }
+                pages.clone()
+            }
+        };
+
+        if indices.is_empty() {
+            return Err(Error::InvalidArgument(
+                "page selection must not be empty".to_owned(),
+            ));
+        }
+
+        Ok(indices)
+    }
+
+    fn validated_unique_sorted_indices(&self, page_count: usize) -> Result<Vec<usize>, Error> {
+        let indices = self.validated_indices(page_count)?;
+        let unique: BTreeSet<_> = indices.iter().copied().collect();
+        if unique.len() != indices.len() {
+            return Err(Error::InvalidArgument(
+                "page selection must not contain duplicates".to_owned(),
+            ));
+        }
+        Ok(unique.into_iter().collect())
+    }
+}
+
+impl From<PageRange> for PageSelection {
+    fn from(range: PageRange) -> Self {
+        Self::Range(range)
+    }
+}
+
+impl From<Range<usize>> for PageSelection {
+    fn from(range: Range<usize>) -> Self {
+        Self::Range(range.into())
+    }
+}
+
+impl From<RangeInclusive<usize>> for PageSelection {
+    fn from(range: RangeInclusive<usize>) -> Self {
+        Self::Range(range.into())
+    }
+}
+
+impl From<Vec<usize>> for PageSelection {
+    fn from(pages: Vec<usize>) -> Self {
+        Self::Pages(pages)
+    }
+}
+
+impl From<&[usize]> for PageSelection {
+    fn from(pages: &[usize]) -> Self {
+        Self::Pages(pages.to_vec())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum InsertPosition {
+    #[default]
+    Append,
+    Before(usize),
+    After(usize),
+}
+
+impl InsertPosition {
+    fn resolve(self, page_count: usize) -> Result<usize, Error> {
+        match self {
+            Self::Append => Ok(page_count),
+            Self::Before(index) if index <= page_count => Ok(index),
+            Self::Before(index) => Err(Error::InvalidArgument(format!(
+                "insert position Before({index}) exceeds page count {page_count}"
+            ))),
+            Self::After(index) if index < page_count => Ok(index + 1),
+            Self::After(index) => Err(Error::InvalidArgument(format!(
+                "insert position After({index}) exceeds page count {page_count}"
+            ))),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InsertPdfOptions {
+    pub source_pages: PageSelection,
+    pub target: InsertPosition,
+    pub rotate: Option<i32>,
+    pub copy_links: bool,
+    pub copy_annotations: bool,
+    pub copy_widgets: bool,
+}
+
+impl Default for InsertPdfOptions {
+    fn default() -> Self {
+        Self {
+            source_pages: PageSelection::All,
+            target: InsertPosition::Append,
+            rotate: None,
+            copy_links: true,
+            copy_annotations: true,
+            copy_widgets: true,
+        }
+    }
+}
+
+impl InsertPdfOptions {
+    fn validate_supported(&self) -> Result<(), Error> {
+        if !self.copy_links || !self.copy_annotations || !self.copy_widgets {
+            return Err(Error::InvalidArgument(
+                "selective link, annotation, and widget copying is not supported yet".to_owned(),
+            ));
+        }
+        if let Some(rotate) = self.rotate {
+            if rotate % 90 != 0 {
+                return Err(Error::InvalidArgument(
+                    "inserted page rotation must be a multiple of 90 degrees".to_owned(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct InsertPdfResult {
+    pub inserted_pages: PageRange,
+    pub page_count: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PageLabelStyle {
+    None,
+    Decimal,
+    UpperRoman,
+    LowerRoman,
+    UpperAlpha,
+    LowerAlpha,
+}
+
+impl PageLabelStyle {
+    fn into_raw(self) -> pdf_page_label_style {
+        match self {
+            Self::None => PDF_PAGE_LABEL_NONE,
+            Self::Decimal => PDF_PAGE_LABEL_DECIMAL,
+            Self::UpperRoman => PDF_PAGE_LABEL_ROMAN_UC,
+            Self::LowerRoman => PDF_PAGE_LABEL_ROMAN_LC,
+            Self::UpperAlpha => PDF_PAGE_LABEL_ALPHA_UC,
+            Self::LowerAlpha => PDF_PAGE_LABEL_ALPHA_LC,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PageLabelRule {
+    pub index: usize,
+    pub style: PageLabelStyle,
+    pub prefix: String,
+    pub start: i32,
+}
+
+impl PageLabelRule {
+    pub fn new(index: usize, style: PageLabelStyle) -> Self {
+        Self {
+            index,
+            style,
+            prefix: String::new(),
+            start: 1,
+        }
+    }
 }
 
 impl Default for PdfDocument {
@@ -888,6 +1128,300 @@ impl PdfDocument {
         Ok(false)
     }
 
+    fn page_count_usize(&self) -> Result<usize, Error> {
+        usize::try_from(self.page_count()?).map_err(|_| {
+            Error::InvalidArgument("document page count cannot be represented as usize".to_owned())
+        })
+    }
+
+    fn checked_page_index(&self, page: usize) -> Result<i32, Error> {
+        let page_count = self.page_count_usize()?;
+        if page >= page_count {
+            return Err(Error::InvalidArgument(format!(
+                "page index {page} exceeds page count {page_count}"
+            )));
+        }
+        i32::try_from(page).map_err(|_| {
+            Error::InvalidArgument(format!("page index {page} cannot be represented as i32"))
+        })
+    }
+
+    fn checked_insert_index(&self, position: InsertPosition) -> Result<usize, Error> {
+        position.resolve(self.page_count_usize()?)
+    }
+
+    pub(crate) fn checked_xref(&self, xref: i32) -> Result<(), Error> {
+        if xref <= 0 {
+            return Err(Error::InvalidArgument(format!(
+                "xref {xref} must be positive"
+            )));
+        }
+        let xref_len = i32::try_from(self.count_objects()?).map_err(|_| {
+            Error::InvalidArgument("xref length cannot be represented as i32".to_owned())
+        })?;
+        if xref >= xref_len {
+            return Err(Error::InvalidArgument(format!(
+                "xref {xref} exceeds xref length {xref_len}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn graft_page_raw(
+        &mut self,
+        src: *mut pdf_document,
+        source_index: usize,
+        target_index: usize,
+    ) -> Result<(), Error> {
+        let source_index = i32::try_from(source_index).map_err(|_| {
+            Error::InvalidArgument(format!(
+                "source page index {source_index} cannot be represented as i32"
+            ))
+        })?;
+        let target_index = i32::try_from(target_index).map_err(|_| {
+            Error::InvalidArgument(format!(
+                "target page index {target_index} cannot be represented as i32"
+            ))
+        })?;
+        unsafe {
+            ffi_try!(mupdf_pdf_graft_page(
+                context(),
+                self.inner,
+                target_index,
+                src,
+                source_index
+            ))
+        }
+    }
+
+    fn delete_page_range_raw(&mut self, range: PageRange) -> Result<(), Error> {
+        let start = i32::try_from(range.start).map_err(|_| {
+            Error::InvalidArgument(format!(
+                "range start {} cannot be represented as i32",
+                range.start
+            ))
+        })?;
+        let end = i32::try_from(range.end).map_err(|_| {
+            Error::InvalidArgument(format!(
+                "range end {} cannot be represented as i32",
+                range.end
+            ))
+        })?;
+        unsafe {
+            ffi_try!(mupdf_pdf_delete_page_range(
+                context(),
+                self.inner,
+                start,
+                end
+            ))
+        }
+    }
+
+    pub fn insert_pdf(
+        &mut self,
+        src: &PdfDocument,
+        options: InsertPdfOptions,
+    ) -> Result<InsertPdfResult, Error> {
+        options.validate_supported()?;
+
+        let source_indices = options
+            .source_pages
+            .validated_indices(src.page_count_usize()?)?;
+        let mut target_index = self.checked_insert_index(options.target)?;
+        let inserted_start = target_index;
+
+        let operation = DocOperation::begin(self, "Insert PDF pages")?;
+        for source_index in source_indices.iter().copied() {
+            operation
+                .doc
+                .graft_page_raw(src.as_raw(), source_index, target_index)?;
+            if let Some(rotate) = options.rotate {
+                operation
+                    .doc
+                    .load_pdf_page(i32::try_from(target_index).map_err(|_| {
+                        Error::InvalidArgument(format!(
+                            "target page index {target_index} cannot be represented as i32"
+                        ))
+                    })?)?
+                    .set_rotation(rotate)?;
+            }
+            target_index += 1;
+        }
+        operation.commit()?;
+
+        Ok(InsertPdfResult {
+            inserted_pages: PageRange::new(inserted_start, target_index),
+            page_count: target_index - inserted_start,
+        })
+    }
+
+    pub fn copy_page(
+        &mut self,
+        source_index: usize,
+        target: InsertPosition,
+    ) -> Result<InsertPdfResult, Error> {
+        self.checked_page_index(source_index)?;
+        let target_index = self.checked_insert_index(target)?;
+
+        let operation = DocOperation::begin(self, "Copy PDF page")?;
+        let src = operation.doc.as_raw();
+        operation
+            .doc
+            .graft_page_raw(src, source_index, target_index)?;
+        operation.commit()?;
+
+        Ok(InsertPdfResult {
+            inserted_pages: PageRange::new(target_index, target_index + 1),
+            page_count: 1,
+        })
+    }
+
+    pub fn duplicate_page(&mut self, source_index: usize) -> Result<InsertPdfResult, Error> {
+        self.copy_page(source_index, InsertPosition::After(source_index))
+    }
+
+    pub fn move_page(&mut self, source_index: usize, target_index: usize) -> Result<(), Error> {
+        let source_index_i32 = self.checked_page_index(source_index)?;
+        let page_count = self.page_count_usize()?;
+        if target_index >= page_count {
+            return Err(Error::InvalidArgument(format!(
+                "target page index {target_index} exceeds page count {page_count}"
+            )));
+        }
+        if source_index == target_index {
+            return Ok(());
+        }
+        let target_index_i32 = i32::try_from(target_index).map_err(|_| {
+            Error::InvalidArgument(format!(
+                "target page index {target_index} cannot be represented as i32"
+            ))
+        })?;
+
+        let operation = DocOperation::begin(self, "Move PDF page")?;
+        let page = operation.doc.find_page(source_index_i32)?;
+        unsafe {
+            ffi_try!(mupdf_pdf_delete_page(
+                context(),
+                operation.doc.inner,
+                source_index_i32
+            ))?;
+            ffi_try!(mupdf_pdf_insert_page(
+                context(),
+                operation.doc.inner,
+                target_index_i32,
+                page.inner
+            ))?;
+        }
+        operation.commit()
+    }
+
+    pub fn delete_pages(&mut self, selection: impl Into<PageSelection>) -> Result<(), Error> {
+        let mut pages = selection
+            .into()
+            .validated_unique_sorted_indices(self.page_count_usize()?)?;
+
+        let operation = DocOperation::begin(self, "Delete PDF pages")?;
+        while let Some(end_page) = pages.pop() {
+            let mut start_page = end_page;
+            while pages
+                .last()
+                .is_some_and(|previous| *previous + 1 == start_page)
+            {
+                start_page = pages.pop().unwrap();
+            }
+            operation
+                .doc
+                .delete_page_range_raw(PageRange::new(start_page, end_page + 1))?;
+        }
+        operation.commit()
+    }
+
+    pub fn select_pages(&mut self, selection: impl Into<PageSelection>) -> Result<(), Error> {
+        let page_count = self.page_count_usize()?;
+        let selected = selection
+            .into()
+            .validated_unique_sorted_indices(page_count)?;
+        let selected: BTreeSet<_> = selected.into_iter().collect();
+        let pages_to_delete: Vec<_> = (0..page_count)
+            .filter(|page| !selected.contains(page))
+            .collect();
+        if pages_to_delete.is_empty() {
+            return Ok(());
+        }
+        self.delete_pages(PageSelection::Pages(pages_to_delete))
+    }
+
+    pub fn reload_page(&self, page_index: usize) -> Result<PdfPage, Error> {
+        self.load_pdf_page(self.checked_page_index(page_index)?)
+    }
+
+    pub fn page_label(&self, page_index: usize) -> Result<String, Error> {
+        let page_index = self.checked_page_index(page_index)?;
+        let mut buf = [0 as c_char; 128];
+        unsafe {
+            ffi_try!(mupdf_pdf_page_label(
+                context(),
+                self.inner,
+                page_index,
+                buf.as_mut_ptr(),
+                buf.len()
+            ))?
+        };
+        let label = unsafe { CStr::from_ptr(buf.as_ptr()) };
+        Ok(label.to_string_lossy().into_owned())
+    }
+
+    pub fn set_page_label_rule(&mut self, rule: PageLabelRule) -> Result<(), Error> {
+        let page_count = self.page_count_usize()?;
+        if rule.index >= page_count {
+            return Err(Error::InvalidArgument(format!(
+                "page label index {} exceeds page count {page_count}",
+                rule.index
+            )));
+        }
+        if rule.start < 1 {
+            return Err(Error::InvalidArgument(
+                "page label start must be at least 1".to_owned(),
+            ));
+        }
+        let index = i32::try_from(rule.index).map_err(|_| {
+            Error::InvalidArgument(format!(
+                "page label index {} cannot be represented as i32",
+                rule.index
+            ))
+        })?;
+        let prefix = CString::new(rule.prefix)?;
+        unsafe {
+            ffi_try!(mupdf_pdf_set_page_labels(
+                context(),
+                self.inner,
+                index,
+                rule.style.into_raw(),
+                prefix.as_ptr(),
+                rule.start
+            ))
+        }
+    }
+
+    pub fn xref_len(&self) -> Result<usize, Error> {
+        self.count_objects().map(|count| count as usize)
+    }
+
+    pub fn xref_object(&self, xref: i32) -> Result<Option<PdfObject>, Error> {
+        self.checked_xref(xref)?;
+        self.new_indirect(xref, 0)?.resolve()
+    }
+
+    pub fn xref_stream(&self, xref: i32) -> Result<Vec<u8>, Error> {
+        self.checked_xref(xref)?;
+        self.new_indirect(xref, 0)?.read_stream()
+    }
+
+    pub fn xref_raw_stream(&self, xref: i32) -> Result<Vec<u8>, Error> {
+        self.checked_xref(xref)?;
+        self.new_indirect(xref, 0)?.read_raw_stream()
+    }
+
     pub fn begin_operation(&self, op: &str) -> Result<(), Error> {
         let c_op = CString::new(op).map_err(|_| Error::InvalidUtf8)?;
         unsafe {
@@ -1064,9 +1598,12 @@ impl<'a> IntoIterator for &'a PdfDocument {
 #[cfg(test)]
 mod test {
     use crate::document::test_document;
-    use crate::Buffer;
+    use crate::{Buffer, Size};
 
-    use super::{EmbeddedFileOptions, PdfDocument, PdfWriteOptions, Permission};
+    use super::{
+        EmbeddedFileOptions, InsertPdfOptions, InsertPosition, PageLabelRule, PageLabelStyle,
+        PageSelection, PdfDocument, PdfWriteOptions, Permission,
+    };
 
     #[test]
     fn test_pdf_write_options_passwords() {
@@ -1213,8 +1750,6 @@ mod test {
 
     #[test]
     fn test_pdf_document_new_page() {
-        use crate::Size;
-
         let mut pdf = PdfDocument::new();
         let page = pdf.new_page(Size::A4).unwrap();
         assert!(pdf.has_unsaved_changes());
@@ -1268,6 +1803,69 @@ mod test {
         assert!(doc.delete_embedded_file("payload").unwrap());
         assert!(doc.embedded_files().unwrap().is_empty());
         assert!(doc.load_embedded_file("payload").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_pdf_document_insert_copy_delete_and_select_pages() {
+        let mut src = PdfDocument::new();
+        src.new_page(Size::A4).unwrap();
+        src.new_page(Size::A5).unwrap();
+
+        let mut dst = PdfDocument::new();
+        dst.new_page(Size::A6).unwrap();
+
+        let result = dst
+            .insert_pdf(
+                &src,
+                InsertPdfOptions {
+                    source_pages: PageSelection::from(0..2),
+                    target: InsertPosition::Append,
+                    rotate: Some(90),
+                    ..InsertPdfOptions::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(result.page_count, 2);
+        assert_eq!(result.inserted_pages.start, 1);
+        assert_eq!(result.inserted_pages.end, 3);
+        assert_eq!(dst.page_count().unwrap(), 3);
+        assert_eq!(dst.load_pdf_page(1).unwrap().rotation().unwrap(), 90);
+
+        dst.copy_page(0, InsertPosition::Append).unwrap();
+        assert_eq!(dst.page_count().unwrap(), 4);
+
+        dst.delete_pages(1..3).unwrap();
+        assert_eq!(dst.page_count().unwrap(), 2);
+
+        dst.select_pages(PageSelection::Pages(vec![0])).unwrap();
+        assert_eq!(dst.page_count().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_pdf_document_page_labels() {
+        let mut doc = PdfDocument::new();
+        doc.new_page(Size::A4).unwrap();
+        doc.new_page(Size::A4).unwrap();
+
+        doc.set_page_label_rule(PageLabelRule {
+            index: 0,
+            style: PageLabelStyle::LowerRoman,
+            prefix: "intro-".to_owned(),
+            start: 1,
+        })
+        .unwrap();
+
+        assert_eq!(doc.page_label(0).unwrap(), "intro-i");
+        assert_eq!(doc.page_label(1).unwrap(), "intro-ii");
+    }
+
+    #[test]
+    fn test_pdf_document_rejects_invalid_page_selection() {
+        let mut doc = PdfDocument::new();
+        doc.new_page(Size::A4).unwrap();
+
+        assert!(doc.delete_pages(PageSelection::Pages(vec![0, 0])).is_err());
+        assert!(doc.delete_pages(1..2).is_err());
     }
 
     #[test]

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -510,6 +510,41 @@ impl PageLabelRule {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct OptionalContentRef {
+    xref: i32,
+}
+
+impl OptionalContentRef {
+    pub fn new(xref: i32) -> Result<Self, Error> {
+        if xref <= 0 {
+            return Err(Error::InvalidArgument(
+                "optional content xref must be positive".to_owned(),
+            ));
+        }
+        Ok(Self { xref })
+    }
+
+    pub fn xref(self) -> i32 {
+        self.xref
+    }
+}
+
+impl TryFrom<i32> for OptionalContentRef {
+    type Error = Error;
+
+    fn try_from(xref: i32) -> Result<Self, Self::Error> {
+        Self::new(xref)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OptionalContentGroup {
+    pub reference: OptionalContentRef,
+    pub name: Option<String>,
+    pub enabled: bool,
+}
+
 impl Default for PdfDocument {
     fn default() -> Self {
         let inner = unsafe { pdf_create_document(context()) };
@@ -1442,6 +1477,252 @@ impl PdfDocument {
         })
     }
 
+    fn optional_content_properties(&self) -> Result<Option<PdfObject>, Error> {
+        match self.catalog()?.get_dict("OCProperties")? {
+            Some(properties) if properties.is_dict()? => Ok(Some(properties)),
+            _ => Ok(None),
+        }
+    }
+
+    fn ensure_optional_content_properties(&self) -> Result<PdfObject, Error> {
+        let mut catalog = self.catalog()?;
+        match catalog.get_dict("OCProperties")? {
+            Some(properties) if properties.is_dict()? => Ok(properties),
+            _ => {
+                let properties = self.new_dict()?;
+                catalog.dict_put_ref("OCProperties", &properties)?;
+                Ok(properties)
+            }
+        }
+    }
+
+    fn ensure_optional_content_default_config(
+        &self,
+        properties: &mut PdfObject,
+    ) -> Result<PdfObject, Error> {
+        match properties.get_dict("D")? {
+            Some(config) if config.is_dict()? => Ok(config),
+            _ => {
+                let config = self.new_dict()?;
+                properties.dict_put_ref("D", &config)?;
+                Ok(config)
+            }
+        }
+    }
+
+    fn ensure_indirect_array_entry(
+        &self,
+        array_owner: &mut PdfObject,
+        key: &str,
+        reference: &PdfObject,
+        xref: i32,
+    ) -> Result<(), Error> {
+        let mut array = match array_owner.get_dict(key)? {
+            Some(array) if array.is_array()? => array,
+            _ => {
+                let array = self.new_array()?;
+                array_owner.dict_put_ref(key, &array)?;
+                array
+            }
+        };
+
+        for index in 0..array.len()? {
+            let Some(item) = array.get_array(index as i32)? else {
+                continue;
+            };
+            if item.is_indirect()? && item.as_indirect()? == xref {
+                return Ok(());
+            }
+        }
+
+        array.array_push_ref(reference)
+    }
+
+    fn remove_indirect_array_entry(
+        array_owner: &mut PdfObject,
+        key: &str,
+        xref: i32,
+    ) -> Result<(), Error> {
+        let Some(mut array) = array_owner.get_dict(key)? else {
+            return Ok(());
+        };
+        if !array.is_array()? {
+            return Ok(());
+        }
+
+        for index in (0..array.len()?).rev() {
+            let Some(item) = array.get_array(index as i32)? else {
+                continue;
+            };
+            if item.is_indirect()? && item.as_indirect()? == xref {
+                array.array_delete(index as i32)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn optional_content_array_contains(
+        array_owner: &PdfObject,
+        key: &str,
+        xref: i32,
+    ) -> Result<bool, Error> {
+        let Some(array) = array_owner.get_dict(key)? else {
+            return Ok(false);
+        };
+        if !array.is_array()? {
+            return Ok(false);
+        }
+        for index in 0..array.len()? {
+            let Some(item) = array.get_array(index as i32)? else {
+                continue;
+            };
+            if item.is_indirect()? && item.as_indirect()? == xref {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn register_optional_content_group_object(
+        &self,
+        oc_ref: &PdfObject,
+        xref: i32,
+    ) -> Result<(), Error> {
+        let mut properties = self.ensure_optional_content_properties()?;
+        self.ensure_indirect_array_entry(&mut properties, "OCGs", oc_ref, xref)?;
+        let mut config = self.ensure_optional_content_default_config(&mut properties)?;
+        self.ensure_indirect_array_entry(&mut config, "ON", oc_ref, xref)?;
+        self.ensure_indirect_array_entry(&mut config, "Order", oc_ref, xref)
+    }
+
+    fn validate_optional_content_ref(
+        &self,
+        reference: OptionalContentRef,
+    ) -> Result<PdfObject, Error> {
+        self.checked_xref(reference.xref())?;
+        let oc_ref = self.new_indirect(reference.xref(), 0)?;
+        let Some(oc_obj) = oc_ref.resolve()? else {
+            return Err(Error::InvalidArgument(format!(
+                "optional content xref {} does not resolve to an object",
+                reference.xref()
+            )));
+        };
+        if !oc_obj.is_dict()? {
+            return Err(Error::InvalidArgument(format!(
+                "optional content xref {} does not refer to a dictionary",
+                reference.xref()
+            )));
+        }
+        let Some(type_obj) = oc_obj.get_dict("Type")? else {
+            return Err(Error::InvalidArgument(format!(
+                "optional content xref {} is missing /Type",
+                reference.xref()
+            )));
+        };
+        if !type_obj.is_name()? {
+            return Err(Error::InvalidArgument(format!(
+                "optional content xref {} has non-name /Type",
+                reference.xref()
+            )));
+        }
+        match type_obj.as_name()? {
+            b"OCG" | b"OCMD" => Ok(oc_ref),
+            _ => Err(Error::InvalidArgument(format!(
+                "optional content xref {} must have /Type /OCG or /OCMD",
+                reference.xref()
+            ))),
+        }
+    }
+
+    pub fn add_optional_content_group(
+        &mut self,
+        name: impl AsRef<str>,
+    ) -> Result<OptionalContentRef, Error> {
+        let mut ocg = self.new_dict_with_capacity(2)?;
+        ocg.dict_put("Type", PdfObject::new_name("OCG")?)?;
+        ocg.dict_put("Name", PdfObject::new_string(name.as_ref())?)?;
+        let ocg = self.add_object(&ocg)?;
+        let xref = ocg.as_indirect()?;
+        self.register_optional_content_group_object(&ocg, xref)?;
+        OptionalContentRef::new(xref)
+    }
+
+    pub fn optional_content_groups(&self) -> Result<Vec<OptionalContentGroup>, Error> {
+        let Some(properties) = self.optional_content_properties()? else {
+            return Ok(Vec::new());
+        };
+        let Some(ocgs) = properties.get_dict("OCGs")? else {
+            return Ok(Vec::new());
+        };
+        if !ocgs.is_array()? {
+            return Ok(Vec::new());
+        }
+        let default_config = properties.get_dict("D")?;
+
+        let mut groups = Vec::new();
+        for index in 0..ocgs.len()? {
+            let Some(reference) = ocgs.get_array(index as i32)? else {
+                continue;
+            };
+            let Ok(xref) = reference.as_indirect() else {
+                continue;
+            };
+            let Some(group) = reference.resolve()? else {
+                continue;
+            };
+            if !group.is_dict()? {
+                continue;
+            }
+            let name = group
+                .get_dict("Name")?
+                .and_then(|name| name.as_string().ok().map(str::to_owned));
+            let enabled = !matches!(
+                default_config.as_ref(),
+                Some(config) if Self::optional_content_array_contains(config, "OFF", xref)?
+            );
+            groups.push(OptionalContentGroup {
+                reference: OptionalContentRef::new(xref)?,
+                name,
+                enabled,
+            });
+        }
+        Ok(groups)
+    }
+
+    pub fn set_optional_content_enabled(
+        &mut self,
+        reference: OptionalContentRef,
+        enabled: bool,
+    ) -> Result<(), Error> {
+        let oc_ref = self.validate_optional_content_ref(reference)?;
+        let mut properties = self.ensure_optional_content_properties()?;
+        self.ensure_indirect_array_entry(&mut properties, "OCGs", &oc_ref, reference.xref())?;
+        let mut config = self.ensure_optional_content_default_config(&mut properties)?;
+        if enabled {
+            Self::remove_indirect_array_entry(&mut config, "OFF", reference.xref())?;
+            self.ensure_indirect_array_entry(&mut config, "ON", &oc_ref, reference.xref())?;
+        } else {
+            Self::remove_indirect_array_entry(&mut config, "ON", reference.xref())?;
+            self.ensure_indirect_array_entry(&mut config, "OFF", &oc_ref, reference.xref())?;
+        }
+        self.ensure_indirect_array_entry(&mut config, "Order", &oc_ref, reference.xref())
+    }
+
+    pub fn optional_content_enabled(&self, reference: OptionalContentRef) -> Result<bool, Error> {
+        self.validate_optional_content_ref(reference)?;
+        let Some(properties) = self.optional_content_properties()? else {
+            return Ok(true);
+        };
+        let Some(config) = properties.get_dict("D")? else {
+            return Ok(true);
+        };
+        Ok(!Self::optional_content_array_contains(
+            &config,
+            "OFF",
+            reference.xref(),
+        )?)
+    }
+
     pub fn begin_operation(&self, op: &str) -> Result<(), Error> {
         let c_op = CString::new(op).map_err(|_| Error::InvalidUtf8)?;
         unsafe {
@@ -1621,8 +1902,8 @@ mod test {
     use crate::{Buffer, Size};
 
     use super::{
-        EmbeddedFileOptions, InsertPdfOptions, InsertPosition, PageLabelRule, PageLabelStyle,
-        PageSelection, PdfDocument, PdfWriteOptions, Permission,
+        EmbeddedFileOptions, InsertPdfOptions, InsertPosition, OptionalContentRef, PageLabelRule,
+        PageLabelStyle, PageSelection, PdfDocument, PdfWriteOptions, Permission,
     };
 
     #[test]
@@ -1892,6 +2173,42 @@ mod test {
         assert!(doc.xref_object(999).is_err());
         assert!(doc.xref_stream(999).is_err());
         assert!(doc.extract_image(999).is_err());
+    }
+
+    #[test]
+    fn test_pdf_document_optional_content_groups() {
+        let mut doc = PdfDocument::new();
+        let oc = doc.add_optional_content_group("Layer 1").unwrap();
+        assert!(oc.xref() > 0);
+
+        let groups = doc.optional_content_groups().unwrap();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].reference, oc);
+        assert_eq!(groups[0].name.as_deref(), Some("Layer 1"));
+        assert!(groups[0].enabled);
+        assert!(doc.optional_content_enabled(oc).unwrap());
+
+        doc.set_optional_content_enabled(oc, false).unwrap();
+        assert!(!doc.optional_content_enabled(oc).unwrap());
+        assert!(!doc.optional_content_groups().unwrap()[0].enabled);
+
+        doc.set_optional_content_enabled(oc, true).unwrap();
+        assert!(doc.optional_content_enabled(oc).unwrap());
+
+        let mut page = doc.new_page(Size::A4).unwrap();
+        let name = page.register_optional_content_ref(&mut doc, oc).unwrap();
+        assert_eq!(name, "/P0");
+        let properties = page
+            .resources()
+            .unwrap()
+            .get_dict("Properties")
+            .unwrap()
+            .unwrap();
+        assert!(properties.get_dict("P0").unwrap().is_some());
+
+        let missing = OptionalContentRef::new(999).unwrap();
+        assert!(doc.optional_content_enabled(missing).is_err());
+        assert!(doc.set_optional_content_enabled(missing, true).is_err());
     }
 
     #[test]

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -10,7 +10,7 @@ use bitflags::bitflags;
 
 use mupdf_sys::*;
 
-use crate::pdf::{DocOperation, FontInfo, PdfGraftMap, PdfObject, PdfPage};
+use crate::pdf::{DocOperation, ExtractedImage, FontInfo, PdfGraftMap, PdfObject, PdfPage};
 use crate::{
     context, from_enum, Buffer, CjkFontOrdering, Destination, Document, Error, FilePath, Font,
     Image, Outline, SimpleFontEncoding, Size, WriteMode,
@@ -1422,6 +1422,26 @@ impl PdfDocument {
         self.new_indirect(xref, 0)?.read_raw_stream()
     }
 
+    pub fn extract_image(&self, xref: i32) -> Result<ExtractedImage, Error> {
+        self.checked_xref(xref)?;
+        let obj = self.new_indirect(xref, 0)?;
+        let Some(info) = PdfPage::image_info_from_object(String::new(), &obj)? else {
+            return Err(Error::InvalidArgument(format!(
+                "xref {xref} does not refer to an image XObject"
+            )));
+        };
+        let encoded = obj.read_raw_stream()?;
+        Ok(ExtractedImage {
+            xref,
+            width: info.width,
+            height: info.height,
+            bits_per_component: info.bits_per_component,
+            color_space: info.color_space,
+            filter: info.filter,
+            encoded,
+        })
+    }
+
     pub fn begin_operation(&self, op: &str) -> Result<(), Error> {
         let c_op = CString::new(op).map_err(|_| Error::InvalidUtf8)?;
         unsafe {
@@ -1857,6 +1877,21 @@ mod test {
 
         assert_eq!(doc.page_label(0).unwrap(), "intro-i");
         assert_eq!(doc.page_label(1).unwrap(), "intro-ii");
+        assert!(doc
+            .set_page_label_rule(PageLabelRule::new(2, PageLabelStyle::Decimal))
+            .is_err());
+        assert!(doc.page_label(2).is_err());
+    }
+
+    #[test]
+    fn test_pdf_document_xref_helpers_reject_missing_xrefs() {
+        let mut doc = PdfDocument::new();
+        doc.new_page(Size::A4).unwrap();
+
+        assert!(doc.xref_object(0).is_err());
+        assert!(doc.xref_object(999).is_err());
+        assert!(doc.xref_stream(999).is_err());
+        assert!(doc.extract_image(999).is_err());
     }
 
     #[test]

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -29,7 +29,10 @@ pub use links::{
     DestPageResolver, FileSpec, LinkAction, PdfAction, PdfDestination, PdfLink, PdfLinkAnnot,
 };
 pub use object::PdfObject;
-pub use page::{FontInfo, InsertFontOptions, PdfPage};
+pub use page::{
+    ExtractedImage, FontInfo, ImagePlacement, InsertFontOptions, InsertImageOptions, PageImageInfo,
+    PageImageSource, PdfPage,
+};
 pub use widget::{FieldFlags, PdfWidget, PdfWidgetIter, WidgetType};
 
 #[must_use]

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -18,7 +18,9 @@ pub use annotation::{
     PdfRedactTextMethod,
 };
 pub use document::{
-    EmbeddedFileInfo, EmbeddedFileOptions, Encryption, PdfDocument, PdfWriteOptions, Permission,
+    EmbeddedFileInfo, EmbeddedFileOptions, Encryption, InsertPdfOptions, InsertPdfResult,
+    InsertPosition, PageLabelRule, PageLabelStyle, PageRange, PageSelection, PdfDocument,
+    PdfWriteOptions, Permission,
 };
 pub use filter::PdfFilterOptions;
 pub use graft_map::PdfGraftMap;

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -19,8 +19,8 @@ pub use annotation::{
 };
 pub use document::{
     EmbeddedFileInfo, EmbeddedFileOptions, Encryption, InsertPdfOptions, InsertPdfResult,
-    InsertPosition, PageLabelRule, PageLabelStyle, PageRange, PageSelection, PdfDocument,
-    PdfWriteOptions, Permission,
+    InsertPosition, OptionalContentGroup, OptionalContentRef, PageLabelRule, PageLabelStyle,
+    PageRange, PageSelection, PdfDocument, PdfWriteOptions, Permission,
 };
 pub use filter::PdfFilterOptions;
 pub use graft_map::PdfGraftMap;

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -23,8 +23,8 @@ use crate::pdf::{
     PdfObject, PdfRedactOptions, PdfWidget, PdfWidgetIter,
 };
 use crate::{
-    context, unsafe_impl_ffi_wrapper, Buffer, CjkFontOrdering, Error, FFIWrapper, Font, Matrix,
-    Page, Point, Rect, SimpleFontEncoding, WriteMode,
+    context, unsafe_impl_ffi_wrapper, Buffer, CjkFontOrdering, Error, FFIWrapper, Font, Image,
+    Matrix, Page, Pixmap, Point, Rect, SimpleFontEncoding, WriteMode,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -66,6 +66,64 @@ impl<'a> InsertFontOptions<'a> {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum PageImageSource<'a> {
+    Image(&'a Image),
+    Pixmap(&'a Pixmap),
+    Bytes {
+        data: &'a [u8],
+        format_hint: Option<&'a str>,
+    },
+    ExistingXref(i32),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct InsertImageOptions {
+    pub overlay: bool,
+    pub opacity: Option<f32>,
+    pub optional_content: Option<i32>,
+}
+
+impl Default for InsertImageOptions {
+    fn default() -> Self {
+        Self {
+            overlay: true,
+            opacity: None,
+            optional_content: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ImagePlacement {
+    pub name: String,
+    pub xref: i32,
+    pub rect: Rect,
+    pub contents_xref: i32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PageImageInfo {
+    pub name: String,
+    pub xref: i32,
+    pub width: u32,
+    pub height: u32,
+    pub bits_per_component: Option<i32>,
+    pub color_space: Option<String>,
+    pub filter: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExtractedImage {
+    pub xref: i32,
+    pub width: u32,
+    pub height: u32,
+    pub bits_per_component: Option<i32>,
+    pub color_space: Option<String>,
+    pub filter: Option<String>,
+    pub encoded: Vec<u8>,
+}
+
 fn canonical_base14_name(name: &str) -> Option<&'static str> {
     match name.trim_start_matches('/').to_ascii_lowercase().as_str() {
         "helv" | "helvetica" => Some("Helvetica"),
@@ -103,6 +161,20 @@ fn cjk_font_name(ordering: CjkFontOrdering) -> &'static str {
         CjkFontOrdering::AdobeJapan => "japan",
         CjkFontOrdering::AdobeKorea => "korea",
     }
+}
+
+fn format_pdf_number(value: f32) -> String {
+    let mut value = format!("{value:.6}");
+    while value.contains('.') && value.ends_with('0') {
+        value.pop();
+    }
+    if value.ends_with('.') {
+        value.pop();
+    }
+    if value == "-0" {
+        value = "0".to_owned();
+    }
+    value
 }
 
 #[derive(Debug)]
@@ -522,6 +594,354 @@ impl PdfPage {
             unsafe { (*self.inner.as_ptr()).doc },
             "PdfPage ownership mismatch: the page is not attached to the provided PdfDocument"
         );
+    }
+
+    fn object_is_image(obj: &PdfObject) -> Result<bool, Error> {
+        let Some(subtype) = obj.get_dict("Subtype")? else {
+            return Ok(false);
+        };
+        Ok(subtype.is_name()? && subtype.as_name()? == b"Image")
+    }
+
+    fn object_to_metadata_string(obj: PdfObject) -> String {
+        obj.to_string()
+    }
+
+    pub(crate) fn image_info_from_object(
+        name: String,
+        obj: &PdfObject,
+    ) -> Result<Option<PageImageInfo>, Error> {
+        let resolved = obj.resolve()?.unwrap_or_else(|| obj.clone());
+        if !Self::object_is_image(&resolved)? {
+            return Ok(None);
+        }
+
+        let xref = obj.as_indirect().unwrap_or(0);
+        let width = resolved
+            .get_dict("Width")?
+            .map(|width| width.as_int())
+            .transpose()?
+            .unwrap_or(0)
+            .max(0) as u32;
+        let height = resolved
+            .get_dict("Height")?
+            .map(|height| height.as_int())
+            .transpose()?
+            .unwrap_or(0)
+            .max(0) as u32;
+        let bits_per_component = resolved
+            .get_dict("BitsPerComponent")?
+            .map(|bpc| bpc.as_int())
+            .transpose()?;
+        let color_space = resolved
+            .get_dict("ColorSpace")?
+            .map(Self::object_to_metadata_string);
+        let filter = resolved
+            .get_dict("Filter")?
+            .map(Self::object_to_metadata_string);
+
+        Ok(Some(PageImageInfo {
+            name,
+            xref,
+            width,
+            height,
+            bits_per_component,
+            color_space,
+            filter,
+        }))
+    }
+
+    fn existing_image_resources(&self) -> Result<Option<PdfObject>, Error> {
+        let page_obj = self.object();
+        let direct_resources = page_obj.get_dict("Resources")?;
+        let resources = match direct_resources {
+            Some(resources) if resources.is_dict()? => Some(resources),
+            Some(_) => None,
+            None => match page_obj.get_dict_inheritable("Resources")? {
+                Some(resources) if resources.is_dict()? => Some(resources),
+                _ => None,
+            },
+        };
+
+        let Some(resources) = resources else {
+            return Ok(None);
+        };
+        match resources.get_dict("XObject")? {
+            Some(xobjects) if xobjects.is_dict()? => Ok(Some(xobjects)),
+            _ => Ok(None),
+        }
+    }
+
+    fn find_image_resource_by_xref(
+        xobjects: &PdfObject,
+        xref: i32,
+    ) -> Result<Option<String>, Error> {
+        for idx in 0..xobjects.dict_len()? {
+            let Some(key) = xobjects.get_dict_key(idx as i32)? else {
+                continue;
+            };
+            let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+                continue;
+            };
+            let Some(value) = xobjects.get_dict_val(idx as i32)? else {
+                continue;
+            };
+            if value.is_indirect()? && value.as_indirect()? == xref {
+                return Ok(Some(key_name.to_owned()));
+            }
+        }
+        Ok(None)
+    }
+
+    fn next_image_resource_slot(xobjects: Option<&PdfObject>) -> Result<String, Error> {
+        let mut used = Vec::new();
+
+        if let Some(xobjects) = xobjects {
+            for idx in 0..xobjects.dict_len()? {
+                let Some(key) = xobjects.get_dict_key(idx as i32)? else {
+                    continue;
+                };
+                let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+                    continue;
+                };
+                let Some(index) = key_name
+                    .strip_prefix("Im")
+                    .filter(|suffix| !suffix.is_empty())
+                    .and_then(|suffix| suffix.parse::<usize>().ok())
+                else {
+                    continue;
+                };
+                used.push(index);
+            }
+        }
+
+        let mut index = 0;
+        while used.contains(&index) {
+            index += 1;
+        }
+        Ok(format!("Im{index}"))
+    }
+
+    fn add_image_resource(
+        &mut self,
+        doc: &mut PdfDocument,
+        image_obj: &PdfObject,
+    ) -> Result<String, Error> {
+        let xref = image_obj.as_indirect()?;
+        let mut resources = self.resources()?;
+        let existing_xobjects = match resources.get_dict("XObject")? {
+            Some(xobjects) if xobjects.is_dict()? => Some(xobjects),
+            _ => None,
+        };
+
+        if let Some(xobjects) = existing_xobjects.as_ref() {
+            if let Some(name) = Self::find_image_resource_by_xref(xobjects, xref)? {
+                return Ok(name);
+            }
+        }
+
+        let slot_name = Self::next_image_resource_slot(existing_xobjects.as_ref())?;
+        let mut xobjects =
+            Self::resource_subdict_for_write(&mut resources, doc, "XObject", existing_xobjects)?;
+        xobjects.dict_put_ref(slot_name.as_str(), image_obj)?;
+
+        Ok(slot_name)
+    }
+
+    fn image_object_from_source(
+        doc: &mut PdfDocument,
+        source: PageImageSource<'_>,
+    ) -> Result<PdfObject, Error> {
+        match source {
+            PageImageSource::Image(image) => doc.add_image(image),
+            PageImageSource::Pixmap(pixmap) => {
+                let image = Image::from_pixmap(pixmap)?;
+                doc.add_image(&image)
+            }
+            PageImageSource::Bytes { data, .. } => {
+                let image = Image::from_bytes(data)?;
+                doc.add_image(&image)
+            }
+            PageImageSource::ExistingXref(xref) => {
+                doc.checked_xref(xref)?;
+                let obj = doc.new_indirect(xref, 0)?;
+                let Some(resolved) = obj.resolve()? else {
+                    return Err(Error::InvalidArgument(format!(
+                        "image xref {xref} does not resolve to an object"
+                    )));
+                };
+                if !Self::object_is_image(&resolved)? {
+                    return Err(Error::InvalidArgument(format!(
+                        "xref {xref} does not refer to an image XObject"
+                    )));
+                }
+                Ok(obj)
+            }
+        }
+    }
+
+    pub fn images(&self) -> Result<Vec<PageImageInfo>, Error> {
+        let Some(xobjects) = self.existing_image_resources()? else {
+            return Ok(Vec::new());
+        };
+
+        let mut images = Vec::new();
+        for idx in 0..xobjects.dict_len()? {
+            let Some(key) = xobjects.get_dict_key(idx as i32)? else {
+                continue;
+            };
+            let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+                continue;
+            };
+            let Some(value) = xobjects.get_dict_val(idx as i32)? else {
+                continue;
+            };
+            if let Some(info) = Self::image_info_from_object(key_name.to_owned(), &value)? {
+                images.push(info);
+            }
+        }
+        Ok(images)
+    }
+
+    pub fn insert_image(
+        &mut self,
+        doc: &mut PdfDocument,
+        rect: Rect,
+        source: PageImageSource<'_>,
+        options: InsertImageOptions,
+    ) -> Result<ImagePlacement, Error> {
+        self.assert_document_owner(doc);
+        if rect.is_empty() {
+            return Err(Error::InvalidArgument(
+                "image insertion requires a non-empty rectangle".to_owned(),
+            ));
+        }
+        if let Some(opacity) = options.opacity {
+            Self::validate_opacity_value(opacity, "image")?;
+        }
+        if let Some(oc_xref) = options.optional_content {
+            Self::validate_optional_content_xref(doc, oc_xref)?;
+        }
+
+        let operation = DocOperation::begin(doc, "Insert image")?;
+        let image_obj = Self::image_object_from_source(operation.doc, source)?;
+        let xref = image_obj.as_indirect()?;
+        let name = self.add_image_resource(operation.doc, &image_obj)?;
+        let gs = match options.opacity {
+            Some(opacity) => self.register_ext_gstate(operation.doc, None, Some(opacity))?,
+            None => None,
+        };
+        let oc = match options.optional_content {
+            Some(oc_xref) => Some(self.register_optional_content(operation.doc, oc_xref)?),
+            None => None,
+        };
+
+        let mut content = String::new();
+        content.push_str("q\n");
+        if let Some(gs) = &gs {
+            content.push_str(gs);
+            content.push_str(" gs\n");
+        }
+        if let Some(oc) = &oc {
+            content.push_str(oc);
+            content.push_str(" BDC\n");
+        }
+        content.push_str(&format!(
+            "{} 0 0 {} {} {} cm\n/{name} Do\n",
+            format_pdf_number(rect.width()),
+            format_pdf_number(rect.height()),
+            format_pdf_number(rect.x0),
+            format_pdf_number(rect.y0)
+        ));
+        if oc.is_some() {
+            content.push_str("EMC\n");
+        }
+        content.push_str("Q\n");
+
+        let contents_xref =
+            self.insert_contents_in_operation(operation.doc, content.as_bytes(), options.overlay)?;
+        operation.commit()?;
+
+        Ok(ImagePlacement {
+            name,
+            xref,
+            rect,
+            contents_xref,
+        })
+    }
+
+    pub fn replace_image(
+        &mut self,
+        doc: &mut PdfDocument,
+        xref: i32,
+        source: PageImageSource<'_>,
+    ) -> Result<ImagePlacement, Error> {
+        self.assert_document_owner(doc);
+        doc.checked_xref(xref)?;
+        let operation = DocOperation::begin(doc, "Replace image")?;
+        let resources = self.resources()?;
+        let Some(mut xobjects) = resources.get_dict("XObject")? else {
+            return Err(Error::InvalidArgument(
+                "page has no image resources".to_owned(),
+            ));
+        };
+        if !xobjects.is_dict()? {
+            return Err(Error::InvalidArgument(
+                "page XObject resources are not a dictionary".to_owned(),
+            ));
+        }
+        let Some(name) = Self::find_image_resource_by_xref(&xobjects, xref)? else {
+            return Err(Error::InvalidArgument(format!(
+                "page does not reference image xref {xref}"
+            )));
+        };
+        let image_obj = Self::image_object_from_source(operation.doc, source)?;
+        let new_xref = image_obj.as_indirect()?;
+        xobjects.dict_put_ref(name.as_str(), &image_obj)?;
+        operation.commit()?;
+
+        Ok(ImagePlacement {
+            name,
+            xref: new_xref,
+            rect: Rect::new(0.0, 0.0, 0.0, 0.0),
+            contents_xref: 0,
+        })
+    }
+
+    pub fn delete_image(&mut self, doc: &mut PdfDocument, xref: i32) -> Result<bool, Error> {
+        self.assert_document_owner(doc);
+        doc.checked_xref(xref)?;
+        let operation = DocOperation::begin(doc, "Delete image")?;
+        let resources = self.resources()?;
+        let Some(mut xobjects) = resources.get_dict("XObject")? else {
+            operation.commit()?;
+            return Ok(false);
+        };
+        if !xobjects.is_dict()? {
+            return Err(Error::InvalidArgument(
+                "page XObject resources are not a dictionary".to_owned(),
+            ));
+        }
+
+        let mut deleted = false;
+        let keys: Vec<_> = (0..xobjects.dict_len()?)
+            .filter_map(|idx| {
+                let value = xobjects.get_dict_val(idx as i32).ok().flatten()?;
+                if value.is_indirect().ok()? && value.as_indirect().ok()? == xref {
+                    let key = xobjects.get_dict_key(idx as i32).ok().flatten()?;
+                    let key = str::from_utf8(key.as_name().ok()?).ok()?.to_owned();
+                    Some(key)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for key in keys {
+            xobjects.dict_delete(key.as_str())?;
+            deleted = true;
+        }
+        operation.commit()?;
+        Ok(deleted)
     }
 
     fn resource_subdict_for_write(
@@ -2013,10 +2433,14 @@ impl TryFrom<Page> for PdfPage {
 mod test {
     use crate::document::test_document;
     use crate::pdf::{
-        InsertFontOptions, PdfAnnotation, PdfAnnotationType, PdfDocument, PdfObject, PdfPage,
+        InsertFontOptions, InsertImageOptions, PageImageSource, PdfAnnotation, PdfAnnotationType,
+        PdfDocument, PdfObject, PdfPage,
     };
     use crate::shape::{Shape, TextOptions};
-    use crate::{Buffer, CjkFontOrdering, Error, Matrix, Point, Rect, SimpleFontEncoding, Size};
+    use crate::{
+        Buffer, CjkFontOrdering, Colorspace, Error, ImageFormat, Matrix, Pixel, Pixmap, Point,
+        Rect, SimpleFontEncoding, Size,
+    };
 
     const CUSTOM_FONT_BYTES: &[u8] = include_bytes!("../../tests/files/custom.ttf");
 
@@ -2044,6 +2468,13 @@ mod test {
     fn add_stream(doc: &mut PdfDocument, bytes: &[u8]) -> PdfObject {
         doc.add_stream(&Buffer::from_bytes(bytes).unwrap(), None, false)
             .unwrap()
+    }
+
+    fn test_pixmap(width: i32, height: i32, pixel: Pixel) -> Pixmap {
+        let cs = Colorspace::device_rgb();
+        let mut pixmap = Pixmap::new_with_w_h(&cs, width, height, false).unwrap();
+        pixmap.set_rect(pixmap.rect(), pixel).unwrap();
+        pixmap
     }
 
     fn default_font_options(name: &str) -> InsertFontOptions<'_> {
@@ -2390,6 +2821,111 @@ mod test {
             doc.new_indirect(second, 0).unwrap().read_stream().unwrap(),
             payload
         );
+    }
+
+    #[test]
+    fn test_page_insert_image_lists_and_extracts_resource() {
+        let mut doc = PdfDocument::new();
+        let mut page = doc.new_page(Size::A4).unwrap();
+        let pixmap = test_pixmap(2, 3, Pixel::rgb(200, 10, 20));
+
+        let placement = page
+            .insert_image(
+                &mut doc,
+                Rect::new(10.0, 20.0, 30.0, 50.0),
+                PageImageSource::Pixmap(&pixmap),
+                InsertImageOptions::default(),
+            )
+            .unwrap();
+
+        assert!(placement.xref > 0);
+        assert_eq!(placement.name, "Im0");
+        assert!(placement.contents_xref > 0);
+
+        let images = page.images().unwrap();
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].name, "Im0");
+        assert_eq!(images[0].xref, placement.xref);
+        assert_eq!(images[0].width, 2);
+        assert_eq!(images[0].height, 3);
+
+        let extracted = doc.extract_image(placement.xref).unwrap();
+        assert_eq!(extracted.xref, placement.xref);
+        assert_eq!(extracted.width, 2);
+        assert_eq!(extracted.height, 3);
+        assert!(!extracted.encoded.is_empty());
+    }
+
+    #[test]
+    fn test_page_replace_and_delete_image_resource() {
+        let mut doc = PdfDocument::new();
+        let mut page = doc.new_page(Size::A4).unwrap();
+        let first = test_pixmap(2, 2, Pixel::rgb(0, 0, 255));
+        let second = test_pixmap(4, 1, Pixel::rgb(0, 255, 0));
+
+        let placement = page
+            .insert_image(
+                &mut doc,
+                Rect::new(0.0, 0.0, 20.0, 20.0),
+                PageImageSource::Pixmap(&first),
+                InsertImageOptions::default(),
+            )
+            .unwrap();
+        let replacement = page
+            .replace_image(&mut doc, placement.xref, PageImageSource::Pixmap(&second))
+            .unwrap();
+
+        assert_eq!(replacement.name, placement.name);
+        assert_ne!(replacement.xref, placement.xref);
+
+        let images = page.images().unwrap();
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].xref, replacement.xref);
+        assert_eq!(images[0].width, 4);
+        assert_eq!(images[0].height, 1);
+
+        assert!(page.delete_image(&mut doc, replacement.xref).unwrap());
+        assert!(page.images().unwrap().is_empty());
+        assert!(!page.delete_image(&mut doc, replacement.xref).unwrap());
+        assert!(page
+            .replace_image(&mut doc, 999, PageImageSource::Pixmap(&second))
+            .is_err());
+        assert!(page.delete_image(&mut doc, 999).is_err());
+    }
+
+    #[test]
+    fn test_page_insert_image_from_encoded_bytes() {
+        let mut doc = PdfDocument::new();
+        let mut page = doc.new_page(Size::A4).unwrap();
+        let pixmap = test_pixmap(2, 2, Pixel::rgb(255, 0, 0));
+        let mut encoded = Vec::new();
+        pixmap.write_to(&mut encoded, ImageFormat::PNG).unwrap();
+
+        let placement = page
+            .insert_image(
+                &mut doc,
+                Rect::new(0.0, 0.0, 10.0, 10.0),
+                PageImageSource::Bytes {
+                    data: &encoded,
+                    format_hint: Some("png"),
+                },
+                InsertImageOptions::default(),
+            )
+            .unwrap();
+
+        let images = page.images().unwrap();
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].xref, placement.xref);
+        assert_eq!(images[0].width, 2);
+        assert_eq!(images[0].height, 2);
+        assert!(page
+            .insert_image(
+                &mut doc,
+                Rect::new(0.0, 0.0, 10.0, 10.0),
+                PageImageSource::ExistingXref(999),
+                InsertImageOptions::default(),
+            )
+            .is_err());
     }
 
     fn contents_stream_bytes(page: &PdfPage) -> Vec<Vec<u8>> {

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -18,9 +18,9 @@ use crate::pdf::links::{
     build_link_annotation, parse_external_link, CachedResolver, DestPageResolver,
 };
 use crate::pdf::{
-    AnnotationArea, AnnotationQuadPoints, DocOperation, LinkAction, PdfAction, PdfAnnotation,
-    PdfAnnotationType, PdfDestination, PdfDocument, PdfFilterOptions, PdfLink, PdfLinkAnnot,
-    PdfObject, PdfRedactOptions, PdfWidget, PdfWidgetIter,
+    AnnotationArea, AnnotationQuadPoints, DocOperation, LinkAction, OptionalContentRef, PdfAction,
+    PdfAnnotation, PdfAnnotationType, PdfDestination, PdfDocument, PdfFilterOptions, PdfLink,
+    PdfLinkAnnot, PdfObject, PdfRedactOptions, PdfWidget, PdfWidgetIter,
 };
 use crate::{
     context, unsafe_impl_ffi_wrapper, Buffer, CjkFontOrdering, Error, FFIWrapper, Font, Image,
@@ -81,7 +81,7 @@ pub enum PageImageSource<'a> {
 pub struct InsertImageOptions {
     pub overlay: bool,
     pub opacity: Option<f32>,
-    pub optional_content: Option<i32>,
+    pub optional_content: Option<OptionalContentRef>,
 }
 
 impl Default for InsertImageOptions {
@@ -819,8 +819,8 @@ impl PdfPage {
         if let Some(opacity) = options.opacity {
             Self::validate_opacity_value(opacity, "image")?;
         }
-        if let Some(oc_xref) = options.optional_content {
-            Self::validate_optional_content_xref(doc, oc_xref)?;
+        if let Some(oc_ref) = options.optional_content {
+            Self::validate_optional_content_xref(doc, oc_ref.xref())?;
         }
 
         let operation = DocOperation::begin(doc, "Insert image")?;
@@ -832,7 +832,7 @@ impl PdfPage {
             None => None,
         };
         let oc = match options.optional_content {
-            Some(oc_xref) => Some(self.register_optional_content(operation.doc, oc_xref)?),
+            Some(oc_ref) => Some(self.register_optional_content(operation.doc, oc_ref.xref())?),
             None => None,
         };
 
@@ -1439,6 +1439,14 @@ impl PdfPage {
         properties.dict_put_ref(slot_name.as_str(), &oc_ref)?;
 
         Ok(format!("/{slot_name}"))
+    }
+
+    pub fn register_optional_content_ref(
+        &mut self,
+        doc: &mut PdfDocument,
+        reference: OptionalContentRef,
+    ) -> Result<String, Error> {
+        self.register_optional_content(doc, reference.xref())
     }
 
     fn cached_font_matches(info: &FontInfo, name: &str, opts: &InsertFontOptions<'_>) -> bool {

--- a/src/pixmap.rs
+++ b/src/pixmap.rs
@@ -1,10 +1,11 @@
+use std::collections::{HashMap, HashSet};
 use std::ffi::CString;
 use std::io::{self, Write};
 use std::slice;
 
 use mupdf_sys::*;
 
-use crate::{context, Buffer, Colorspace, Error, IRect};
+use crate::{context, Buffer, Colorspace, Error, IRect, Quad};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
@@ -14,6 +15,69 @@ pub enum ImageFormat {
     PAM = 2,
     PSD = 3,
     PS = 4,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Pixel {
+    components: Vec<u8>,
+}
+
+impl Pixel {
+    pub fn new(components: impl Into<Vec<u8>>) -> Self {
+        Self {
+            components: components.into(),
+        }
+    }
+
+    pub fn gray(value: u8) -> Self {
+        Self::new([value])
+    }
+
+    pub fn rgb(red: u8, green: u8, blue: u8) -> Self {
+        Self::new([red, green, blue])
+    }
+
+    pub fn rgba(red: u8, green: u8, blue: u8, alpha: u8) -> Self {
+        Self::new([red, green, blue, alpha])
+    }
+
+    pub fn components(&self) -> &[u8] {
+        &self.components
+    }
+}
+
+impl AsRef<[u8]> for Pixel {
+    fn as_ref(&self) -> &[u8] {
+        self.components()
+    }
+}
+
+impl From<Vec<u8>> for Pixel {
+    fn from(components: Vec<u8>) -> Self {
+        Self::new(components)
+    }
+}
+
+impl<const N: usize> From<[u8; N]> for Pixel {
+    fn from(components: [u8; N]) -> Self {
+        Self::new(components)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PixmapDigest([u8; 16]);
+
+impl PixmapDigest {
+    pub fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColorUsage {
+    pub pixel: Pixel,
+    pub count: usize,
+    pub ratio: f32,
 }
 
 /// Pixmaps (pixel maps) are objects at the heart of MuPDF’s rendering capabilities.
@@ -142,7 +206,13 @@ impl Pixmap {
     }
 
     pub fn samples(&self) -> &[u8] {
-        let len = (self.width() * self.height() * self.n() as u32) as usize;
+        let len = match usize::try_from(self.stride())
+            .ok()
+            .and_then(|stride| stride.checked_mul(self.height() as usize))
+        {
+            Some(len) => len,
+            None => return &[],
+        };
         let ptr = unsafe { (*self.inner).samples };
         if ptr.is_null() {
             &[]
@@ -152,13 +222,137 @@ impl Pixmap {
     }
 
     pub fn samples_mut(&mut self) -> &mut [u8] {
-        let len = (self.width() * self.height() * self.n() as u32) as usize;
+        let len = match usize::try_from(self.stride())
+            .ok()
+            .and_then(|stride| stride.checked_mul(self.height() as usize))
+        {
+            Some(len) => len,
+            None => return &mut [],
+        };
         let ptr = unsafe { (*self.inner).samples };
         if ptr.is_null() {
             &mut []
         } else {
             unsafe { slice::from_raw_parts_mut(ptr, len) }
         }
+    }
+
+    fn pixel_rows(&self) -> impl Iterator<Item = &[u8]> {
+        let n = self.n() as usize;
+        let row_len = (self.width() as usize).saturating_mul(n);
+        self.samples()
+            .chunks(self.stride().max(1) as usize)
+            .map(move |row| &row[..row_len.min(row.len())])
+    }
+
+    fn checked_stride(&self) -> Result<usize, Error> {
+        usize::try_from(self.stride()).map_err(|_| {
+            Error::InvalidArgument("pixmap stride cannot be represented as usize".to_owned())
+        })
+    }
+
+    fn pixel_offset(&self, x: i32, y: i32) -> Result<usize, Error> {
+        let rect = self.rect();
+        if !rect.contains(x, y) {
+            return Err(Error::InvalidArgument(format!(
+                "pixel coordinate ({x}, {y}) is outside pixmap bounds {rect}"
+            )));
+        }
+
+        let n = self.n() as usize;
+        let stride = self.checked_stride()?;
+        let row = usize::try_from(y - rect.y0).unwrap();
+        let column = usize::try_from(x - rect.x0).unwrap();
+        let offset = row
+            .checked_mul(stride)
+            .and_then(|offset| offset.checked_add(column.checked_mul(n)?))
+            .ok_or_else(|| Error::InvalidArgument("pixel offset overflow".to_owned()))?;
+
+        let len = self.samples().len();
+        if offset.checked_add(n).is_none_or(|end| end > len) {
+            return Err(Error::InvalidArgument(
+                "pixel offset exceeds pixmap samples".to_owned(),
+            ));
+        }
+
+        Ok(offset)
+    }
+
+    fn validate_pixel_components(&self, pixel: &Pixel) -> Result<(), Error> {
+        let expected = self.n() as usize;
+        let actual = pixel.components().len();
+        if actual != expected {
+            return Err(Error::InvalidArgument(format!(
+                "pixel has {actual} components but pixmap requires {expected}"
+            )));
+        }
+        Ok(())
+    }
+
+    pub fn pixel(&self, x: i32, y: i32) -> Result<Pixel, Error> {
+        let offset = self.pixel_offset(x, y)?;
+        let n = self.n() as usize;
+        Ok(Pixel::new(self.samples()[offset..offset + n].to_vec()))
+    }
+
+    pub fn set_pixel(&mut self, x: i32, y: i32, pixel: impl Into<Pixel>) -> Result<(), Error> {
+        let pixel = pixel.into();
+        self.validate_pixel_components(&pixel)?;
+        let offset = self.pixel_offset(x, y)?;
+        let n = self.n() as usize;
+        self.samples_mut()[offset..offset + n].copy_from_slice(pixel.components());
+        Ok(())
+    }
+
+    pub fn set_rect(&mut self, rect: IRect, pixel: impl Into<Pixel>) -> Result<(), Error> {
+        if !rect.is_valid() {
+            return Err(Error::InvalidArgument(format!(
+                "pixmap rectangle {rect} is not valid"
+            )));
+        }
+
+        let pixel = pixel.into();
+        self.validate_pixel_components(&pixel)?;
+        let rect = rect.intersect(&self.rect());
+        if rect.is_empty() {
+            return Ok(());
+        }
+
+        let n = self.n() as usize;
+        let stride = self.checked_stride()?;
+        let bounds = self.rect();
+        let row_start = usize::try_from(rect.y0 - bounds.y0).unwrap();
+        let row_end = usize::try_from(rect.y1 - bounds.y0).unwrap();
+        let column_start = usize::try_from(rect.x0 - bounds.x0).unwrap();
+        let column_end = usize::try_from(rect.x1 - bounds.x0).unwrap();
+        let samples = self.samples_mut();
+
+        for row in row_start..row_end {
+            for column in column_start..column_end {
+                let offset = row
+                    .checked_mul(stride)
+                    .and_then(|offset| offset.checked_add(column.checked_mul(n)?))
+                    .ok_or_else(|| Error::InvalidArgument("pixel offset overflow".to_owned()))?;
+                samples[offset..offset + n].copy_from_slice(pixel.components());
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn set_alpha(&mut self, alpha: u8) -> Result<(), Error> {
+        if !self.alpha() {
+            return Err(Error::InvalidArgument(
+                "pixmap does not have an alpha component".to_owned(),
+            ));
+        }
+
+        let n = self.n() as usize;
+        let alpha_index = n - 1;
+        for pixel in self.samples_mut().chunks_exact_mut(n) {
+            pixel[alpha_index] = alpha;
+        }
+        Ok(())
     }
 
     /// Only valid for RGBA or BGRA pixmaps
@@ -196,6 +390,21 @@ impl Pixmap {
         unsafe { ffi_try!(mupdf_clear_pixmap_with_value(context(), self.inner, value)) }
     }
 
+    pub fn clear_rect_with(&mut self, rect: IRect, value: i32) -> Result<(), Error> {
+        let rect = rect.intersect(&self.rect());
+        if rect.is_empty() {
+            return Ok(());
+        }
+        unsafe {
+            ffi_try!(mupdf_clear_pixmap_rect_with_value(
+                context(),
+                self.inner,
+                value,
+                rect.into()
+            ))
+        }
+    }
+
     pub fn save_as(&self, filename: &str, format: ImageFormat) -> Result<(), Error> {
         let c_filename = CString::new(filename)?;
         unsafe {
@@ -210,6 +419,84 @@ impl Pixmap {
 
     pub fn invert(&mut self) -> Result<(), Error> {
         unsafe { ffi_try!(mupdf_invert_pixmap(context(), self.inner)) }
+    }
+
+    pub fn invert_rect(&mut self, rect: IRect) -> Result<(), Error> {
+        let rect = rect.intersect(&self.rect());
+        if rect.is_empty() {
+            return Ok(());
+        }
+        unsafe { ffi_try!(mupdf_invert_pixmap_rect(context(), self.inner, rect.into())) }
+    }
+
+    pub fn digest(&self) -> Result<PixmapDigest, Error> {
+        let mut digest = [0; 16];
+        unsafe { ffi_try!(mupdf_md5_pixmap(context(), self.inner, digest.as_mut_ptr()))? };
+        Ok(PixmapDigest(digest))
+    }
+
+    pub fn color_count(&self) -> usize {
+        let n = self.n() as usize;
+        if n == 0 {
+            return 0;
+        }
+        self.pixel_rows()
+            .flat_map(|row| row.chunks_exact(n))
+            .map(|components| Pixel::new(components.to_vec()))
+            .collect::<HashSet<_>>()
+            .len()
+    }
+
+    pub fn top_color_usage(&self) -> Option<ColorUsage> {
+        let n = self.n() as usize;
+        if n == 0 || self.samples().is_empty() {
+            return None;
+        }
+
+        let mut counts = HashMap::<Pixel, usize>::new();
+        for components in self.pixel_rows().flat_map(|row| row.chunks_exact(n)) {
+            *counts.entry(Pixel::new(components.to_vec())).or_default() += 1;
+        }
+
+        let total = (self.width() as usize).checked_mul(self.height() as usize)?;
+        counts
+            .into_iter()
+            .max_by_key(|(_, count)| *count)
+            .map(|(pixel, count)| ColorUsage {
+                pixel,
+                count,
+                ratio: count as f32 / total as f32,
+            })
+    }
+
+    /// Subsample this pixmap in place by a power-of-two level.
+    ///
+    /// A level of `1` halves the dimensions, `2` quarters them, and so on.
+    pub fn shrink(&mut self, level: i32) -> Result<(), Error> {
+        if level < 1 {
+            return Err(Error::InvalidArgument(
+                "shrink level must be at least 1".to_owned(),
+            ));
+        }
+        unsafe { ffi_try!(mupdf_subsample_pixmap(context(), self.inner, level)) }
+    }
+
+    pub fn warp(&self, points: impl Into<Quad>, width: i32, height: i32) -> Result<Pixmap, Error> {
+        if width <= 0 || height <= 0 {
+            return Err(Error::InvalidArgument(
+                "warp width and height must be positive".to_owned(),
+            ));
+        }
+        unsafe {
+            ffi_try!(mupdf_warp_pixmap(
+                context(),
+                self.inner,
+                points.into().into(),
+                width,
+                height
+            ))
+        }
+        .map(|inner| Self { inner })
     }
 
     /// Apply a gamma factor to a pixmap, i.e. lighten or darken it.
@@ -265,7 +552,9 @@ impl Clone for Pixmap {
 
 #[cfg(test)]
 mod test {
-    use super::{Colorspace, IRect, Pixmap};
+    use crate::Rect;
+
+    use super::{Colorspace, IRect, Pixel, Pixmap};
 
     #[test]
     fn test_pixmap_properties() {
@@ -344,5 +633,56 @@ mod test {
         let mut pixmap = Pixmap::new_with_w_h(&cs, 0, 0, false).expect("Pixmap::new_with_w_h");
         assert!(pixmap.samples().is_empty());
         assert!(pixmap.samples_mut().is_empty());
+    }
+
+    #[test]
+    fn test_pixmap_pixel_editing_and_color_usage() {
+        let cs = Colorspace::device_rgb();
+        let mut pixmap = Pixmap::new_with_w_h(&cs, 3, 3, false).unwrap();
+        pixmap.clear_with(0).unwrap();
+
+        pixmap.set_pixel(1, 1, Pixel::rgb(10, 20, 30)).unwrap();
+        assert_eq!(pixmap.pixel(1, 1).unwrap(), Pixel::rgb(10, 20, 30));
+        assert!(pixmap.set_pixel(3, 1, Pixel::rgb(1, 2, 3)).is_err());
+        assert!(pixmap.set_pixel(1, 1, Pixel::rgba(1, 2, 3, 4)).is_err());
+
+        pixmap
+            .set_rect(IRect::new(0, 0, 2, 2), Pixel::rgb(7, 8, 9))
+            .unwrap();
+        assert_eq!(pixmap.pixel(0, 0).unwrap(), Pixel::rgb(7, 8, 9));
+        assert_eq!(pixmap.pixel(1, 1).unwrap(), Pixel::rgb(7, 8, 9));
+        assert_eq!(pixmap.color_count(), 2);
+
+        let usage = pixmap.top_color_usage().unwrap();
+        assert_eq!(usage.pixel, Pixel::new(vec![0, 0, 0]));
+        assert_eq!(usage.count, 5);
+        assert!((usage.ratio - 5.0 / 9.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_pixmap_alpha_digest_rect_invert_shrink_and_warp() {
+        let cs = Colorspace::device_rgb();
+        let mut pixmap = Pixmap::new_with_w_h(&cs, 4, 4, true).unwrap();
+        pixmap.clear_with(16).unwrap();
+        pixmap.set_alpha(127).unwrap();
+        assert_eq!(pixmap.pixel(0, 0).unwrap(), Pixel::rgba(16, 16, 16, 127));
+
+        let before = pixmap.digest().unwrap();
+        pixmap.invert_rect(IRect::new(0, 0, 2, 2)).unwrap();
+        let after = pixmap.digest().unwrap();
+        assert_ne!(before, after);
+
+        let warped = pixmap
+            .warp(Rect::new(0.0, 0.0, 4.0, 4.0).quad(), 2, 2)
+            .unwrap();
+        assert_eq!(warped.width(), 2);
+        assert_eq!(warped.height(), 2);
+
+        pixmap.shrink(1).unwrap();
+        assert_eq!(pixmap.width(), 2);
+        assert_eq!(pixmap.height(), 2);
+
+        let mut no_alpha = Pixmap::new_with_w_h(&cs, 1, 1, false).unwrap();
+        assert!(no_alpha.set_alpha(255).is_err());
     }
 }


### PR DESCRIPTION
## Summary
- add Rust-native page range, selection, insertion option, and insertion result types
- add document page insert/copy/duplicate/move/delete/select/reload helpers
- add page label and xref convenience APIs

## Stack
Base: `main`

## Validation
- `git log --oneline main..codex/api-parity-page-composition`
- `cargo test --lib -- --skip document_writer::test::test_writer_ocr` on the top of the dependent stack
- `cargo test` was also run on the stack tip; it only failed at the existing OCR test because local Tesseract data is missing (`./eng.traineddata`).