### PR TITLE
Fix UB in `PdfObject` `as_string`, `as_name`, `as_bytes`

### DIFF
--- a/src/destination.rs
+++ b/src/destination.rs
@@ -395,7 +395,7 @@ impl DestinationKind {
                 .as_float()
         }
 
-        let destination_kind = match kind_name {
+        let destination_kind = match kind_name.as_slice() {
             b"Fit" => DestinationKind::Fit,
             b"FitB" => DestinationKind::FitB,
             b"FitH" => DestinationKind::FitH {

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -1097,7 +1097,7 @@ impl PdfDocument {
         while index + 1 < len {
             let Some(name) = array
                 .get_array(index as i32)?
-                .and_then(|name| name.as_string().ok().map(str::to_owned))
+                .and_then(|name| name.as_string().ok())
             else {
                 index += 2;
                 continue;
@@ -1629,7 +1629,7 @@ impl PdfDocument {
                 reference.xref()
             )));
         }
-        match type_obj.as_name()? {
+        match type_obj.as_name()?.as_slice() {
             b"OCG" | b"OCMD" => Ok(oc_ref),
             _ => Err(Error::InvalidArgument(format!(
                 "optional content xref {} must have /Type /OCG or /OCMD",
@@ -1679,7 +1679,7 @@ impl PdfDocument {
             }
             let name = group
                 .get_dict("Name")?
-                .and_then(|name| name.as_string().ok().map(str::to_owned));
+                .and_then(|name| name.as_string().ok());
             let enabled = !matches!(
                 default_config.as_ref(),
                 Some(config) if Self::optional_content_array_contains(config, "OFF", xref)?

--- a/src/pdf/links/extraction.rs
+++ b/src/pdf/links/extraction.rs
@@ -563,10 +563,10 @@ fn parse_dest_value(dest: &PdfObject, doc: &PdfDocument) -> Result<Option<PdfDes
     if dest.is_array()? && dest.len()? > 0 {
         parse_dest_array(dest, doc).map(Some)
     } else if dest.is_name()? {
-        let name = std::str::from_utf8(dest.as_name()?).map_err(|_| Error::InvalidUtf8)?;
-        Ok(Some(PdfDestination::Named(name.to_owned())))
+        let name = String::from_utf8(dest.as_name()?).map_err(|_| Error::InvalidUtf8)?;
+        Ok(Some(PdfDestination::Named(name)))
     } else if dest.is_string()? {
-        Ok(Some(PdfDestination::Named(dest.as_string()?.to_owned())))
+        Ok(Some(PdfDestination::Named(dest.as_string()?)))
     } else {
         Ok(None)
     }
@@ -695,7 +695,7 @@ fn parse_action_dict(
         return Ok(None);
     };
 
-    match type_obj.as_name()? {
+    match type_obj.as_name()?.as_slice() {
         b"GoTo" => {
             let Some(dest_obj) = action.get_dict("D")? else {
                 return Ok(None);
@@ -707,7 +707,7 @@ fn parse_action_dict(
             let Some(uri_obj) = action.get_dict("URI")? else {
                 return Ok(None);
             };
-            let uri = uri_obj.as_string()?.to_owned();
+            let uri = uri_obj.as_string()?;
             // MuPDF prepends the document URI base for non-external URIs.
             // pdf-link.c:536-543
             if is_external_link(&uri) {
@@ -718,7 +718,7 @@ fn parse_action_dict(
                     .get_dict("Root")?
                     .and_then(|root| root.get_dict("URI").ok().flatten())
                     .and_then(|uri_dict| uri_dict.get_dict("Base").ok().flatten())
-                    .and_then(|base_obj| base_obj.as_string().ok().map(|s| s.to_owned()));
+                    .and_then(|base_obj| base_obj.as_string().ok());
                 let mut full_uri = base.unwrap_or_else(|| "file://".to_owned());
                 full_uri.reserve(uri.len());
                 full_uri.push_str(&uri);
@@ -742,10 +742,10 @@ fn parse_action_dict(
                         PdfDestination::Page { page, kind }
                     } else if dest.is_name()? {
                         let name =
-                            std::str::from_utf8(dest.as_name()?).map_err(|_| Error::InvalidUtf8)?;
-                        PdfDestination::Named(name.to_owned())
+                            String::from_utf8(dest.as_name()?).map_err(|_| Error::InvalidUtf8)?;
+                        PdfDestination::Named(name)
                     } else if dest.is_string()? {
-                        PdfDestination::Named(dest.as_string()?.to_owned())
+                        PdfDestination::Named(dest.as_string()?)
                     } else {
                         PdfDestination::default()
                     }
@@ -766,7 +766,7 @@ fn parse_action_dict(
                 return Ok(None);
             };
             let total = doc.page_count()?;
-            let target = match dest_obj.as_name()? {
+            let target = match dest_obj.as_name()?.as_slice() {
                 b"FirstPage" => Some(0),
                 b"LastPage" => Some((total - 1).max(0)),
                 b"PrevPage" => page_no.map(|p| (p - 1).max(0)),
@@ -818,7 +818,7 @@ fn parse_action_dict(
 /// [`afterward`]: https://github.com/ArtifexSoftware/mupdf/blob/60bf95d09f496ab67a5e4ea872bdd37a74b745fe/source/pdf/pdf-link.c#L304
 fn parse_filespec(obj: &PdfObject) -> Result<FileSpec, Error> {
     if obj.is_string()? {
-        return Ok(FileSpec::Path(obj.as_string()?.to_owned()));
+        return Ok(FileSpec::Path(obj.as_string()?));
     }
 
     if obj.is_dict()? {
@@ -829,14 +829,14 @@ fn parse_filespec(obj: &PdfObject) -> Result<FileSpec, Error> {
                 // `UF`, `Unix`, `DOS`, or `Mac` as URL text, as MuPDF does, since `F` should be
                 // only a 7-bit ASCII URL string, whereas `UF`, for example, is Unicode text.
                 if let Some(f) = obj.get_dict("F")? {
-                    return Ok(FileSpec::Url(f.as_string()?.to_owned()));
+                    return Ok(FileSpec::Url(f.as_string()?));
                 }
             }
         }
 
         if let Some(name) = get_file_name(obj)? {
             if name.is_string()? {
-                return Ok(FileSpec::Path(name.as_string()?.to_owned()));
+                return Ok(FileSpec::Path(name.as_string()?));
             }
         }
     }

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -150,22 +150,24 @@ impl PdfObject {
         unsafe { ffi_try!(mupdf_pdf_to_indirect(context(), self.inner)) }
     }
 
-    pub fn as_name(&self) -> Result<&[u8], Error> {
+    pub fn as_name(&self) -> Result<Vec<u8>, Error> {
         let name_ptr = unsafe { ffi_try!(mupdf_pdf_to_name(context(), self.inner)) }?;
-        let c_name = unsafe { CStr::from_ptr(name_ptr) };
-        Ok(c_name.to_bytes())
+        Ok(unsafe { CStr::from_ptr(name_ptr) }.to_bytes().to_vec())
     }
 
-    pub fn as_string(&self) -> Result<&str, Error> {
+    pub fn as_string(&self) -> Result<String, Error> {
         let str_ptr = unsafe { ffi_try!(mupdf_pdf_to_string(context(), self.inner)) }?;
         let c_str = unsafe { CStr::from_ptr(str_ptr) };
-        c_str.to_str().map_err(|_| Error::InvalidUtf8)
+        c_str
+            .to_str()
+            .map(ToOwned::to_owned)
+            .map_err(|_| Error::InvalidUtf8)
     }
 
-    pub fn as_bytes(&self) -> Result<&[u8], Error> {
+    pub fn as_bytes(&self) -> Result<Vec<u8>, Error> {
         let mut len = 0;
         let ptr = unsafe { ffi_try!(mupdf_pdf_to_bytes(context(), self.inner, &mut len)) }?;
-        Ok(unsafe { slice::from_raw_parts(ptr, len) })
+        Ok(unsafe { slice::from_raw_parts(ptr, len) }.to_vec())
     }
 
     pub fn resolve(&self) -> Result<Option<Self>, Error> {

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -152,11 +152,17 @@ impl PdfObject {
 
     pub fn as_name(&self) -> Result<Vec<u8>, Error> {
         let name_ptr = unsafe { ffi_try!(mupdf_pdf_to_name(context(), self.inner)) }?;
+        if name_ptr.is_null() {
+            return Err(Error::UnexpectedNullPtr);
+        }
         Ok(unsafe { CStr::from_ptr(name_ptr) }.to_bytes().to_vec())
     }
 
     pub fn as_string(&self) -> Result<String, Error> {
         let str_ptr = unsafe { ffi_try!(mupdf_pdf_to_string(context(), self.inner)) }?;
+        if str_ptr.is_null() {
+            return Err(Error::UnexpectedNullPtr);
+        }
         let c_str = unsafe { CStr::from_ptr(str_ptr) };
         c_str
             .to_str()
@@ -167,6 +173,9 @@ impl PdfObject {
     pub fn as_bytes(&self) -> Result<Vec<u8>, Error> {
         let mut len = 0;
         let ptr = unsafe { ffi_try!(mupdf_pdf_to_bytes(context(), self.inner, &mut len)) }?;
+        if ptr.is_null() {
+            return Err(Error::UnexpectedNullPtr);
+        }
         Ok(unsafe { slice::from_raw_parts(ptr, len) }.to_vec())
     }
 

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -680,14 +680,14 @@ impl PdfPage {
             let Some(key) = xobjects.get_dict_key(idx as i32)? else {
                 continue;
             };
-            let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+            let Ok(key_name) = String::from_utf8(key.as_name()?) else {
                 continue;
             };
             let Some(value) = xobjects.get_dict_val(idx as i32)? else {
                 continue;
             };
             if value.is_indirect()? && value.as_indirect()? == xref {
-                return Ok(Some(key_name.to_owned()));
+                return Ok(Some(key_name));
             }
         }
         Ok(None)
@@ -701,7 +701,7 @@ impl PdfPage {
                 let Some(key) = xobjects.get_dict_key(idx as i32)? else {
                     continue;
                 };
-                let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+                let Ok(key_name) = String::from_utf8(key.as_name()?) else {
                     continue;
                 };
                 let Some(index) = key_name
@@ -790,13 +790,13 @@ impl PdfPage {
             let Some(key) = xobjects.get_dict_key(idx as i32)? else {
                 continue;
             };
-            let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+            let Ok(key_name) = String::from_utf8(key.as_name()?) else {
                 continue;
             };
             let Some(value) = xobjects.get_dict_val(idx as i32)? else {
                 continue;
             };
-            if let Some(info) = Self::image_info_from_object(key_name.to_owned(), &value)? {
+            if let Some(info) = Self::image_info_from_object(key_name, &value)? {
                 images.push(info);
             }
         }
@@ -929,7 +929,7 @@ impl PdfPage {
                 let value = xobjects.get_dict_val(idx as i32).ok().flatten()?;
                 if value.is_indirect().ok()? && value.as_indirect().ok()? == xref {
                     let key = xobjects.get_dict_key(idx as i32).ok().flatten()?;
-                    let key = str::from_utf8(key.as_name().ok()?).ok()?.to_owned();
+                    let key = String::from_utf8(key.as_name().ok()?).ok()?;
                     Some(key)
                 } else {
                     None
@@ -1114,7 +1114,7 @@ impl PdfPage {
             let Some(key) = ext_gstates.get_dict_key(idx as i32)? else {
                 continue;
             };
-            let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+            let Ok(key_name) = String::from_utf8(key.as_name()?) else {
                 continue;
             };
             let Some(value) = ext_gstates.get_dict_val(idx as i32)? else {
@@ -1136,7 +1136,7 @@ impl PdfPage {
                 let Some(key) = ext_gstates.get_dict_key(idx as i32)? else {
                     continue;
                 };
-                let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+                let Ok(key_name) = String::from_utf8(key.as_name()?) else {
                     continue;
                 };
                 let Some(index) = key_name
@@ -1184,7 +1184,7 @@ impl PdfPage {
             )));
         }
 
-        match type_obj.as_name()? {
+        match type_obj.as_name()?.as_slice() {
             b"OCG" | b"OCMD" => Ok(()),
             _ => Err(Error::InvalidArgument(format!(
                 "optional content xref {oc_xref} must have /Type /OCG or /OCMD"
@@ -1302,7 +1302,7 @@ impl PdfPage {
             let Some(key) = properties.get_dict_key(idx as i32)? else {
                 continue;
             };
-            let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+            let Ok(key_name) = String::from_utf8(key.as_name()?) else {
                 continue;
             };
             let Some(value) = properties.get_dict_val(idx as i32)? else {
@@ -1326,7 +1326,7 @@ impl PdfPage {
                 let Some(key) = properties.get_dict_key(idx as i32)? else {
                     continue;
                 };
-                let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+                let Ok(key_name) = String::from_utf8(key.as_name()?) else {
                     continue;
                 };
                 let Some(index) = key_name
@@ -1491,7 +1491,7 @@ impl PdfPage {
 
     fn resource_font_base_name(font_obj: &PdfObject) -> Result<Option<String>, Error> {
         if let Some(base_font) = font_obj.get_dict("BaseFont")? {
-            let base_font = str::from_utf8(base_font.as_name()?)
+            let base_font = str::from_utf8(&base_font.as_name()?)
                 .map(Self::normalized_base_font_name)
                 .map(str::to_owned)
                 .ok();
@@ -1510,7 +1510,7 @@ impl PdfPage {
             return Ok(None);
         };
 
-        Ok(str::from_utf8(base_font.as_name()?)
+        Ok(str::from_utf8(&base_font.as_name()?)
             .map(Self::normalized_base_font_name)
             .map(str::to_owned)
             .ok())
@@ -1527,7 +1527,7 @@ impl PdfPage {
             let Ok(encoding_name) = encoding.as_name() else {
                 return Ok(None);
             };
-            let Ok(encoding_name) = str::from_utf8(encoding_name) else {
+            let Ok(encoding_name) = str::from_utf8(&encoding_name) else {
                 return Ok(None);
             };
             return match encoding_name {
@@ -1547,7 +1547,7 @@ impl PdfPage {
             let Ok(name) = item.as_name() else {
                 continue;
             };
-            let Ok(name) = str::from_utf8(name) else {
+            let Ok(name) = str::from_utf8(&name) else {
                 continue;
             };
             if name.contains("cyrillic") || name.starts_with("afii10") {
@@ -1621,7 +1621,7 @@ impl PdfPage {
             let Some(key) = font_dict.get_dict_key(idx as i32)? else {
                 continue;
             };
-            let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+            let Ok(key_name) = String::from_utf8(key.as_name()?) else {
                 continue;
             };
             let Some(value) = font_dict.get_dict_val(idx as i32)? else {
@@ -1671,7 +1671,7 @@ impl PdfPage {
                 let Some(key) = font_dict.get_dict_key(idx as i32)? else {
                     continue;
                 };
-                let Ok(key_name) = str::from_utf8(key.as_name()?) else {
+                let Ok(key_name) = String::from_utf8(key.as_name()?) else {
                     continue;
                 };
                 let Some(index) = key_name

--- a/src/shape/finish.rs
+++ b/src/shape/finish.rs
@@ -337,7 +337,7 @@ mod tests {
         (0..properties.dict_len().unwrap())
             .map(|index| {
                 let key = properties.get_dict_key(index as i32).unwrap().unwrap();
-                let key = str::from_utf8(key.as_name().unwrap()).unwrap().to_owned();
+                let key = String::from_utf8(key.as_name().unwrap()).unwrap();
                 let value = properties.get_dict_val(index as i32).unwrap().unwrap();
                 (key, value)
             })
@@ -349,7 +349,7 @@ mod tests {
         (0..ext_gstates.dict_len().unwrap())
             .map(|index| {
                 let key = ext_gstates.get_dict_key(index as i32).unwrap().unwrap();
-                let key = str::from_utf8(key.as_name().unwrap()).unwrap().to_owned();
+                let key = String::from_utf8(key.as_name().unwrap()).unwrap();
                 let value = ext_gstates.get_dict_val(index as i32).unwrap().unwrap();
                 (key, value)
             })

--- a/tests/test_issues.rs
+++ b/tests/test_issues.rs
@@ -1,4 +1,4 @@
-use mupdf::pdf::PdfDocument;
+use mupdf::pdf::{PdfDocument, PdfObject};
 use mupdf::{Error, TextPageFlags};
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -119,4 +119,65 @@ fn test_issue_no_json() {
     let text_page = page.to_text_page(TextPageFlags::empty()).unwrap();
     let json = text_page.to_json(1.0);
     assert!(json.is_err());
+}
+
+// Regression tests for issue #207: `as_string`/`as_name`/`as_bytes` returned
+// references into MuPDF's resolved (xref-backed) object, which `delete_object`
+// can free. The returned values must therefore be *owned* copies that survive
+// deletion of the backing object.
+//
+// Written with `.as_bytes()`/`.as_slice()` so they compile against both the old
+// borrowed API and the new owned API.
+
+#[test]
+fn test_as_string_indirect_delete() {
+    let mut pdf = PdfDocument::new();
+    let original = "A".repeat(1000);
+
+    let string_obj = PdfObject::new_string(&original).unwrap();
+    let indirect = pdf.add_object(&string_obj).unwrap();
+    let obj_num = indirect.as_indirect().unwrap();
+    let s = indirect.as_string().unwrap();
+    drop(string_obj);
+    pdf.delete_object(obj_num).unwrap();
+    // Reclaim the freed buffer so a dangling read observes garbage, not the
+    // original bytes (makes the unsoundness surface deterministically).
+    for _ in 0..32 {
+        let _ = PdfObject::new_string(&"B".repeat(1000));
+    }
+    assert_eq!(s.as_bytes(), original.as_bytes());
+}
+
+#[test]
+fn test_as_name_indirect_delete() {
+    let mut pdf = PdfDocument::new();
+    let original = "A".repeat(100);
+
+    let name_obj = PdfObject::new_name(&original).unwrap();
+    let indirect = pdf.add_object(&name_obj).unwrap();
+    let obj_num = indirect.as_indirect().unwrap();
+    let name = indirect.as_name().unwrap();
+    drop(name_obj);
+    pdf.delete_object(obj_num).unwrap();
+    for _ in 0..32 {
+        let _ = PdfObject::new_name(&"B".repeat(100));
+    }
+    assert_eq!(&name[..], original.as_bytes());
+}
+
+#[test]
+fn test_as_bytes_owned_indirect_delete() {
+    let mut pdf = PdfDocument::new();
+    let original = "A".repeat(1000);
+
+    let string_obj = PdfObject::new_string(&original).unwrap();
+    let indirect = pdf.add_object(&string_obj).unwrap();
+    let obj_num = indirect.as_indirect().unwrap();
+    let bytes = indirect.as_bytes().unwrap();
+    drop(string_obj);
+    pdf.delete_object(obj_num).unwrap();
+    for _ in 0..32 {
+        let _ = PdfObject::new_string(&"B".repeat(1000));
+    }
+    assert_eq!(&bytes[..], original.as_bytes());
 }


### PR DESCRIPTION
These accessors returned borrows (`&str` / `&[u8]`) tied to `&self`, but MuPDF resolves indirect references first and returns a pointer into the document's shared xref entry, not into `self`. Freeing that entry via `delete_object` then leaves the reference dangling, and since indirect objects alias the xref the borrow checker cannot prevent it.

Return owned data instead: `as_string() -> String`, `as_name() ->
Vec<u8>`, `as_bytes() -> Vec<u8>`. The returned copies outlive any mutation of the document, closing the soundness hole unconditionally with no new types, crates, or error variants.

Closes #207.