### PR TITLE
Add zero-copy Buffer::from_shared_bytes and Document::from_shared_bytes

### DIFF
--- a/mupdf-sys/wrapper/buffer.c
+++ b/mupdf-sys/wrapper/buffer.c
@@ -43,6 +43,11 @@ fz_buffer *mupdf_buffer_from_copied_bytes(fz_context *ctx, const unsigned char *
     TRY_CATCH(fz_buffer*, NULL, fz_new_buffer_from_copied_data(ctx, data, len));
 }
 
+fz_buffer *mupdf_buffer_from_shared_bytes(fz_context *ctx, const unsigned char *data, size_t len, mupdf_error_t **errptr)
+{
+    TRY_CATCH(fz_buffer*, NULL, fz_new_buffer_from_shared_data(ctx, data, len));
+}
+
 fz_buffer *mupdf_buffer_from_str(fz_context *ctx, const char *s, mupdf_error_t **errptr)
 {
     TRY_CATCH(fz_buffer*, NULL, fz_new_buffer_from_copied_data(ctx, (const unsigned char *)s, strlen(s)));

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -60,6 +60,31 @@ impl Buffer {
         .map(|inner| Self { inner, offset: 0 })
     }
 
+    /// Creates a buffer backed directly by `bytes`, without copying them.
+    ///
+    /// [`from_bytes`](Self::from_bytes) copies the whole slice into a new
+    /// allocation; this variant makes the returned buffer borrow the caller's
+    /// data instead, which matters when opening large documents from several
+    /// threads at once.
+    ///
+    /// # Safety
+    ///
+    /// `bytes` must outlive the returned buffer and everything that keeps a
+    /// reference to it (for instance a [`Document`](crate::Document) opened
+    /// from it, and anything derived from that document), and must not be
+    /// mutated while any of them is alive.
+    pub unsafe fn from_shared_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        // SAFETY: upheld by the caller; the shared fz_buffer never frees `bytes`.
+        unsafe {
+            ffi_try!(mupdf_buffer_from_shared_bytes(
+                context(),
+                bytes.as_ptr(),
+                bytes.len()
+            ))
+        }
+        .map(|inner| Self { inner, offset: 0 })
+    }
+
     pub fn with_capacity(cap: usize) -> Result<Self, Error> {
         unsafe { ffi_try!(mupdf_new_buffer(context(), cap)) }.map(|inner| Self { inner, offset: 0 })
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -85,6 +85,14 @@ impl Buffer {
         .map(|inner| Self { inner, offset: 0 })
     }
 
+    /// Safe variant of [`from_shared_bytes`](Self::from_shared_bytes) for
+    /// `'static` data (e.g. `include_bytes!`): the bytes are guaranteed to
+    /// outlive the buffer and shared references are never mutated.
+    pub fn from_static_bytes(bytes: &'static [u8]) -> Result<Self, Error> {
+        // SAFETY: `bytes` lives forever and cannot be mutated behind `&'static`.
+        unsafe { Self::from_shared_bytes(bytes) }
+    }
+
     pub fn with_capacity(cap: usize) -> Result<Self, Error> {
         unsafe { ffi_try!(mupdf_new_buffer(context(), cap)) }.map(|inner| Self { inner, offset: 0 })
     }

--- a/src/document.rs
+++ b/src/document.rs
@@ -82,6 +82,35 @@ impl Document {
         .map(|inner| Self { inner })
     }
 
+    /// Opens a document backed directly by `bytes`, without copying them.
+    ///
+    /// [`from_bytes`](Self::from_bytes) copies the whole input into a new
+    /// `fz_buffer`, so every open of a large document costs its full size in
+    /// memory again (e.g. one `Document` per thread on a multi-hundred-MB
+    /// scanned PDF). This variant opens the document on a borrowed view of
+    /// the caller's data instead.
+    ///
+    /// # Safety
+    ///
+    /// `bytes` must outlive the returned `Document` and everything derived
+    /// from it (pages, pixmaps being rendered, ...), and must not be mutated
+    /// while any of them is alive.
+    pub unsafe fn from_shared_bytes(bytes: &[u8], magic: &str) -> Result<Self, Error> {
+        let c_magic = CString::new(magic)?;
+        // SAFETY: upheld by the caller. The document's stream takes its own
+        // reference on the shared fz_buffer, so dropping `buf` here is fine.
+        let buf = unsafe { Buffer::from_shared_bytes(bytes)? };
+        // SAFETY: `buf.inner` is a valid fz_buffer and `c_magic` a valid C string.
+        unsafe {
+            ffi_try!(mupdf_open_document_from_bytes(
+                context(),
+                buf.inner,
+                c_magic.as_ptr()
+            ))
+        }
+        .map(|inner| Self { inner })
+    }
+
     pub fn recognize(magic: &str) -> Result<bool, Error> {
         let c_magic = CString::new(magic)?;
         unsafe { ffi_try!(mupdf_recognize_document(context(), c_magic.as_ptr())) }
@@ -388,6 +417,21 @@ mod test {
 
         let cs = doc.output_intent().unwrap();
         assert!(cs.is_none());
+    }
+
+    #[test]
+    fn test_document_from_shared_bytes() {
+        let bytes = include_bytes!("../tests/files/dummy.pdf");
+        // SAFETY: `bytes` is 'static and never mutated.
+        let doc = unsafe { Document::from_shared_bytes(bytes, "pdf") }.unwrap();
+        assert!(doc.is_pdf());
+        assert_eq!(doc.page_count().unwrap(), 1);
+
+        // Same rendering-relevant behaviour as the copying constructor.
+        let copied = Document::from_bytes(bytes, "pdf").unwrap();
+        let bounds = doc.load_page(0).unwrap().bounds().unwrap();
+        let copied_bounds = copied.load_page(0).unwrap().bounds().unwrap();
+        assert_eq!(bounds, copied_bounds);
     }
 
     #[test]

--- a/src/document.rs
+++ b/src/document.rs
@@ -111,6 +111,14 @@ impl Document {
         .map(|inner| Self { inner })
     }
 
+    /// Safe variant of [`from_shared_bytes`](Self::from_shared_bytes) for
+    /// `'static` data (e.g. `include_bytes!`): the bytes are guaranteed to
+    /// outlive the document and shared references are never mutated.
+    pub fn from_static_bytes(bytes: &'static [u8], magic: &str) -> Result<Self, Error> {
+        // SAFETY: `bytes` lives forever and cannot be mutated behind `&'static`.
+        unsafe { Self::from_shared_bytes(bytes, magic) }
+    }
+
     pub fn recognize(magic: &str) -> Result<bool, Error> {
         let c_magic = CString::new(magic)?;
         unsafe { ffi_try!(mupdf_recognize_document(context(), c_magic.as_ptr())) }
@@ -432,6 +440,10 @@ mod test {
         let bounds = doc.load_page(0).unwrap().bounds().unwrap();
         let copied_bounds = copied.load_page(0).unwrap().bounds().unwrap();
         assert_eq!(bounds, copied_bounds);
+
+        // The safe 'static wrapper goes through the same path.
+        let from_static = Document::from_static_bytes(bytes, "pdf").unwrap();
+        assert_eq!(from_static.page_count().unwrap(), 1);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ impl fmt::Display for MuPdfError {
         write!(
             f,
             "MuPDF error, code: {}, message: {}",
-            self.code, &self.message
+            self.code, self.message
         )
     }
 }


### PR DESCRIPTION
Document::from_bytes copies the entire input into a new fz_buffer, so every open of a large document costs its full size in memory again. When one Document is opened per thread on a multi-hundred-MB PDF (e.g. rendering a scanned document with rayon), the copies dominate peak RSS: measured 22 threads x 283 MB = ~6 GB just in buffer copies.

MuPDF already provides fz_new_buffer_from_shared_data for this. Expose it as unsafe fns Buffer::from_shared_bytes / Document::from_shared_bytes: the caller guarantees the bytes outlive the buffer/document, in exchange the open is zero-copy. Includes a parity test against the copying constructor.