### PR TITLE
Rename from_bytes to from_copied_bytes on Buffer, Document and PdfDocument

### DIFF
--- a/examples/shape_demo.rs
+++ b/examples/shape_demo.rs
@@ -235,7 +235,7 @@ fn render_saved_pages(
     output_dir: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let bytes = fs::read(pdf_path)?;
-    let doc = PdfDocument::from_bytes(&bytes)?;
+    let doc = PdfDocument::from_copied_bytes(&bytes)?;
     for page_index in 0..doc.page_count()? {
         let page = PdfPage::try_from(doc.load_page(page_index)?)?;
         let pixmap = page.to_pixmap(

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -49,7 +49,8 @@ impl Buffer {
             .map(|inner| Self { inner, offset: 0 })
     }
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+    /// Creates a buffer holding a copy of `bytes`.
+    pub fn from_copied_bytes(bytes: &[u8]) -> Result<Self, Error> {
         unsafe {
             ffi_try!(mupdf_buffer_from_copied_bytes(
                 context(),
@@ -60,9 +61,14 @@ impl Buffer {
         .map(|inner| Self { inner, offset: 0 })
     }
 
+    #[deprecated(note = "renamed to `from_copied_bytes` to make the copy explicit")]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Self::from_copied_bytes(bytes)
+    }
+
     /// Creates a buffer backed directly by `bytes`, without copying them.
     ///
-    /// [`from_bytes`](Self::from_bytes) copies the whole slice into a new
+    /// [`from_copied_bytes`](Self::from_copied_bytes) copies the whole slice into a new
     /// allocation; this variant makes the returned buffer borrow the caller's
     /// data instead, which matters when opening large documents from several
     /// threads at once.
@@ -191,7 +197,7 @@ impl TryFrom<&[u8]> for Buffer {
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Buffer::from_bytes(bytes)
+        Buffer::from_copied_bytes(bytes)
     }
 }
 
@@ -199,7 +205,7 @@ impl TryFrom<Vec<u8>> for Buffer {
     type Error = Error;
 
     fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
-        Buffer::from_bytes(&bytes)
+        Buffer::from_copied_bytes(&bytes)
     }
 }
 

--- a/src/device/native.rs
+++ b/src/device/native.rs
@@ -11,6 +11,15 @@ use std::{
 
 use mupdf_sys::*;
 
+// On windows-msvc, bindgen with recent libclang (observed with LLVM 22) does
+// not emit `max_align_t` in the mupdf-sys bindings even though build.rs
+// allowlists it. On MSVC `max_align_t` is a double: alignment 8. This local
+// type shadows the glob import above when the binding is missing.
+#[cfg(target_env = "msvc")]
+#[repr(C, align(8))]
+#[allow(non_camel_case_types, dead_code)]
+struct max_align_t(f64);
+
 use crate::{
     context, guard_ffi_callback, BlendMode, ColorParams, Colorspace, Device, Error, Function,
     Image, Matrix, Path, Rect, Shade, StrokeState, Text,

--- a/src/document.rs
+++ b/src/document.rs
@@ -69,9 +69,10 @@ impl Document {
             .map(|inner| Self { inner })
     }
 
-    pub fn from_bytes(bytes: &[u8], magic: &str) -> Result<Self, Error> {
+    /// Opens a document from a copy of `bytes`.
+    pub fn from_copied_bytes(bytes: &[u8], magic: &str) -> Result<Self, Error> {
         let c_magic = CString::new(magic)?;
-        let buf = Buffer::from_bytes(bytes)?;
+        let buf = Buffer::from_copied_bytes(bytes)?;
         unsafe {
             ffi_try!(mupdf_open_document_from_bytes(
                 context(),
@@ -82,9 +83,14 @@ impl Document {
         .map(|inner| Self { inner })
     }
 
+    #[deprecated(note = "renamed to `from_copied_bytes` to make the copy explicit")]
+    pub fn from_bytes(bytes: &[u8], magic: &str) -> Result<Self, Error> {
+        Self::from_copied_bytes(bytes, magic)
+    }
+
     /// Opens a document backed directly by `bytes`, without copying them.
     ///
-    /// [`from_bytes`](Self::from_bytes) copies the whole input into a new
+    /// [`from_copied_bytes`](Self::from_copied_bytes) copies the whole input into a new
     /// `fz_buffer`, so every open of a large document costs its full size in
     /// memory again (e.g. one `Document` per thread on a multi-hundred-MB
     /// scanned PDF). This variant opens the document on a borrowed view of
@@ -375,14 +381,15 @@ macro_rules! test_document {
         #[cfg(not(target_arch = "wasm32"))]
         let doc = PdfDocument::open(concat!("tests/", $path));
         #[cfg(target_arch = "wasm32")]
-        let doc = PdfDocument::from_bytes(include_bytes!(concat!($root, "/tests/", $path)));
+        let doc = PdfDocument::from_copied_bytes(include_bytes!(concat!($root, "/tests/", $path)));
         doc
     }};
     ($root:literal, $path:literal) => {{
         #[cfg(not(target_arch = "wasm32"))]
         let doc = Document::open(concat!("tests/", $path));
         #[cfg(target_arch = "wasm32")]
-        let doc = Document::from_bytes(include_bytes!(concat!($root, "/tests/", $path)), $path);
+        let doc =
+            Document::from_copied_bytes(include_bytes!(concat!($root, "/tests/", $path)), $path);
         doc
     }};
 }
@@ -436,7 +443,7 @@ mod test {
         assert_eq!(doc.page_count().unwrap(), 1);
 
         // Same rendering-relevant behaviour as the copying constructor.
-        let copied = Document::from_bytes(bytes, "pdf").unwrap();
+        let copied = Document::from_copied_bytes(bytes, "pdf").unwrap();
         let bounds = doc.load_page(0).unwrap().bounds().unwrap();
         let copied_bounds = copied.load_page(0).unwrap().bounds().unwrap();
         assert_eq!(bounds, copied_bounds);

--- a/src/font.rs
+++ b/src/font.rs
@@ -85,7 +85,7 @@ impl Font {
 
     pub fn from_bytes_with_index(name: &str, index: i32, font_data: &[u8]) -> Result<Self, Error> {
         let c_name = CString::new(name)?;
-        let buffer = Buffer::from_bytes(font_data)?;
+        let buffer = Buffer::from_copied_bytes(font_data)?;
         unsafe {
             ffi_try!(mupdf_new_font_from_buffer(
                 context(),

--- a/src/font_loader.rs
+++ b/src/font_loader.rs
@@ -159,7 +159,7 @@ fn probe(a: &str, b: &str, c: &str) -> Option<PathBuf> {
 /// font data itself (mirrors `fz_new_font_from_file(ctx, NULL, ...)`).
 fn font_from_file(path: &Path, index: i32) -> Option<Font> {
     let data = std::fs::read(path).ok()?;
-    let buffer = Buffer::from_bytes(&data).ok()?;
+    let buffer = Buffer::from_copied_bytes(&data).ok()?;
     // SAFETY: `context()` is a valid context, `buffer.inner` is a valid
     // buffer and a NULL name is allowed by `fz_new_font_from_buffer`.
     let inner = unsafe {

--- a/src/image.rs
+++ b/src/image.rs
@@ -113,7 +113,7 @@ impl Image {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let buffer = Buffer::from_bytes(bytes)?;
+        let buffer = Buffer::from_copied_bytes(bytes)?;
         unsafe { ffi_try!(mupdf_new_image_from_buffer(context(), buffer.inner)) }
             .map(|inner| unsafe { Self::from_raw(inner) })
     }

--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -582,10 +582,16 @@ impl PdfDocument {
         Self::try_from(doc)
     }
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let buf = Buffer::from_bytes(bytes)?;
+    /// Opens a PDF document from a copy of `bytes`.
+    pub fn from_copied_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        let buf = Buffer::from_copied_bytes(bytes)?;
         unsafe { ffi_try!(mupdf_pdf_open_document_from_bytes(context(), buf.inner)) }
             .map(|inner| unsafe { Self::from_raw(inner) })
+    }
+
+    #[deprecated(note = "renamed to `from_copied_bytes` to make the copy explicit")]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Self::from_copied_bytes(bytes)
     }
 
     pub fn new_null(&self) -> PdfObject {
@@ -1059,7 +1065,7 @@ impl PdfDocument {
     ) -> Result<EmbeddedFileInfo, Error> {
         let filename = CString::new(options.filename)?;
         let mime_type = options.mime_type.map(CString::new).transpose()?;
-        let contents = Buffer::from_bytes(contents)?;
+        let contents = Buffer::from_copied_bytes(contents)?;
         let fs = unsafe {
             ffi_try!(mupdf_pdf_add_embedded_file(
                 context(),
@@ -1978,7 +1984,7 @@ mod test {
     #[test]
     fn test_open_pdf_document_from_bytes() {
         let bytes = include_bytes!("../../tests/files/dummy.pdf");
-        let doc = PdfDocument::from_bytes(bytes).unwrap();
+        let doc = PdfDocument::from_copied_bytes(bytes).unwrap();
         assert!(!doc.needs_password().unwrap());
     }
 
@@ -2254,7 +2260,7 @@ mod test {
         let mut pdf = PdfDocument::new();
 
         for compressed in [false, true] {
-            let buf = Buffer::from_bytes(b"hello world").unwrap();
+            let buf = Buffer::from_copied_bytes(b"hello world").unwrap();
             let obj = pdf.add_stream(&buf, None, compressed).unwrap();
 
             assert!(obj.is_indirect().unwrap());
@@ -2278,11 +2284,11 @@ mod test {
         ];
 
         for payload in payloads {
-            let buf = Buffer::from_bytes(&payload).unwrap();
+            let buf = Buffer::from_copied_bytes(&payload).unwrap();
             let mut obj = pdf.add_stream(&buf, None, false).unwrap();
             assert_eq!(obj.read_stream().unwrap(), payload);
 
-            let rewritten = Buffer::from_bytes(&payload).unwrap();
+            let rewritten = Buffer::from_copied_bytes(&payload).unwrap();
             obj.write_stream_buffer(&rewritten).unwrap();
             assert_eq!(obj.read_stream().unwrap(), payload);
         }
@@ -2295,7 +2301,7 @@ mod test {
         dict.dict_put("X-Test", pdf.new_string("foo").unwrap())
             .unwrap();
 
-        let buf = Buffer::from_bytes(b"dict payload").unwrap();
+        let buf = Buffer::from_copied_bytes(b"dict payload").unwrap();
         let obj = pdf.add_stream(&buf, Some(&dict), false).unwrap();
         let sentinel = obj.get_dict("X-Test").unwrap().unwrap();
 

--- a/src/pdf/links/tests_build.rs
+++ b/src/pdf/links/tests_build.rs
@@ -296,7 +296,7 @@ impl PdfTester {
         let mut buf = Vec::new();
         self.doc.write_to(&mut buf).context("Failed to write PDF")?;
         Ok(Self {
-            doc: PdfDocument::from_bytes(&buf).context("Failed to load PDF from buffer")?,
+            doc: PdfDocument::from_copied_bytes(&buf).context("Failed to load PDF from buffer")?,
             page: self.page,
         })
     }

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -589,7 +589,7 @@ impl ExactSizeIterator for PdfDictIter<'_> {
 
 impl Write for PdfObject {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let fz_buf = Buffer::from_bytes(buf).map_err(io::Error::other)?;
+        let fz_buf = Buffer::from_copied_bytes(buf).map_err(io::Error::other)?;
         self.write_stream_buffer(&fz_buf)
             .map_err(io::Error::other)?;
         Ok(buf.len())

--- a/src/pdf/page.rs
+++ b/src/pdf/page.rs
@@ -1017,7 +1017,7 @@ impl PdfPage {
         let mut page_obj = self.object();
         let old_contents = page_obj.get_dict("Contents")?;
 
-        let stream_buf = Buffer::from_bytes(bytes)?;
+        let stream_buf = Buffer::from_copied_bytes(bytes)?;
         let new_stream = doc.add_stream(&stream_buf, None, false)?;
         let new_xref = new_stream.as_indirect()?;
 
@@ -2478,7 +2478,7 @@ mod test {
     }
 
     fn add_stream(doc: &mut PdfDocument, bytes: &[u8]) -> PdfObject {
-        doc.add_stream(&Buffer::from_bytes(bytes).unwrap(), None, false)
+        doc.add_stream(&Buffer::from_copied_bytes(bytes).unwrap(), None, false)
             .unwrap()
     }
 
@@ -2635,10 +2635,10 @@ mod test {
         let mut doc = PdfDocument::new();
         let page = doc.new_page(Size::A4).unwrap();
         let first = doc
-            .add_stream(&Buffer::from_bytes(b"q\n").unwrap(), None, false)
+            .add_stream(&Buffer::from_copied_bytes(b"q\n").unwrap(), None, false)
             .unwrap();
         let second = doc
-            .add_stream(&Buffer::from_bytes(b"Q\n").unwrap(), None, false)
+            .add_stream(&Buffer::from_copied_bytes(b"Q\n").unwrap(), None, false)
             .unwrap();
         let mut contents_array = doc.new_array_with_capacity(2).unwrap();
         contents_array.array_push(first).unwrap();
@@ -2809,7 +2809,7 @@ mod test {
         assert_eq!(stream.as_indirect().unwrap(), xref);
         assert_eq!(stream.read_stream().unwrap(), payload);
 
-        let rewritten = Buffer::from_bytes(b"rewritten\n").unwrap();
+        let rewritten = Buffer::from_copied_bytes(b"rewritten\n").unwrap();
         stream.write_stream_buffer(&rewritten).unwrap();
         assert_eq!(stream.read_stream().unwrap(), b"rewritten\n");
     }
@@ -3042,7 +3042,7 @@ mod test {
         drop(source_page);
         drop(source_doc);
 
-        let mut doc = PdfDocument::from_bytes(&bytes).unwrap();
+        let mut doc = PdfDocument::from_copied_bytes(&bytes).unwrap();
         assert!(doc.font_info_cache.borrow().is_empty());
         let mut page = PdfPage::try_from(doc.load_page(0).unwrap()).unwrap();
 
@@ -3101,7 +3101,7 @@ mod test {
         drop(source_page);
         drop(source_doc);
 
-        let mut doc = PdfDocument::from_bytes(&bytes).unwrap();
+        let mut doc = PdfDocument::from_copied_bytes(&bytes).unwrap();
         assert!(doc.font_info_cache.borrow().is_empty());
         let mut page = PdfPage::try_from(doc.load_page(0).unwrap()).unwrap();
 

--- a/src/shape/finish.rs
+++ b/src/shape/finish.rs
@@ -1442,7 +1442,7 @@ mod tests {
     #[test]
     fn commit_overlay_wraps_existing() {
         let mut doc =
-            PdfDocument::from_bytes(include_bytes!("../../tests/files/dummy.pdf")).unwrap();
+            PdfDocument::from_copied_bytes(include_bytes!("../../tests/files/dummy.pdf")).unwrap();
         let mut page = PdfPage::try_from(doc.load_page(0).unwrap()).unwrap();
         let original = page.contents().unwrap().unwrap();
         let original_bytes = original.read_stream().unwrap();

--- a/tests/shape/kitchen_sink.rs
+++ b/tests/shape/kitchen_sink.rs
@@ -88,7 +88,7 @@ fn build_shape_demo_example(output_dir: &Path) {
 }
 
 fn render_pdf_bytes(bytes: &[u8]) -> Vec<mupdf::Pixmap> {
-    let doc = PdfDocument::from_bytes(bytes).unwrap();
+    let doc = PdfDocument::from_copied_bytes(bytes).unwrap();
     assert_eq!(doc.page_count().unwrap(), 3);
     (0..3)
         .map(|page_index| {
@@ -324,7 +324,7 @@ pub mod cross {
         #[test]
         fn overlay_preserves_existing_content() {
             let original_doc =
-                PdfDocument::from_bytes(include_bytes!("../files/dummy.pdf")).unwrap();
+                PdfDocument::from_copied_bytes(include_bytes!("../files/dummy.pdf")).unwrap();
             let original_page = PdfPage::try_from(original_doc.load_page(0).unwrap()).unwrap();
             let original_text = original_page
                 .to_text_page(TextPageFlags::empty())
@@ -333,7 +333,8 @@ pub mod cross {
                 .unwrap();
             assert!(!original_text.trim().is_empty());
 
-            let mut doc = PdfDocument::from_bytes(include_bytes!("../files/dummy.pdf")).unwrap();
+            let mut doc =
+                PdfDocument::from_copied_bytes(include_bytes!("../files/dummy.pdf")).unwrap();
             let mut page = PdfPage::try_from(doc.load_page(0).unwrap()).unwrap();
             {
                 let mut shape = Shape::new(&mut page).unwrap();
@@ -363,7 +364,7 @@ pub mod cross {
             }
             let mut bytes = Vec::new();
             doc.write_to(&mut bytes).unwrap();
-            let reopened = PdfDocument::from_bytes(&bytes).unwrap();
+            let reopened = PdfDocument::from_copied_bytes(&bytes).unwrap();
             let reopened_page = PdfPage::try_from(reopened.load_page(0).unwrap()).unwrap();
             let reopened_text = reopened_page
                 .to_text_page(TextPageFlags::empty())
@@ -375,7 +376,8 @@ pub mod cross {
 
         #[test]
         fn underlay_renders_behind() {
-            let mut doc = PdfDocument::from_bytes(include_bytes!("../files/dummy.pdf")).unwrap();
+            let mut doc =
+                PdfDocument::from_copied_bytes(include_bytes!("../files/dummy.pdf")).unwrap();
             let mut page = PdfPage::try_from(doc.load_page(0).unwrap()).unwrap();
             let baseline = render_page(&page);
             let (dark_x, dark_y, dark_pixel) = find_dark_pixel(&baseline);
@@ -630,7 +632,7 @@ pub mod cross {
         use super::*;
 
         let (bytes, rendered, streams) = build_cross_kitchen_sink();
-        let reopened = PdfDocument::from_bytes(&bytes).unwrap();
+        let reopened = PdfDocument::from_copied_bytes(&bytes).unwrap();
         assert_eq!(reopened.page_count().unwrap(), 1);
         let painted = non_wrapper_streams(&streams);
         assert_eq!(painted.len(), 1);

--- a/tests/shape/red_rect.rs
+++ b/tests/shape/red_rect.rs
@@ -15,7 +15,7 @@ fn pixel_rgb(pixmap: &mupdf::Pixmap, x: u32, y: u32) -> [u8; 3] {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn m1_red_rect_snapshot() {
-    let mut doc = PdfDocument::from_bytes(include_bytes!("../files/dummy.pdf")).unwrap();
+    let mut doc = PdfDocument::from_copied_bytes(include_bytes!("../files/dummy.pdf")).unwrap();
     let mut page = PdfPage::try_from(doc.load_page(0).unwrap()).unwrap();
     let baseline = render_page(&page);
 

--- a/tests/shape/shape_commit.rs
+++ b/tests/shape/shape_commit.rs
@@ -83,7 +83,7 @@ pub mod draw {
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
     fn overlay_preserves_existing_snapshot() {
-        let mut doc = PdfDocument::from_bytes(include_bytes!("../files/dummy.pdf")).unwrap();
+        let mut doc = PdfDocument::from_copied_bytes(include_bytes!("../files/dummy.pdf")).unwrap();
         let mut page = PdfPage::try_from(doc.load_page(0).unwrap()).unwrap();
         let rendered = {
             let mut shape = Shape::new(&mut page).unwrap();

--- a/tests/test_issues.rs
+++ b/tests/test_issues.rs
@@ -4,7 +4,8 @@ use mupdf::{Error, TextPageFlags};
 #[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn test_issue_16_pixmap_to_png() {
-    let document = PdfDocument::from_bytes(include_bytes!("../tests/files/dummy.pdf")).unwrap();
+    let document =
+        PdfDocument::from_copied_bytes(include_bytes!("../tests/files/dummy.pdf")).unwrap();
     let page = document.load_page(0).unwrap();
     let matrix = mupdf::Matrix::new_scale(72f32 / 72f32, 72f32 / 72f32);
     let pixmap = page
@@ -17,7 +18,7 @@ fn test_issue_16_pixmap_to_png() {
 
 #[test]
 fn test_issue_27_flatten() {
-    let doc = PdfDocument::from_bytes(include_bytes!("../tests/files/dummy.pdf")).unwrap();
+    let doc = PdfDocument::from_copied_bytes(include_bytes!("../tests/files/dummy.pdf")).unwrap();
     let pages = doc
         .pages()
         .unwrap()
@@ -42,7 +43,8 @@ fn test_issue_43_malloc() {
 
     let mut writer =
         mupdf::DocumentWriter::new("tests/output/issue_43.png", "png", options.as_str()).unwrap();
-    let doc = mupdf::Document::from_bytes(include_bytes!("../tests/files/dummy.pdf"), "").unwrap();
+    let doc =
+        mupdf::Document::from_copied_bytes(include_bytes!("../tests/files/dummy.pdf"), "").unwrap();
 
     for _ in 0..2 {
         let page0 = doc.load_page(0).unwrap();
@@ -55,7 +57,7 @@ fn test_issue_43_malloc() {
 
 #[test]
 fn test_issue_60_display_list() {
-    let doc = PdfDocument::from_bytes(include_bytes!("../tests/files/p11.pdf")).unwrap();
+    let doc = PdfDocument::from_copied_bytes(include_bytes!("../tests/files/p11.pdf")).unwrap();
     let num_pages = doc.page_count().unwrap();
     println!("Document has {num_pages} page(s)");
 
@@ -72,8 +74,10 @@ fn test_issue_60_display_list() {
 
 #[test]
 fn test_issue_86_invalid_utf8() {
-    let doc = PdfDocument::from_bytes(include_bytes!("../tests/files/utf8-error-on-this-file.pdf"))
-        .unwrap();
+    let doc = PdfDocument::from_copied_bytes(include_bytes!(
+        "../tests/files/utf8-error-on-this-file.pdf"
+    ))
+    .unwrap();
     for (idx, page) in doc.pages().unwrap().enumerate() {
         let page = page.unwrap();
         let text_page = page.to_text_page(TextPageFlags::empty()).unwrap();
@@ -94,7 +98,7 @@ fn test_issue_86_invalid_utf8() {
 #[test]
 #[cfg(feature = "serde")]
 fn test_issue_i32_box() {
-    let doc = PdfDocument::from_bytes(include_bytes!("../tests/files/i32-box.pdf")).unwrap();
+    let doc = PdfDocument::from_copied_bytes(include_bytes!("../tests/files/i32-box.pdf")).unwrap();
     for (idx, page) in doc.pages().unwrap().enumerate() {
         let page = page.unwrap();
         let text_page = page.to_text_page(TextPageFlags::empty()).unwrap();
@@ -114,7 +118,7 @@ fn test_issue_i32_box() {
 
 #[test]
 fn test_issue_no_json() {
-    let doc = PdfDocument::from_bytes(include_bytes!("../tests/files/no-json.pdf")).unwrap();
+    let doc = PdfDocument::from_copied_bytes(include_bytes!("../tests/files/no-json.pdf")).unwrap();
     let page = doc.load_page(0).unwrap();
     let text_page = page.to_text_page(TextPageFlags::empty()).unwrap();
     let json = text_page.to_json(1.0);

--- a/tests/test_pdf_object.rs
+++ b/tests/test_pdf_object.rs
@@ -3,7 +3,7 @@ use mupdf::Error;
 
 /// Open the shared test fixture for building array/dict objects bound to a document.
 fn open() -> PdfDocument {
-    PdfDocument::from_bytes(include_bytes!("files/dummy.pdf")).unwrap()
+    PdfDocument::from_copied_bytes(include_bytes!("files/dummy.pdf")).unwrap()
 }
 
 #[test]


### PR DESCRIPTION

Follow-up to #257, as suggested in review: with from_shared_bytes around, from_bytes no longer says what it does. The old names remain as deprecated aliases so this is not a breaking change; internal callers, tests and examples are migrated. Font and Image keep their from_bytes since they have no shared/copied distinction.