### PR TITLE
Fix several FFI correctness and soundness bugs

### DIFF
--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -47,13 +47,29 @@ impl Bitmap {
     }
 
     pub fn samples(&self) -> &[u8] {
-        let len = (self.width() * self.height()) as usize;
-        unsafe { slice::from_raw_parts((*self.inner).samples, len) }
+        let len = match crate::samples_len(self.stride(), self.height()) {
+            Some(len) => len,
+            None => return &[],
+        };
+        let ptr = unsafe { (*self.inner).samples };
+        if ptr.is_null() {
+            &[]
+        } else {
+            unsafe { slice::from_raw_parts(ptr, len) }
+        }
     }
 
     pub fn samples_mut(&mut self) -> &mut [u8] {
-        let len = (self.width() * self.height()) as usize;
-        unsafe { slice::from_raw_parts_mut((*self.inner).samples, len) }
+        let len = match crate::samples_len(self.stride(), self.height()) {
+            Some(len) => len,
+            None => return &mut [],
+        };
+        let ptr = unsafe { (*self.inner).samples };
+        if ptr.is_null() {
+            &mut []
+        } else {
+            unsafe { slice::from_raw_parts_mut(ptr, len) }
+        }
     }
 }
 
@@ -95,5 +111,20 @@ mod test {
         let mut pixmap = Pixmap::new_with_w_h(&cs, 100, 100, false).expect("Pixmap::new_with_w_h");
         pixmap.clear().unwrap();
         assert!(Bitmap::from_pixmap(&pixmap).is_err());
+    }
+
+    #[test]
+    fn test_bitmap_samples_len_is_stride_times_height() {
+        // Bitmaps pack 1 bit per pixel, row-aligned to 32 bits, so the sample
+        // buffer is `stride * height` bytes -- NOT `width * height`, which would
+        // read ~8x past the allocation (see fz_new_bitmap in MuPDF's bitmap.c).
+        let cs = Colorspace::device_gray();
+        let mut pixmap = Pixmap::new_with_w_h(&cs, 100, 100, false).expect("Pixmap::new_with_w_h");
+        pixmap.clear().unwrap();
+        let mut bitmap = Bitmap::from_pixmap(&pixmap).expect("Bitmap::from_pixmap");
+        assert_eq!(bitmap.n(), 1);
+        let expected = (bitmap.stride() as usize) * (bitmap.height() as usize);
+        assert_eq!(bitmap.samples().len(), expected);
+        assert_eq!(bitmap.samples_mut().len(), expected);
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -144,13 +144,19 @@ impl Context {
         }
     }
 
-    pub fn user_css(&self) -> Option<&str> {
+    /// The user CSS string currently set on the context, if any.
+    ///
+    /// Returns an owned `String` because the underlying C string lives in
+    /// context-owned storage that a sibling `Context` handle can free at any
+    /// time via `set_user_css` (all `Context::get()` handles alias the same
+    /// thread-local `fz_context`). Returning a borrow would be a use-after-free.
+    pub fn user_css(&self) -> Option<String> {
         let css = unsafe { fz_user_css(self.inner) };
         if css.is_null() {
             return None;
         }
         let c_css = unsafe { CStr::from_ptr(css) };
-        c_css.to_str().ok()
+        c_css.to_str().ok().map(str::to_owned)
     }
 
     pub fn set_user_css(&mut self, css: &str) -> Result<(), Error> {
@@ -174,7 +180,14 @@ pub(crate) fn context() -> *mut fz_context {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Mutex;
+
     use super::Context;
+    use mupdf_sys::fz_set_user_css;
+
+    // `user_css` lives in the shared `fz_style_context`, so a `set_user_css` on
+    // any handle is visible process-wide. Serialize the tests that touch it.
+    static USER_CSS_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_context() {
@@ -184,6 +197,24 @@ mod test {
         assert_eq!(ctx.graphics_aa_level(), 8);
         assert_eq!(ctx.graphics_min_line_width(), 0.0);
         assert!(ctx.use_document_css());
+        let _guard = USER_CSS_LOCK.lock().unwrap();
         assert!(ctx.user_css().is_none());
+    }
+
+    /// `user_css()` returns an owned `String` (not a borrow) because a sibling
+    /// `Context::get()` handle can free the underlying C string via
+    /// `set_user_css`. The owned copy must outlive such a call.
+    #[test]
+    fn user_css_owned_survives_set() {
+        let _guard = USER_CSS_LOCK.lock().unwrap();
+        let mut c = Context::get();
+        c.set_user_css("body { color: red; }").unwrap();
+        let owned = c.user_css().unwrap();
+        Context::get()
+            .set_user_css("body { color: blue; }")
+            .unwrap();
+        assert_eq!(owned, "body { color: red; }");
+        // Restore the shared style to its default (no user CSS) for other tests.
+        unsafe { fz_set_user_css(super::context(), std::ptr::null()) };
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -40,8 +40,17 @@ impl<T> Image<T> {
         unsafe { (*self.inner).bpc }
     }
 
-    pub fn color_space(&self) -> Colorspace {
-        unsafe { Colorspace::from_raw((*self.inner).colorspace) }
+    /// The colorspace of the image.
+    ///
+    /// This is `None` for image masks, which have no colorspace (they are 1-bit
+    /// stencils painted with a fill color).
+    pub fn color_space(&self) -> Option<Colorspace> {
+        let ptr = unsafe { (*self.inner).colorspace };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { Colorspace::from_raw(ptr) })
+        }
     }
 
     pub fn resolution(&self) -> (i32, i32) {
@@ -139,5 +148,55 @@ impl<T> Drop for Image<T> {
 impl<T> Clone for Image<T> {
     fn clone(&self) -> Self {
         unsafe { Self::from_raw(fz_keep_image(context(), self.inner)) }
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod test {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use crate::{ColorParams, Colorspace, Device, Document, Image, Matrix, NativeDevice};
+
+    /// An image mask has no colorspace. `Image::color_space()` must report
+    /// `None` for it rather than handing back a `Colorspace` that wraps a NULL
+    /// pointer (any later colorspace query on such a handle would dereference
+    /// NULL). We render a page that paints an image mask through a
+    /// `NativeDevice` and inspect the image delivered to `fill_image_mask`.
+    #[test]
+    fn test_image_mask_color_space_is_none() {
+        struct MaskCapturer {
+            image: Option<Image>,
+        }
+        impl NativeDevice for MaskCapturer {
+            fn fill_image_mask(
+                &mut self,
+                img: &Image,
+                _ctm: Matrix,
+                _cs: &Colorspace,
+                _color: &[f32],
+                _alpha: f32,
+                _cp: ColorParams,
+            ) {
+                self.image = Some(img.clone());
+            }
+        }
+
+        let doc = Document::open("tests/files/image-mask.pdf").expect("open fixture");
+        let page = doc.load_page(0).expect("load page");
+        let state = Rc::new(RefCell::new(MaskCapturer { image: None }));
+        let dev = Device::from_native(state.clone()).expect("build device");
+        page.run(&dev, &Matrix::new(1.0, 0.0, 0.0, 1.0, 0.0, 0.0))
+            .expect("run page");
+
+        let captured = state
+            .borrow_mut()
+            .image
+            .take()
+            .expect("fill_image_mask was not called; fixture did not render a mask");
+        assert!(
+            captured.color_space().is_none(),
+            "image mask must report no colorspace"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,18 @@ pub(crate) fn non_null<T>(ptr: *mut T) -> Result<NonNull<T>, Error> {
     NonNull::new(ptr).ok_or(Error::UnexpectedNullPtr)
 }
 
+/// Byte length of a row-strided sample buffer (`stride * height`), or `None`
+/// when `stride` is negative or the product overflows `usize`.
+///
+/// Shared by `Bitmap::samples`/`samples_mut` and `Pixmap::samples`/`samples_mut`
+/// so the OOB-safe length calculation lives in one place.
+pub(crate) fn samples_len(stride: impl TryInto<usize>, height: u32) -> Option<usize> {
+    stride
+        .try_into()
+        .ok()
+        .and_then(|s| s.checked_mul(height as usize))
+}
+
 /// # Safety
 ///
 /// * `ptr` can be null (this function will simply return an error if that is the case), but if it

--- a/src/page.rs
+++ b/src/page.rs
@@ -423,6 +423,23 @@ pub struct StextPage {
 mod test {
     use crate::{document::test_document, Document, Matrix};
 
+    /// Regression guard: a `Page` stays usable after its `Document` is dropped.
+    ///
+    /// MuPDF keeps the document alive for the page's lifetime — `fz_new_page_of_size`
+    /// does `page->doc = fz_keep_document(ctx, doc)` and `fz_drop_page` releases it
+    /// — so dropping the Rust `Document` wrapper only decrements the refcount.
+    #[test]
+    fn page_survives_document_drop() {
+        let page = {
+            let doc = test_document!("..", "files/dummy.pdf").unwrap();
+            doc.load_page(0).unwrap()
+        };
+        assert!(
+            page.bounds().is_ok(),
+            "page must remain usable after document drop"
+        );
+    }
+
     #[test]
     #[cfg(feature = "serde")]
     fn test_get_stext_page_as_json() {

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -829,7 +829,9 @@ impl PdfDocument {
         if let Some(root) = trailer.get_dict("Root")? {
             if let Some(form) = root.get_dict("AcroForm")? {
                 if let Some(xfa) = form.get_dict("XFA")? {
-                    return xfa.is_null();
+                    // Present and non-null means an XFA form (explicit `XFA: null`
+                    // resolves to MuPDF's null object and correctly reports false).
+                    return Ok(!xfa.is_null()?);
                 }
             }
         }
@@ -1905,7 +1907,7 @@ mod test {
 
     use super::{
         EmbeddedFileOptions, InsertPdfOptions, InsertPosition, OptionalContentRef, PageLabelRule,
-        PageLabelStyle, PageSelection, PdfDocument, PdfWriteOptions, Permission,
+        PageLabelStyle, PageSelection, PdfDocument, PdfObject, PdfWriteOptions, Permission,
     };
 
     #[test]
@@ -1946,6 +1948,33 @@ mod test {
 
         let catalog = doc.catalog().unwrap();
         assert!(!catalog.is_null().unwrap());
+    }
+
+    #[test]
+    fn test_has_xfa_form_detects_present_xfa() {
+        let doc = doc_with_acroform(true);
+        assert!(doc.has_xfa_form().unwrap());
+    }
+
+    #[test]
+    fn test_has_xfa_form_absent_when_acroform_has_no_xfa() {
+        let doc = doc_with_acroform(false);
+        assert!(!doc.has_xfa_form().unwrap());
+    }
+
+    /// Opens dummy.pdf (which has no AcroForm) and installs one by aliasing its
+    /// `Pages` dict as `Root/AcroForm`, optionally with an `XFA` entry.
+    fn doc_with_acroform(add_xfa: bool) -> PdfDocument {
+        let doc = test_document!("../..", "files/dummy.pdf" as PdfDocument).unwrap();
+        let mut catalog = doc.catalog().unwrap();
+        let mut acro_form = catalog.get_dict("Pages").unwrap().unwrap();
+        if add_xfa {
+            acro_form
+                .dict_put("XFA", PdfObject::new_name("xfa").unwrap())
+                .unwrap();
+        }
+        catalog.dict_put("AcroForm", acro_form).unwrap();
+        doc
     }
 
     #[test]

--- a/src/pixmap.rs
+++ b/src/pixmap.rs
@@ -206,10 +206,7 @@ impl Pixmap {
     }
 
     pub fn samples(&self) -> &[u8] {
-        let len = match usize::try_from(self.stride())
-            .ok()
-            .and_then(|stride| stride.checked_mul(self.height() as usize))
-        {
+        let len = match crate::samples_len(self.stride(), self.height()) {
             Some(len) => len,
             None => return &[],
         };
@@ -222,10 +219,7 @@ impl Pixmap {
     }
 
     pub fn samples_mut(&mut self) -> &mut [u8] {
-        let len = match usize::try_from(self.stride())
-            .ok()
-            .and_then(|stride| stride.checked_mul(self.height() as usize))
-        {
+        let len = match crate::samples_len(self.stride(), self.height()) {
             Some(len) => len,
             None => return &mut [],
         };

--- a/tests/files/image-mask.pdf
+++ b/tests/files/image-mask.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+%âãÏÓ
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 72 72] /Contents 5 0 R /Resources << /XObject << /Im0 4 0 R >> >> >>
+endobj
+4 0 obj
+<< /Type /XObject /Subtype /Image /ImageMask true /Width 8 /Height 8 /BitsPerComponent 1 /Length 8 >>
+stream
+ÿÿÿÿÿÿÿÿ
+endstream
+endobj
+5 0 obj
+<< /Length 28 >>
+stream
+q 72 0 0 72 0 0 cm /Im0 Do Q
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000015 00000 n
+0000000064 00000 n
+0000000121 00000 n
+0000000249 00000 n
+0000000392 00000 n
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+470
+%%EOF


### PR DESCRIPTION
Four bugs found via a correctness review, each with a regression test:

- `Bitmap::samples/samples_mut` computed the slice length as width*height (pixels) instead of stride*height (bytes), reading ~8x past the 1-bpp allocation. Now uses the shared OOB-safe `samples_len()` helper (also adopted by `Pixmap::samples/samples_mut`).
- `PdfDocument::has_xfa_form` returned the inverted result: it returned false when an XFA entry was present. Now returns `!xfa.is_null()`.
- `Image::color_space` returned a `Colorspace` wrapping a NULL pointer for image masks (which have no colorspace). Now returns `Option<Colorspace>`, matching `Pixmap::color_space`.
- `Context::user_css` returned a `&str` borrowing a C string that a sibling Context handle can free via `set_user_css` (all handles alias the same thread-local `fz_context`) -- a use-after-free confirmed under ASAN. Now returns an owned `Option<String>`.

Adds an image-mask fixture (tests/files/image-mask.pdf) for the `Image::color_space` test. Adds a Page/Document lifetime guard test (MuPDF keeps the document alive via the page, so there is no UAF).