### PR TITLE
mupdf-sys: cross-language ThinLTO on Windows (linker-plugin-lto) + default WPO off

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,9 @@ docx-output = ["mupdf-sys/docx-output"]
 tesseract = ["mupdf-sys/tesseract"]
 zxingcpp = ["mupdf-sys/zxingcpp"]
 libarchive = ["mupdf-sys/libarchive"]
+# Cross-language ThinLTO across the Rust<->C boundary (ClangCL only). See the
+# mupdf-sys feature of the same name for the toolset + consumer RUSTFLAGS it requires.
+linker-plugin-lto = ["mupdf-sys/linker-plugin-lto"]
 
 # Derive Serialize/Deserialize for a few structs
 serde = ["dep:serde"]

--- a/mupdf-sys/Cargo.toml
+++ b/mupdf-sys/Cargo.toml
@@ -235,6 +235,14 @@ docx-output = []
 tesseract = []
 zxingcpp = []
 libarchive = []
+# Compile the vendored MuPDF C/C++ as LLVM ThinLTO bitcode so the final
+# (clang-cl + lld) rustc link can inline and optimize across the Rust<->C
+# boundary -- the one whole-program win MSVC `/GL` cannot deliver (its MSIL never
+# crosses into Rust). Off by default. Requires the ClangCL toolset and a
+# clang/LLVM whose major version matches rustc's bundled LLVM; the consuming
+# binary must also build with
+# `-Clinker-plugin-lto -Clinker=clang-cl -Clink-arg=-fuse-ld=lld`.
+linker-plugin-lto = []
 
 zerocopy = ["dep:zerocopy"]
 

--- a/mupdf-sys/build.rs
+++ b/mupdf-sys/build.rs
@@ -63,7 +63,7 @@ fn run() -> Result<()> {
         patch_mupdf_sources(build_dir.as_ref())?;
 
         Build::new(&target).run(&target, build_dir)?;
-        build_wrapper().map_err(|e| format!("Unable to compile mupdf wrapper:\n  {e}"))?;
+        build_wrapper(&target).map_err(|e| format!("Unable to compile mupdf wrapper:\n  {e}"))?;
     }
 
     generate_bindings(&target, &out_dir.join("bindings.rs"), sysroot)
@@ -209,8 +209,15 @@ fn patch_mupdf_sources(build_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn build_wrapper() -> Result<()> {
+fn build_wrapper(target: &Target) -> Result<()> {
     let mut build = cc::Build::new();
+    // For cross-language LTO the wrapper TUs -- which rustc links directly, not via
+    // libmupdf -- must also be clang-cl ThinLTO bitcode so they participate in the
+    // whole-program link. Scope to the MSVC/ClangCL path (the only one msbuild.rs
+    // gates the feature on); other targets use their own LTO mechanism.
+    if cfg!(feature = "linker-plugin-lto") && target.env == "msvc" {
+        build.compiler("clang-cl").flag("/clang:-flto=thin");
+    }
     for entry in fs::read_dir("wrapper")? {
         let entry = entry?;
         let path = entry.path();

--- a/mupdf-sys/msbuild.rs
+++ b/mupdf-sys/msbuild.rs
@@ -159,8 +159,6 @@ impl Msbuild {
     }
 
     pub fn build(mut self, target: &Target, build_dir: &str) -> Result<()> {
-        self.cl.push("/MP".to_owned());
-
         self.patch_nan(build_dir)?;
         self.remove_libresources_fonts(build_dir)?;
 
@@ -183,6 +181,25 @@ impl Msbuild {
         // doesn't set) so plain MSVC (v142/v143) builds are untouched.
         if clang_cl {
             self.cl.push("/clang:-msse4.1".to_owned());
+        }
+
+        // Cross-language LTO: emit libmupdf's TUs as LLVM ThinLTO bitcode so the
+        // consuming rustc link (built with `-Clinker-plugin-lto`, clang-cl + lld)
+        // can inline and optimize across the Rust<->C boundary. MSVC `/GL` can't do
+        // this -- its MSIL is not LLVM bitcode and never crosses into Rust -- so
+        // this is ClangCL-only; error out under any MSVC toolset. `/clang:` forwards
+        // to the clang driver (same mechanism as the SSE4.1 flag above). `/GL`/WPO
+        // must stay off (it is, by default) -- the two whole-program models are
+        // mutually exclusive.
+        if cfg!(feature = "linker-plugin-lto") {
+            if !clang_cl {
+                Err(
+                    "the `linker-plugin-lto` feature requires the ClangCL toolset \
+                     (MSVC `/GL` is not LLVM bitcode); set \
+                     MUPDF_MSVC_PLATFORM_TOOLSET=ClangCL",
+                )?;
+            }
+            self.cl.push("/clang:-flto=thin".to_owned());
         }
 
         // The MSBuild project graph hard-codes every optional dependency ON; strip
@@ -208,14 +225,35 @@ impl Msbuild {
         let Some(mut msbuild) = windows_registry::find(&target.arch, "msbuild.exe") else {
             Err("Could not find msbuild.exe. Do you have it installed?")?
         };
+        let mut args = vec![
+            r"platform\win32\mupdf.sln".to_owned(),
+            "/target:libmupdf".to_owned(),
+            format!("/p:Configuration={configuration}"),
+            format!("/p:Platform={platform}"),
+            format!("/p:PlatformToolset={platform_toolset}"),
+        ];
+        // MuPDF's Release config sets `<WholeProgramOptimization>true</…>` (`/GL`),
+        // which is the wrong default for libmupdf *as built here*: it's a static lib
+        // produced solely to be linked by an external (rustc) link. `/GL` defers code
+        // generation to that final link, so the .lib ships version-locked MSIL objects
+        // rather than finished code. Consequences for the consumer:
+        //   - the final rustc link (which doesn't pass `/LTCG`) makes link.exe detect
+        //     the `/GL` modules and *restart* with `/LTCG`, re-running whole-program
+        //     codegen of all of libmupdf on every relink (slow; on some toolsets it
+        //     ICEs, e.g. freetype t1load.c C1001 / link.exe 0xc0000005);
+        //   - `lld-link` (an increasingly common Rust linker) can't consume `/GL`
+        //     objects at all → hard link failure;
+        //   - MS itself advises against shipping `.lib` files made of `/GL` objects.
+        // The `/GL`→Rust link can't optimize across the Rust↔C boundary anyway, so the
+        // only thing lost is cross-TU optimization *within* MuPDF — a real but bounded
+        // runtime win. Default it off; let perf-sensitive users opt back in. A global
+        // `/p:` overrides the per-config project setting. (ClangCL builds don't emit
+        // MSIL for `/GL`, so they're unaffected either way.)
+        if env::var_os("MUPDF_MSVC_WHOLE_PROGRAM_OPT").is_none() {
+            args.push("/p:WholeProgramOptimization=false".to_owned());
+        }
         let status = msbuild
-            .args([
-                r"platform\win32\mupdf.sln",
-                "/target:libmupdf",
-                &format!("/p:Configuration={configuration}"),
-                &format!("/p:Platform={platform}"),
-                &format!("/p:PlatformToolset={platform_toolset}"),
-            ])
+            .args(&args)
             .current_dir(build_dir)
             .env("CL", self.cl.join(" "))
             .status()
@@ -243,6 +281,11 @@ impl Msbuild {
 
         println!("cargo:rustc-link-lib=dylib=libmupdf");
         println!("cargo:rustc-link-lib=dylib=libthirdparty");
+        // NB: no separate libtesseract/libleptonica directives are needed even with
+        // the `tesseract` feature — MSVC "Link Library Dependencies" merges the
+        // ProjectReference'd static libs into libmupdf.lib (it carries the
+        // libtesseract/libleptonica objects directly), so libmupdf alone resolves
+        // all OCR symbols. Verified 2026-06-27 via dumpbin /ARCHIVEMEMBERS.
 
         Ok(())
     }


### PR DESCRIPTION
Three related MSBuild-path changes that make the libmupdf static lib a better citizen for the external rustc/lld link it's built for, and add opt-in cross-language LTO.

### 1. Default `WholeProgramOptimization` (`/GL`) off (opt back in: `MUPDF_MSVC_WHOLE_PROGRAM_OPT`)

MuPDF's `Release` config ships `/GL`, which is wrong for a static lib consumed by an external `rustc` link — `/GL` emits version-locked MSIL, not finished code, so:

- the `rustc` link (no `/LTCG`) restarts `link.exe` with `/LTCG` and re-runs whole-program codegen of all of libmupdf on **every** relink (slow; ICEs on some toolsets);
- **`lld-link` cannot consume `/GL` objects at all** → hard link failure;
- MS advises against shipping `/GL` `.lib` files.

`/GL` can't optimize across the Rust↔C boundary anyway, so the only loss is cross-TU opt *within* MuPDF. Passed as a global `/p:WholeProgramOptimization=false` (overrides the per-config setting). Framing: **perf / lld-link support**, not a crash fix.

### 2. New `linker-plugin-lto` feature (off by default, ClangCL only)

Compiles the vendored MuPDF C/C++ and the mupdf-sys wrapper TUs as LLVM ThinLTO bitcode (`/clang:-flto=thin`), so a consumer built with `-Clinker-plugin-lto` optimizes **across the Rust↔C boundary** — which MSVC `/GL` cannot (its MSIL never crosses into Rust). ClangCL-only: under MSVC the feature errors out (`/GL` ≠ bitcode). `/clang:-flto=thin` mirrors PR-1's `/clang:-msse4.1`; `build_wrapper()` also builds the wrapper TUs (linked directly by rustc) as bitcode so they join the link. WPO stays off.

### 3. `/MP` removed

`/MP` is a `cl.exe`-only flag that spawns child compiler processes; `clang-cl` does not support it and errors when it appears in the `CL` env var. Removed unconditionally since PR #247 put ClangCL on this path. MSBuild's own `/maxcpucount` still parallelises at the project level — compile wall-time is unchanged in practice.

### Consumer side (not settable by a `-sys` crate — documented for users)

```
RUSTFLAGS="-Clinker-plugin-lto -Clinker=lld-link -Clink-arg=/opt:lldltojobs=1" \
  cargo build --release --features mupdf/linker-plugin-lto \
  --target x86_64-pc-windows-msvc
```

- `--target` so RUSTFLAGS hit only the target, not host proc-macros (dylibs / `-C prefer-dynamic`, which `-Clinker-plugin-lto` rejects).
- **Link with `lld-link` directly, not the `clang-cl` driver** — rustc emits MSVC link flags (`/NOLOGO`, `/defaultlib`, `/NATVIS`) the clang-cl driver mistakes for inputs; `lld-link` groks them and has ThinLTO built in.
- **Serial ThinLTO (`/opt:lldltojobs=1`).** Parallel ThinLTO is unstable on MuPDF-scale IR under O2 — non-deterministic `0xC0000005` (codegen, or debug-metadata) link crashes, persisting across debug/non-debug and reduced job counts; consistent with backend instability under parallel optimization of large, SCC-heavy IR (small worker-thread stacks). Serial restores deterministic linking with **no change to opt level or codegen** (`lldlto=2` either way) — cost is link wall-time only. `/STACK` does not affect it (sets the output PE stack, not lld's worker stacks).

A clang/LLVM whose major matches rustc's bundled LLVM must be on `PATH`.

### Testing

MuPDF 1.27.2 (`v0.8.0`'s vendored core), MSVC + ClangCL:

- `default-features = false`: builds/links/runs unchanged (WPO-off is transparent).
- `--features linker-plugin-lto` (ClangCL): links + runs, with real cross-language LTO: MuPDF objects in `libmupdf.lib` are bitcode (`42 43 C0 DE`) as are rustc's → one LTO partition; `lld-link` ran cross-module `ipsccp`/const-hoisting over the merged module; `-pass-remarks=inline` shows C wrappers inlined into Rust (`mupdf_drop_error` → `mupdf::error`); `-print-imports` shows 34 core `fz_*` (incl. `fz_open_document`, the `fz_do_try` machinery) imported into the Rust module — depth beyond wrappers.
- `--features tesseract` under ClangCL remains unsupported (pre-existing; unchanged).