### PR TITLE
Add `array_iter` / `dict_iter` to `PdfObject`

### DIFF
--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -28,7 +28,7 @@ pub use intent::Intent;
 pub use links::{
     DestPageResolver, FileSpec, LinkAction, PdfAction, PdfDestination, PdfLink, PdfLinkAnnot,
 };
-pub use object::PdfObject;
+pub use object::{PdfArrayIter, PdfDictIter, PdfObject};
 pub use page::{
     ExtractedImage, FontInfo, ImagePlacement, InsertFontOptions, InsertImageOptions, PageImageInfo,
     PageImageSource, PdfPage,

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -373,6 +373,58 @@ impl PdfObject {
         unsafe { ffi_try!(mupdf_pdf_dict_delete(context(), self.inner, key_obj.inner)) }
     }
 
+    /// Returns an iterator over the elements of this array.
+    ///
+    /// Each yielded [`PdfObject`] is independently reference-counted, so it stays
+    /// valid even after the source object is dropped. The items are `Result`s so
+    /// errors surface per-element rather than aborting the whole iteration.
+    ///
+    /// This is the ergonomic replacement for looping with
+    /// [`get_array`](Self::get_array):
+    ///
+    /// ```text
+    /// for item in arr.array_iter()? {
+    ///     let item = item?;
+    ///     // ...
+    /// }
+    /// ```
+    ///
+    /// Returns an error if `self` is not an array.
+    pub fn array_iter(&self) -> Result<PdfArrayIter<'_>, Error> {
+        if !self.is_array()? {
+            return Err(Error::InvalidArgument(
+                "PdfObject is not an array".to_string(),
+            ));
+        }
+        Ok(PdfArrayIter {
+            obj: self,
+            index: 0,
+            len: i32::try_from(self.len()?)?,
+        })
+    }
+
+    /// Returns an iterator over the `(key, value)` pairs of this dictionary.
+    ///
+    /// Both halves of each pair are independently reference-counted [`PdfObject`]s
+    /// that stay valid after the source object is dropped. Keys are PDF name
+    /// objects; read them with [`as_name`](Self::as_name).
+    ///
+    /// This is the ergonomic replacement for looping with
+    /// [`get_dict_key`](Self::get_dict_key) and [`get_dict_val`](Self::get_dict_val).
+    /// Returns an error if `self` is not a dictionary.
+    pub fn dict_iter(&self) -> Result<PdfDictIter<'_>, Error> {
+        if !self.is_dict()? {
+            return Err(Error::InvalidArgument(
+                "PdfObject is not a dictionary".to_string(),
+            ));
+        }
+        Ok(PdfDictIter {
+            obj: self,
+            index: 0,
+            len: i32::try_from(self.dict_len()?)?,
+        })
+    }
+
     fn print(&self, tight: bool, ascii: bool) -> Result<String, Error> {
         let ptr =
             unsafe { ffi_try!(mupdf_pdf_obj_to_string(context(), self.inner, tight, ascii)) }?;
@@ -394,6 +446,95 @@ impl PdfObject {
 
     pub fn page_ctm(&self) -> Result<Matrix, Error> {
         unsafe { ffi_try!(mupdf_pdf_page_obj_transform(context(), self.inner)) }.map(Into::into)
+    }
+}
+
+/// Iterator over the elements of a PDF array.
+///
+/// Created by [`PdfObject::array_iter`]. Each item is a `Result<PdfObject, Error>`;
+/// unwrap it with `?` inside the loop body.
+#[derive(Debug)]
+pub struct PdfArrayIter<'a> {
+    obj: &'a PdfObject,
+    index: i32,
+    len: i32,
+}
+
+impl Iterator for PdfArrayIter<'_> {
+    type Item = Result<PdfObject, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+        let idx = self.index;
+        self.index += 1;
+        match self.obj.get_array(idx) {
+            Ok(Some(obj)) => Some(Ok(obj)),
+            // Within bounds an element always exists. A null return means the
+            // underlying object changed (e.g. mutated through another handle)
+            // since we measured its length; surface that as an error rather than
+            // silently truncating iteration and breaking ExactSizeIterator.
+            Ok(None) => Some(Err(Error::UnexpectedNullPtr)),
+            Err(err) => Some(Err(err)),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = (self.len - self.index) as usize;
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for PdfArrayIter<'_> {
+    fn len(&self) -> usize {
+        (self.len - self.index) as usize
+    }
+}
+
+/// Iterator over the `(key, value)` pairs of a PDF dictionary.
+///
+/// Created by [`PdfObject::dict_iter`].
+#[derive(Debug)]
+pub struct PdfDictIter<'a> {
+    obj: &'a PdfObject,
+    index: i32,
+    len: i32,
+}
+
+impl Iterator for PdfDictIter<'_> {
+    type Item = Result<(PdfObject, PdfObject), Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+        let idx = self.index;
+        self.index += 1;
+        let key = match self.obj.get_dict_key(idx) {
+            Ok(Some(key)) => key,
+            // A null return within bounds means the dict changed under us; treat
+            // it as an error instead of silently ending iteration.
+            Ok(None) => return Some(Err(Error::UnexpectedNullPtr)),
+            Err(err) => return Some(Err(err)),
+        };
+        let val = match self.obj.get_dict_val(idx) {
+            Ok(Some(val)) => val,
+            Ok(None) => return Some(Err(Error::UnexpectedNullPtr)),
+            Err(err) => return Some(Err(err)),
+        };
+        Some(Ok((key, val)))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = (self.len - self.index) as usize;
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for PdfDictIter<'_> {
+    fn len(&self) -> usize {
+        (self.len - self.index) as usize
     }
 }
 

--- a/tests/test_pdf_object.rs
+++ b/tests/test_pdf_object.rs
@@ -1,0 +1,151 @@
+use mupdf::pdf::{PdfDocument, PdfObject};
+use mupdf::Error;
+
+/// Open the shared test fixture for building array/dict objects bound to a document.
+fn open() -> PdfDocument {
+    PdfDocument::from_bytes(include_bytes!("files/dummy.pdf")).unwrap()
+}
+
+#[test]
+fn array_iter_yields_pushed_values_in_order() -> Result<(), Error> {
+    let doc = open();
+    let mut arr = doc.new_array()?;
+    arr.array_push(PdfObject::new_int(1)?)?;
+    arr.array_push(PdfObject::new_int(2)?)?;
+    arr.array_push(PdfObject::new_int(3)?)?;
+
+    let collected: Vec<i32> = arr
+        .array_iter()?
+        .map(|item| item?.as_int())
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(collected, vec![1, 2, 3]);
+
+    // ExactSizeIterator reports the remaining length.
+    assert_eq!(arr.array_iter()?.len(), 3);
+    Ok(())
+}
+
+#[test]
+fn array_iter_empty() -> Result<(), Error> {
+    let doc = open();
+    let arr = doc.new_array()?;
+    assert_eq!(arr.array_iter()?.count(), 0);
+    assert_eq!(arr.array_iter()?.len(), 0);
+    Ok(())
+}
+
+/// Soundness: the wrapper keeps a reference on every get, so iterated elements
+/// must stay valid even after the source array is dropped.
+#[test]
+fn array_iter_values_outlive_source() -> Result<(), Error> {
+    let doc = open();
+    let values: Vec<PdfObject> = {
+        let mut arr = doc.new_array()?;
+        arr.array_push(PdfObject::new_int(1)?)?;
+        arr.array_push(PdfObject::new_string("hi")?)?;
+        arr.array_push(PdfObject::new_int(3)?)?;
+        arr.array_iter()?.collect::<Result<Vec<_>, _>>()?
+        // `arr` dropped here: releases only its own reference.
+    };
+    assert_eq!(values.len(), 3);
+    assert_eq!(values[0].as_int()?, 1);
+    assert_eq!(values[1].as_string()?, "hi");
+    assert_eq!(values[2].as_int()?, 3);
+    Ok(())
+}
+
+/// Owned elements can themselves be iterated, forming borrow chains safely.
+#[test]
+fn array_iter_nested() -> Result<(), Error> {
+    let doc = open();
+    let mut inner_a = doc.new_array()?;
+    inner_a.array_push(PdfObject::new_int(7)?)?;
+    inner_a.array_push(PdfObject::new_int(8)?)?;
+    let mut inner_b = doc.new_array()?;
+    inner_b.array_push(PdfObject::new_int(9)?)?;
+
+    let mut outer = doc.new_array()?;
+    outer.array_push(inner_a)?;
+    outer.array_push(inner_b)?;
+
+    let collected: Vec<Vec<i32>> = outer
+        .array_iter()?
+        .map(|item| {
+            let item = item?;
+            item.array_iter()?
+                .map(|i| i?.as_int())
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(collected, vec![vec![7, 8], vec![9]]);
+    Ok(())
+}
+
+/// Iterating a non-array must fail loudly rather than silently yield nothing.
+#[test]
+fn array_iter_rejects_non_array() -> Result<(), Error> {
+    let doc = open();
+    let dict = doc.new_dict()?;
+    assert!(matches!(dict.array_iter(), Err(Error::InvalidArgument(_))));
+    Ok(())
+}
+
+#[test]
+fn dict_iter_rejects_non_dict() -> Result<(), Error> {
+    let doc = open();
+    let arr = doc.new_array()?;
+    assert!(matches!(arr.dict_iter(), Err(Error::InvalidArgument(_))));
+    Ok(())
+}
+
+#[test]
+fn dict_iter_yields_inserted_pairs() -> Result<(), Error> {
+    let doc = open();
+    let mut dict = doc.new_dict()?;
+    dict.dict_put("Type", PdfObject::new_name("Catalog")?)?;
+    dict.dict_put("Count", PdfObject::new_int(42)?)?;
+
+    let mut count: Option<i32> = None;
+    let mut type_name: Option<Vec<u8>> = None;
+    for pair in dict.dict_iter()? {
+        let (key, val) = pair?;
+        let key = key.as_name()?;
+        if &key[..] == b"Type" {
+            type_name = Some(val.as_name()?);
+        } else if &key[..] == b"Count" {
+            count = Some(val.as_int()?);
+        }
+    }
+    assert_eq!(count, Some(42));
+    assert_eq!(type_name, Some(b"Catalog".to_vec()));
+    assert_eq!(dict.dict_iter()?.len(), 2);
+    Ok(())
+}
+
+#[test]
+fn dict_iter_empty() -> Result<(), Error> {
+    let doc = open();
+    let dict = doc.new_dict()?;
+    assert_eq!(dict.dict_iter()?.count(), 0);
+    assert_eq!(dict.dict_iter()?.len(), 0);
+    Ok(())
+}
+
+/// Soundness: keys and values stay valid after the source dict is dropped.
+#[test]
+fn dict_iter_pairs_outlive_source() -> Result<(), Error> {
+    let doc = open();
+    let pairs: Vec<(PdfObject, PdfObject)> = {
+        let mut dict = doc.new_dict()?;
+        dict.dict_put("A", PdfObject::new_int(1)?)?;
+        dict.dict_put("B", PdfObject::new_int(2)?)?;
+        dict.dict_iter()?.collect::<Result<Vec<_>, _>>()?
+    };
+    assert_eq!(pairs.len(), 2);
+    let mut sum = 0;
+    for (_, val) in pairs {
+        sum += val.as_int()?;
+    }
+    assert_eq!(sum, 3);
+    Ok(())
+}


### PR DESCRIPTION
Add ergonomic, non-breaking iterators over PDF arrays and dictionaries, delivering the narrower request behind #2 (the full enum refactor was closed as not planned since it conflicts with MuPDF's type-erased indirect-object model).

- `PdfObject::array_iter()` yields owned array elements.
- `PdfObject::dict_iter()` yields owned `(key, value)` pairs.
- Both implement `Iterator` (`Item = Result<..>`) and `ExactSizeIterator`, and error on a non-array / non-dict instead of silently yielding nothing.

Iterated objects are independently reference-counted (the FFI getters call `pdf_keep_obj`), so they stay valid after the source object is dropped.