### PR TITLE
 Add binding for pdf_annot_obj (allows PdfAnnotation -> PdfObject conversion)

### DIFF
--- a/mupdf-sys/wrapper/pdf_annot.c
+++ b/mupdf-sys/wrapper/pdf_annot.c
@@ -126,6 +126,11 @@ bool mupdf_pdf_apply_redaction(fz_context *ctx, pdf_annot *annot, pdf_redact_opt
     TRY_CATCH(bool, false, pdf_apply_redaction(ctx, annot, opts));
 }
 
+pdf_obj *mupdf_pdf_annot_obj(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
+{
+  TRY_CATCH(pdf_obj *, NULL, pdf_annot_obj(ctx, annot));
+}
+
 const char *mupdf_pdf_annot_author(fz_context *ctx, pdf_annot *annot, mupdf_error_t **errptr)
 {
     TRY_CATCH(const char *, NULL, pdf_annot_author(ctx, annot));

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 
 use mupdf_sys::*;
 
+use crate::pdf::PdfAnnotation;
 use crate::pdf::PdfDocument;
 use crate::{context, Buffer, Error, Matrix};
 
@@ -458,5 +459,14 @@ impl TryFrom<String> for PdfObject {
 
     fn try_from(s: String) -> Result<PdfObject, Self::Error> {
         PdfObject::new_string(&s)
+    }
+}
+
+impl TryFrom<&PdfAnnotation> for PdfObject {
+    type Error = Error;
+
+    fn try_from(annot: &PdfAnnotation) -> Result<PdfObject, Self::Error> {
+        unsafe { ffi_try!(mupdf_pdf_annot_obj(context(), annot.inner.as_ptr())) }
+            .map(|inner| unsafe { PdfObject::from_raw_keep_ref(inner) })
     }
 }


### PR DESCRIPTION
My use case is it lets me access IRT (in reply to) data on an annotation, the binding for which is already exposed for Rust as a method to PdfObject. I had written this up two weeks ago but I think it should not be redundant even with the new changes?