### PR TITLE
feat(pdf): add widget and embedded file APIs

### DIFF
--- a/mupdf-sys/wrapper/pdf_annot.c
+++ b/mupdf-sys/wrapper/pdf_annot.c
@@ -15,6 +15,112 @@ int mupdf_pdf_update_annot(fz_context *ctx, pdf_annot *annot, mupdf_error_t **er
     TRY_CATCH(int, 0, pdf_update_annot(ctx, annot));
 }
 
+pdf_annot *mupdf_pdf_first_widget(fz_context *ctx, pdf_page *page, mupdf_error_t **errptr)
+{
+    TRY_CATCH(pdf_annot*, NULL, pdf_first_widget(ctx, page));
+}
+
+pdf_annot *mupdf_pdf_next_widget(fz_context *ctx, pdf_annot *previous, mupdf_error_t **errptr)
+{
+    TRY_CATCH(pdf_annot*, NULL, pdf_next_widget(ctx, previous));
+}
+
+pdf_annot *mupdf_pdf_create_signature_widget(fz_context *ctx, pdf_page *page, const char *name, mupdf_error_t **errptr)
+{
+    TRY_CATCH(pdf_annot*, NULL, pdf_create_signature_widget(ctx, page, (char *)name));
+}
+
+int mupdf_pdf_update_widget(fz_context *ctx, pdf_annot *widget, mupdf_error_t **errptr)
+{
+    TRY_CATCH(int, 0, pdf_update_widget(ctx, widget));
+}
+
+enum pdf_widget_type mupdf_pdf_widget_type(fz_context *ctx, pdf_annot *widget, mupdf_error_t **errptr)
+{
+    TRY_CATCH(enum pdf_widget_type, PDF_WIDGET_TYPE_UNKNOWN, pdf_widget_type(ctx, widget));
+}
+
+int mupdf_pdf_widget_is_signed(fz_context *ctx, pdf_annot *widget, mupdf_error_t **errptr)
+{
+    TRY_CATCH(int, 0, pdf_widget_is_signed(ctx, widget));
+}
+
+int mupdf_pdf_widget_is_readonly(fz_context *ctx, pdf_annot *widget, mupdf_error_t **errptr)
+{
+    TRY_CATCH(int, 0, pdf_widget_is_readonly(ctx, widget));
+}
+
+char *mupdf_pdf_load_widget_field_name(fz_context *ctx, pdf_annot *widget, mupdf_error_t **errptr)
+{
+    TRY_CATCH(char*, NULL, pdf_load_field_name(ctx, pdf_annot_obj(ctx, widget)));
+}
+
+const char *mupdf_pdf_widget_field_type_string(fz_context *ctx, pdf_annot *widget, mupdf_error_t **errptr)
+{
+    TRY_CATCH(const char*, NULL, pdf_field_type_string(ctx, pdf_annot_obj(ctx, widget)));
+}
+
+int mupdf_pdf_widget_field_flags(fz_context *ctx, pdf_annot *widget, mupdf_error_t **errptr)
+{
+    TRY_CATCH(int, 0, pdf_field_flags(ctx, pdf_annot_obj(ctx, widget)));
+}
+
+const char *mupdf_pdf_widget_field_value(fz_context *ctx, pdf_annot *widget, mupdf_error_t **errptr)
+{
+    TRY_CATCH(const char*, NULL, pdf_field_value(ctx, pdf_annot_obj(ctx, widget)));
+}
+
+const char *mupdf_pdf_widget_field_label(fz_context *ctx, pdf_annot *widget, mupdf_error_t **errptr)
+{
+    TRY_CATCH(const char*, NULL, pdf_field_label(ctx, pdf_annot_obj(ctx, widget)));
+}
+
+int mupdf_pdf_set_widget_field_value(fz_context *ctx, pdf_document *doc, pdf_annot *widget, const char *value, int ignore_trigger_events, mupdf_error_t **errptr)
+{
+    TRY_CATCH(int, 0, pdf_set_field_value(ctx, doc, pdf_annot_obj(ctx, widget), value, ignore_trigger_events));
+}
+
+void mupdf_pdf_reset_widget_field(fz_context *ctx, pdf_document *doc, pdf_annot *widget, mupdf_error_t **errptr)
+{
+    TRY_CATCH_VOID(pdf_field_reset(ctx, doc, pdf_annot_obj(ctx, widget)));
+}
+
+pdf_obj *mupdf_pdf_add_embedded_file(fz_context *ctx, pdf_document *doc, const char *filename, const char *mimetype, fz_buffer *contents, int64_t created, int64_t modified, int add_checksum, mupdf_error_t **errptr)
+{
+    TRY_CATCH(pdf_obj*, NULL, pdf_add_embedded_file(ctx, doc, filename, mimetype, contents, created, modified, add_checksum));
+}
+
+int mupdf_pdf_is_embedded_file(fz_context *ctx, pdf_obj *fs, mupdf_error_t **errptr)
+{
+    TRY_CATCH(int, 0, pdf_is_embedded_file(ctx, fs));
+}
+
+pdf_filespec_params mupdf_pdf_get_filespec_params(fz_context *ctx, pdf_obj *fs, mupdf_error_t **errptr)
+{
+    pdf_filespec_params params = {0};
+    params.created = -1;
+    params.modified = -1;
+    fz_try(ctx)
+    {
+        pdf_get_filespec_params(ctx, fs, &params);
+    }
+    fz_catch(ctx)
+    {
+        mupdf_save_error(ctx, errptr);
+    }
+    return params;
+}
+
+fz_buffer *mupdf_pdf_load_embedded_file_contents(fz_context *ctx, pdf_obj *fs, mupdf_error_t **errptr)
+{
+    TRY_CATCH(fz_buffer*, NULL, pdf_load_embedded_file_contents(ctx, fs));
+}
+
+int mupdf_pdf_verify_embedded_file_checksum(fz_context *ctx, pdf_obj *fs, mupdf_error_t **errptr)
+{
+    TRY_CATCH(int, 0, pdf_verify_embedded_file_checksum(ctx, fs));
+}
+
 bool mupdf_pdf_apply_redaction(fz_context *ctx, pdf_annot *annot, pdf_redact_options *opts, mupdf_error_t **errptr)
 {
     TRY_CATCH(bool, false, pdf_apply_redaction(ctx, annot, opts));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,10 @@ pub use matrix::Matrix;
 pub use outline::Outline;
 pub use page::Page;
 pub use path::{Path, PathWalker};
-pub use pdf::{FontInfo, InsertFontOptions};
+pub use pdf::{
+    EmbeddedFileInfo, EmbeddedFileOptions, FieldFlags, FontInfo, InsertFontOptions, PdfWidget,
+    PdfWidgetIter, WidgetType,
+};
 pub use pixmap::{ImageFormat, Pixmap};
 pub use point::Point;
 pub use quad::Quad;

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::ffi::{c_int, CStr, CString};
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::ops::{Deref, DerefMut};
 use std::ptr::{self, NonNull};
 
@@ -236,6 +236,38 @@ pub struct PdfDocument {
     inner: *mut pdf_document,
     doc: Document,
     pub(crate) font_info_cache: RefCell<HashMap<i32, FontInfo>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EmbeddedFileOptions<'a> {
+    pub filename: &'a str,
+    pub mime_type: Option<&'a str>,
+    pub created: Option<i64>,
+    pub modified: Option<i64>,
+    pub add_checksum: bool,
+}
+
+impl<'a> EmbeddedFileOptions<'a> {
+    pub fn new(filename: &'a str) -> Self {
+        Self {
+            filename,
+            mime_type: None,
+            created: None,
+            modified: None,
+            add_checksum: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EmbeddedFileInfo {
+    pub name: String,
+    pub xref: i32,
+    pub filename: Option<String>,
+    pub mime_type: Option<String>,
+    pub size: usize,
+    pub created: Option<i64>,
+    pub modified: Option<i64>,
 }
 
 impl Default for PdfDocument {
@@ -617,6 +649,245 @@ impl PdfDocument {
         unsafe { ffi_try!(mupdf_pdf_delete_page(context(), self.inner, page_no)) }
     }
 
+    fn ensure_embedded_files_array(&self) -> Result<PdfObject, Error> {
+        let mut catalog = self.catalog()?;
+        let mut names = match catalog.get_dict("Names")? {
+            Some(names) if names.is_dict()? => names,
+            _ => {
+                let names = self.new_dict()?;
+                catalog.dict_put_ref("Names", &names)?;
+                names
+            }
+        };
+        let mut embedded_files = match names.get_dict("EmbeddedFiles")? {
+            Some(embedded_files) if embedded_files.is_dict()? => embedded_files,
+            _ => {
+                let embedded_files = self.new_dict()?;
+                names.dict_put_ref("EmbeddedFiles", &embedded_files)?;
+                embedded_files
+            }
+        };
+        match embedded_files.get_dict("Names")? {
+            Some(array) if array.is_array()? => Ok(array),
+            _ => {
+                let array = self.new_array()?;
+                embedded_files.dict_put_ref("Names", &array)?;
+                Ok(array)
+            }
+        }
+    }
+
+    fn embedded_files_array(&self) -> Result<Option<PdfObject>, Error> {
+        let Some(names) = self.catalog()?.get_dict("Names")? else {
+            return Ok(None);
+        };
+        if !names.is_dict()? {
+            return Ok(None);
+        }
+        let Some(embedded_files) = names.get_dict("EmbeddedFiles")? else {
+            return Ok(None);
+        };
+        if !embedded_files.is_dict()? {
+            return Ok(None);
+        }
+        match embedded_files.get_dict("Names")? {
+            Some(array) if array.is_array()? => Ok(Some(array)),
+            _ => Ok(None),
+        }
+    }
+
+    fn named_embedded_file_object(&self, name: &str) -> Result<Option<PdfObject>, Error> {
+        let Some(array) = self.embedded_files_array()? else {
+            return Ok(None);
+        };
+        let len = array.len()?;
+        let mut index = 0;
+        while index + 1 < len {
+            let key_matches = array
+                .get_array(index as i32)?
+                .and_then(|key| key.as_string().ok().map(|key| key == name))
+                .unwrap_or(false);
+            if key_matches {
+                return array.get_array((index + 1) as i32);
+            }
+            index += 2;
+        }
+        Ok(None)
+    }
+
+    fn filespec_info(&self, name: String, fs: PdfObject) -> Result<EmbeddedFileInfo, Error> {
+        let is_embedded =
+            unsafe { ffi_try!(mupdf_pdf_is_embedded_file(context(), fs.inner))? != 0 };
+        if !is_embedded {
+            return Err(Error::InvalidArgument(format!(
+                "named file {name} is not an embedded file"
+            )));
+        }
+
+        let params = unsafe { ffi_try!(mupdf_pdf_get_filespec_params(context(), fs.inner))? };
+        let filename = if params.filename.is_null() {
+            None
+        } else {
+            Some(
+                unsafe { CStr::from_ptr(params.filename) }
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        };
+        let mime_type = if params.mimetype.is_null() {
+            None
+        } else {
+            Some(
+                unsafe { CStr::from_ptr(params.mimetype) }
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        };
+
+        Ok(EmbeddedFileInfo {
+            name,
+            xref: fs.as_indirect().unwrap_or(0),
+            filename,
+            mime_type,
+            size: params.size.max(0) as usize,
+            created: (params.created >= 0).then_some(params.created),
+            modified: (params.modified >= 0).then_some(params.modified),
+        })
+    }
+
+    fn put_named_embedded_file(&self, name: &str, filespec: &PdfObject) -> Result<(), Error> {
+        let mut array = self.ensure_embedded_files_array()?;
+        let len = array.len()?;
+        let mut index = 0;
+        while index + 1 < len {
+            let key_matches = array
+                .get_array(index as i32)?
+                .and_then(|key| key.as_string().ok().map(|key| key == name))
+                .unwrap_or(false);
+            if key_matches {
+                array.array_put((index + 1) as i32, filespec.clone())?;
+                return Ok(());
+            }
+            index += 2;
+        }
+        array.array_push(PdfObject::new_string(name)?)?;
+        array.array_push_ref(filespec)
+    }
+
+    pub fn add_embedded_file(
+        &mut self,
+        name: &str,
+        contents: &[u8],
+        options: EmbeddedFileOptions<'_>,
+    ) -> Result<EmbeddedFileInfo, Error> {
+        let filename = CString::new(options.filename)?;
+        let mime_type = options.mime_type.map(CString::new).transpose()?;
+        let contents = Buffer::from_bytes(contents)?;
+        let fs = unsafe {
+            ffi_try!(mupdf_pdf_add_embedded_file(
+                context(),
+                self.inner,
+                filename.as_ptr(),
+                mime_type
+                    .as_ref()
+                    .map_or(ptr::null(), |mime_type| mime_type.as_ptr()),
+                contents.inner,
+                options.created.unwrap_or(-1),
+                options.modified.unwrap_or(-1),
+                i32::from(options.add_checksum)
+            ))
+        }
+        .map(|inner| unsafe { PdfObject::from_raw(inner) })?;
+        let fs = if fs.is_indirect()? {
+            fs
+        } else {
+            self.add_object(&fs)?
+        };
+        self.put_named_embedded_file(name, &fs)?;
+        self.filespec_info(name.to_owned(), fs)
+    }
+
+    pub fn embedded_files(&self) -> Result<Vec<EmbeddedFileInfo>, Error> {
+        let Some(array) = self.embedded_files_array()? else {
+            return Ok(Vec::new());
+        };
+
+        let mut files = Vec::new();
+        let len = array.len()?;
+        let mut index = 0;
+        while index + 1 < len {
+            let Some(name) = array
+                .get_array(index as i32)?
+                .and_then(|name| name.as_string().ok().map(str::to_owned))
+            else {
+                index += 2;
+                continue;
+            };
+            if let Some(filespec) = array.get_array((index + 1) as i32)? {
+                files.push(self.filespec_info(name, filespec)?);
+            }
+            index += 2;
+        }
+        Ok(files)
+    }
+
+    pub fn embedded_file(&self, name: &str) -> Result<Option<EmbeddedFileInfo>, Error> {
+        let Some(filespec) = self.named_embedded_file_object(name)? else {
+            return Ok(None);
+        };
+        self.filespec_info(name.to_owned(), filespec).map(Some)
+    }
+
+    pub fn load_embedded_file(&self, name: &str) -> Result<Option<Vec<u8>>, Error> {
+        let Some(filespec) = self.named_embedded_file_object(name)? else {
+            return Ok(None);
+        };
+        let buffer = unsafe {
+            ffi_try!(mupdf_pdf_load_embedded_file_contents(
+                context(),
+                filespec.inner
+            ))
+        }?;
+        let mut buffer = unsafe { Buffer::from_raw(buffer) };
+        let mut contents = Vec::with_capacity(buffer.len());
+        buffer.read_to_end(&mut contents)?;
+        Ok(Some(contents))
+    }
+
+    pub fn verify_embedded_file_checksum(&self, name: &str) -> Result<Option<bool>, Error> {
+        let Some(filespec) = self.named_embedded_file_object(name)? else {
+            return Ok(None);
+        };
+        unsafe {
+            ffi_try!(mupdf_pdf_verify_embedded_file_checksum(
+                context(),
+                filespec.inner
+            ))
+        }
+        .map(|valid| Some(valid != 0))
+    }
+
+    pub fn delete_embedded_file(&mut self, name: &str) -> Result<bool, Error> {
+        let Some(mut array) = self.embedded_files_array()? else {
+            return Ok(false);
+        };
+        let len = array.len()?;
+        let mut index = 0;
+        while index + 1 < len {
+            let key_matches = array
+                .get_array(index as i32)?
+                .and_then(|key| key.as_string().ok().map(|key| key == name))
+                .unwrap_or(false);
+            if key_matches {
+                array.array_delete((index + 1) as i32)?;
+                array.array_delete(index as i32)?;
+                return Ok(true);
+            }
+            index += 2;
+        }
+        Ok(false)
+    }
+
     pub fn begin_operation(&self, op: &str) -> Result<(), Error> {
         let c_op = CString::new(op).map_err(|_| Error::InvalidUtf8)?;
         unsafe {
@@ -795,7 +1066,7 @@ mod test {
     use crate::document::test_document;
     use crate::Buffer;
 
-    use super::{PdfDocument, PdfWriteOptions, Permission};
+    use super::{EmbeddedFileOptions, PdfDocument, PdfWriteOptions, Permission};
 
     #[test]
     fn test_pdf_write_options_passwords() {
@@ -960,6 +1231,43 @@ mod test {
     fn test_pdf_document_find_page() {
         let doc = test_document!("../..", "files/dummy.pdf" as PdfDocument).unwrap();
         let _page = doc.find_page(0).unwrap();
+    }
+
+    #[test]
+    fn test_pdf_document_named_embedded_files() {
+        let mut doc = PdfDocument::new();
+        let info = doc
+            .add_embedded_file(
+                "payload",
+                b"hello embedded",
+                EmbeddedFileOptions {
+                    mime_type: Some("text/plain"),
+                    ..EmbeddedFileOptions::new("payload.txt")
+                },
+            )
+            .unwrap();
+
+        assert_eq!(info.name, "payload");
+        assert_eq!(info.filename.as_deref(), Some("payload.txt"));
+        assert_eq!(info.mime_type.as_deref(), Some("text/plain"));
+        assert_eq!(info.size, b"hello embedded".len());
+
+        let files = doc.embedded_files().unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].name, "payload");
+        assert_eq!(
+            doc.load_embedded_file("payload").unwrap().unwrap(),
+            b"hello embedded"
+        );
+        assert_eq!(
+            doc.verify_embedded_file_checksum("payload").unwrap(),
+            Some(true)
+        );
+        assert!(doc.embedded_file("payload").unwrap().is_some());
+
+        assert!(doc.delete_embedded_file("payload").unwrap());
+        assert!(doc.embedded_files().unwrap().is_empty());
+        assert!(doc.load_embedded_file("payload").unwrap().is_none());
     }
 
     #[test]

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -6,6 +6,7 @@ pub mod intent;
 pub mod links;
 pub mod object;
 pub mod page;
+pub mod widget;
 
 #[cfg(test)]
 mod tests_annotation;
@@ -16,7 +17,9 @@ pub use annotation::{
     PdfAnnotationType, PdfRedactImageMethod, PdfRedactLineArtMethod, PdfRedactOptions,
     PdfRedactTextMethod,
 };
-pub use document::{Encryption, PdfDocument, PdfWriteOptions, Permission};
+pub use document::{
+    EmbeddedFileInfo, EmbeddedFileOptions, Encryption, PdfDocument, PdfWriteOptions, Permission,
+};
 pub use filter::PdfFilterOptions;
 pub use graft_map::PdfGraftMap;
 pub use intent::Intent;
@@ -25,6 +28,7 @@ pub use links::{
 };
 pub use object::PdfObject;
 pub use page::{FontInfo, InsertFontOptions, PdfPage};
+pub use widget::{FieldFlags, PdfWidget, PdfWidgetIter, WidgetType};
 
 #[must_use]
 pub struct DocOperation<'a> {

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::str;
 use std::{
-    ffi::CStr,
+    ffi::{CStr, CString},
     mem::ManuallyDrop,
     ops::{Deref, DerefMut},
     ptr::NonNull,
@@ -20,7 +20,7 @@ use crate::pdf::links::{
 use crate::pdf::{
     AnnotationArea, AnnotationQuadPoints, DocOperation, LinkAction, PdfAction, PdfAnnotation,
     PdfAnnotationType, PdfDestination, PdfDocument, PdfFilterOptions, PdfLink, PdfLinkAnnot,
-    PdfObject, PdfRedactOptions,
+    PdfObject, PdfRedactOptions, PdfWidget, PdfWidgetIter,
 };
 use crate::{
     context, unsafe_impl_ffi_wrapper, Buffer, CjkFontOrdering, Error, FFIWrapper, Font, Matrix,
@@ -397,6 +397,39 @@ impl PdfPage {
             next: NonNull::new(next),
             marker: PhantomData,
         }
+    }
+
+    pub fn widgets(&self) -> PdfWidgetIter<'_> {
+        let next = unsafe { pdf_first_widget(context(), self.as_ptr().cast_mut()) };
+        PdfWidgetIter {
+            next: NonNull::new(next),
+            marker: PhantomData,
+        }
+    }
+
+    pub fn load_widget(&self, xref: i32) -> Result<Option<PdfWidget>, Error> {
+        for widget in self.widgets() {
+            if widget.xref()? == xref {
+                return Ok(Some(widget));
+            }
+        }
+        Ok(None)
+    }
+
+    pub fn delete_widget(&mut self, widget: PdfWidget) -> Result<(), Error> {
+        self.delete_annotation(widget.into_annotation())
+    }
+
+    pub fn add_signature_widget(&mut self, name: &str) -> Result<PdfWidget, Error> {
+        let name = CString::new(name)?;
+        unsafe {
+            ffi_try!(mupdf_pdf_create_signature_widget(
+                context(),
+                self.as_mut_ptr(),
+                name.as_ptr()
+            ))
+        }
+        .map(|widget| unsafe { PdfWidget::from_raw(widget) })
     }
 
     pub fn update(&mut self) -> Result<bool, Error> {
@@ -2114,6 +2147,26 @@ mod test {
         assert_eq!(annots.len(), 1);
         assert_eq!(annots[0].r#type().unwrap(), PdfAnnotationType::Text);
         assert_eq!(annots[0].rect().unwrap(), expected);
+    }
+
+    #[test]
+    fn test_page_widgets_empty_and_signature_widget() {
+        let mut doc = PdfDocument::new();
+        let mut page = doc.new_page(Size::A4).unwrap();
+        assert_eq!(page.widgets().count(), 0);
+
+        let widget = page.add_signature_widget("Sig1").unwrap();
+        assert_eq!(widget.r#type().unwrap(), crate::WidgetType::Signature);
+        assert_eq!(widget.name().unwrap().as_deref(), Some("Sig1"));
+        assert!(!widget.is_signed().unwrap());
+
+        let xref = widget.xref().unwrap();
+        drop(widget);
+
+        let widgets: Vec<_> = page.widgets().collect();
+        assert_eq!(widgets.len(), 1);
+        assert_eq!(widgets[0].xref().unwrap(), xref);
+        assert!(page.load_widget(xref).unwrap().is_some());
     }
 
     #[test]

--- a/src/pdf/widget.rs
+++ b/src/pdf/widget.rs
@@ -1,0 +1,260 @@
+use std::ffi::{CStr, CString};
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+use mupdf_sys::*;
+
+use crate::pdf::{PdfAnnotation, PdfDocument};
+use crate::{context, from_enum, Error};
+
+from_enum! { pdf_widget_type => pdf_widget_type,
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum WidgetType {
+        Unknown = PDF_WIDGET_TYPE_UNKNOWN,
+        Button = PDF_WIDGET_TYPE_BUTTON,
+        Checkbox = PDF_WIDGET_TYPE_CHECKBOX,
+        Combobox = PDF_WIDGET_TYPE_COMBOBOX,
+        Listbox = PDF_WIDGET_TYPE_LISTBOX,
+        RadioButton = PDF_WIDGET_TYPE_RADIOBUTTON,
+        Signature = PDF_WIDGET_TYPE_SIGNATURE,
+        Text = PDF_WIDGET_TYPE_TEXT,
+    }
+}
+
+bitflags::bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct FieldFlags: i32 {
+        const READ_ONLY = PDF_FIELD_IS_READ_ONLY as i32;
+        const REQUIRED = PDF_FIELD_IS_REQUIRED as i32;
+        const NO_EXPORT = PDF_FIELD_IS_NO_EXPORT as i32;
+        const MULTILINE = PDF_TX_FIELD_IS_MULTILINE as i32;
+        const PASSWORD = PDF_TX_FIELD_IS_PASSWORD as i32;
+        const FILE_SELECT = PDF_TX_FIELD_IS_FILE_SELECT as i32;
+        const DO_NOT_SPELL_CHECK = PDF_TX_FIELD_IS_DO_NOT_SPELL_CHECK as i32;
+        const DO_NOT_SCROLL = PDF_TX_FIELD_IS_DO_NOT_SCROLL as i32;
+        const COMB = PDF_TX_FIELD_IS_COMB as i32;
+        const RICH_TEXT = PDF_TX_FIELD_IS_RICH_TEXT as i32;
+        const NO_TOGGLE_TO_OFF = PDF_BTN_FIELD_IS_NO_TOGGLE_TO_OFF as i32;
+        const RADIO = PDF_BTN_FIELD_IS_RADIO as i32;
+        const PUSHBUTTON = PDF_BTN_FIELD_IS_PUSHBUTTON as i32;
+        const RADIOS_IN_UNISON = PDF_BTN_FIELD_IS_RADIOS_IN_UNISON as i32;
+        const COMBO = PDF_CH_FIELD_IS_COMBO as i32;
+        const EDIT = PDF_CH_FIELD_IS_EDIT as i32;
+        const SORT = PDF_CH_FIELD_IS_SORT as i32;
+        const MULTI_SELECT = PDF_CH_FIELD_IS_MULTI_SELECT as i32;
+        const COMMIT_ON_SEL_CHANGE = PDF_CH_FIELD_IS_COMMIT_ON_SEL_CHANGE as i32;
+    }
+}
+
+#[derive(Debug)]
+pub struct PdfWidget {
+    annot: PdfAnnotation,
+}
+
+impl PdfWidget {
+    pub(crate) unsafe fn from_raw(ptr: *mut pdf_annot) -> Self {
+        Self {
+            annot: PdfAnnotation::from_raw(ptr),
+        }
+    }
+
+    pub(crate) unsafe fn from_raw_keep_ref(ptr: *mut pdf_annot) -> Self {
+        Self {
+            annot: PdfAnnotation::from_raw_keep_ref(ptr),
+        }
+    }
+
+    pub fn annotation(&self) -> &PdfAnnotation {
+        &self.annot
+    }
+
+    pub fn into_annotation(self) -> PdfAnnotation {
+        self.annot
+    }
+
+    pub fn xref(&self) -> Result<i32, Error> {
+        self.annot.xref()
+    }
+
+    fn assert_document_owner(&self, doc: &PdfDocument) -> Result<(), Error> {
+        let page = self.annot.page_ptr()?;
+        assert_eq!(
+            doc.as_raw(),
+            unsafe { (*page).doc },
+            "PdfWidget ownership mismatch: the widget is not attached to the provided PdfDocument"
+        );
+        Ok(())
+    }
+
+    pub fn r#type(&self) -> Result<WidgetType, Error> {
+        self.annot.ensure_attached()?;
+        unsafe { ffi_try!(mupdf_pdf_widget_type(context(), self.annot.inner.as_ptr())) }
+            .map(|kind| WidgetType::try_from(kind).unwrap_or(WidgetType::Unknown))
+    }
+
+    pub fn update(&mut self) -> Result<bool, Error> {
+        self.annot.ensure_attached()?;
+        unsafe {
+            ffi_try!(mupdf_pdf_update_widget(
+                context(),
+                self.annot.inner.as_ptr()
+            ))
+        }
+        .map(|updated| updated != 0)
+    }
+
+    pub fn is_signed(&self) -> Result<bool, Error> {
+        self.annot.ensure_attached()?;
+        unsafe {
+            ffi_try!(mupdf_pdf_widget_is_signed(
+                context(),
+                self.annot.inner.as_ptr()
+            ))
+        }
+        .map(|signed| signed != 0)
+    }
+
+    pub fn is_readonly(&self) -> Result<bool, Error> {
+        self.annot.ensure_attached()?;
+        unsafe {
+            ffi_try!(mupdf_pdf_widget_is_readonly(
+                context(),
+                self.annot.inner.as_ptr()
+            ))
+        }
+        .map(|readonly| readonly != 0)
+    }
+
+    pub fn name(&self) -> Result<Option<String>, Error> {
+        self.annot.ensure_attached()?;
+        let ptr = unsafe {
+            ffi_try!(mupdf_pdf_load_widget_field_name(
+                context(),
+                self.annot.inner.as_ptr()
+            ))?
+        };
+        if ptr.is_null() {
+            return Ok(None);
+        }
+        let value = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { fz_free(context(), ptr.cast()) };
+        Ok(Some(value))
+    }
+
+    pub fn field_type_name(&self) -> Result<Option<String>, Error> {
+        self.annot.ensure_attached()?;
+        let ptr = unsafe {
+            ffi_try!(mupdf_pdf_widget_field_type_string(
+                context(),
+                self.annot.inner.as_ptr()
+            ))?
+        };
+        if ptr.is_null() {
+            return Ok(None);
+        }
+        Ok(Some(
+            unsafe { CStr::from_ptr(ptr) }
+                .to_string_lossy()
+                .into_owned(),
+        ))
+    }
+
+    pub fn field_flags(&self) -> Result<FieldFlags, Error> {
+        self.annot.ensure_attached()?;
+        unsafe {
+            ffi_try!(mupdf_pdf_widget_field_flags(
+                context(),
+                self.annot.inner.as_ptr()
+            ))
+        }
+        .map(FieldFlags::from_bits_truncate)
+    }
+
+    pub fn value(&self) -> Result<Option<String>, Error> {
+        self.annot.ensure_attached()?;
+        let ptr = unsafe {
+            ffi_try!(mupdf_pdf_widget_field_value(
+                context(),
+                self.annot.inner.as_ptr()
+            ))?
+        };
+        if ptr.is_null() {
+            return Ok(None);
+        }
+        Ok(Some(
+            unsafe { CStr::from_ptr(ptr) }
+                .to_string_lossy()
+                .into_owned(),
+        ))
+    }
+
+    pub fn label(&self) -> Result<Option<String>, Error> {
+        self.annot.ensure_attached()?;
+        let ptr = unsafe {
+            ffi_try!(mupdf_pdf_widget_field_label(
+                context(),
+                self.annot.inner.as_ptr()
+            ))?
+        };
+        if ptr.is_null() {
+            return Ok(None);
+        }
+        Ok(Some(
+            unsafe { CStr::from_ptr(ptr) }
+                .to_string_lossy()
+                .into_owned(),
+        ))
+    }
+
+    pub fn set_value(
+        &mut self,
+        doc: &mut PdfDocument,
+        value: &str,
+        ignore_trigger_events: bool,
+    ) -> Result<bool, Error> {
+        self.annot.ensure_attached()?;
+        self.assert_document_owner(doc)?;
+        let value = CString::new(value)?;
+        unsafe {
+            ffi_try!(mupdf_pdf_set_widget_field_value(
+                context(),
+                doc.as_raw(),
+                self.annot.inner.as_ptr(),
+                value.as_ptr(),
+                i32::from(ignore_trigger_events)
+            ))
+        }
+        .map(|accepted| accepted != 0)
+    }
+
+    pub fn reset(&mut self, doc: &mut PdfDocument) -> Result<(), Error> {
+        self.annot.ensure_attached()?;
+        self.assert_document_owner(doc)?;
+        unsafe {
+            ffi_try!(mupdf_pdf_reset_widget_field(
+                context(),
+                doc.as_raw(),
+                self.annot.inner.as_ptr()
+            ))
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PdfWidgetIter<'a> {
+    pub(crate) next: Option<NonNull<pdf_annot>>,
+    pub(crate) marker: PhantomData<&'a PdfWidget>,
+}
+
+impl Iterator for PdfWidgetIter<'_> {
+    type Item = PdfWidget;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self.next?;
+        let next = unsafe { pdf_next_widget(context(), current.as_ptr()) };
+        self.next = NonNull::new(next);
+        Some(unsafe { PdfWidget::from_raw_keep_ref(current.as_ptr()) })
+    }
+}


### PR DESCRIPTION
## Summary
- add PDF widget model, field flags, widget iteration, and signature widget helpers
- add read-only widget metadata/value helpers
- add named embedded-file add/list/load/checksum/delete APIs

## Stack
Independent PR based on `main`. The original roadmap commit was adjusted during branch split so this PR does not carry unrelated page composition, image, text, or optional-content commits.

## Validation
- `git log --oneline main..codex/api-parity-widgets-embedded-files`
- `cargo fmt --all --check`
- `cargo test test_pdf_document_named_embedded_files`
- `cargo test test_page_widgets_empty_and_signature_widget`
